### PR TITLE
chore(ui5-calendar): address VD feedback

### DIFF
--- a/packages/main/src/themes/DayPicker.css
+++ b/packages/main/src/themes/DayPicker.css
@@ -33,8 +33,7 @@
 .ui5-dp-item {
 	width: var(--_ui5_day_picker_item_width);
 	height: var(--_ui5_day_picker_item_height);
-	margin-block-start: var(--_ui5_daypicker_item_margin);
-	margin-inline-end: var(--_ui5_daypicker_item_margin);
+	margin: var(--_ui5_daypicker_item_margin);
 	font-family: "72override", var(--sapFontFamily);
 	border-radius: var(--_ui5_daypicker_item_border_radius);
 }
@@ -412,8 +411,13 @@
 	padding-block: var(--_ui5_daypicker_item_now_selected_two_calendar_focus_secondary_text_padding_block);
 }
 
+.ui5-dp-item--withsecondtype {
+	width: var(--_ui5_day_picker_item_with_secondtype_width_height, var(--_ui5_day_picker_item_width));
+	height: var(--_ui5_day_picker_item_with_secondtype_width_height, var(--_ui5_day_picker_item_height));
+}
+
 .ui5-dp-item--withsecondtype .ui5-dp-daytext {
-	font-size: 0.75rem;
+	font-size: 0.875rem;
 }
 
 .ui5-dp-item.ui5-dp-item--withsecondtype .ui5-dp-specialday,

--- a/packages/main/src/themes/base/DayPicker-parameters.css
+++ b/packages/main/src/themes/base/DayPicker-parameters.css
@@ -1,6 +1,6 @@
 :root {
 	--_ui5_daypicker_item_box_shadow: inset 0 0 0 0.0625rem var(--sapContent_Selected_ForegroundColor);
-	--_ui5_daypicker_item_margin: 2px;
+	--_ui5_daypicker_item_margin: 0.0625rem;
 	--_ui5_daypicker_item_border: none;
 	--_ui5_daypicker_item_selected_border_color: var(--sapList_Background);
 	--_ui5_daypicker_daynames_container_height: 2rem;

--- a/packages/main/src/themes/base/sizes-parameters.css
+++ b/packages/main/src/themes/base/sizes-parameters.css
@@ -27,7 +27,7 @@
 	--_ui5_dp_two_calendar_item_secondary_text_padding: 0 0.5rem;
 	--_ui5_daypicker_item_now_selected_two_calendar_focus_secondary_text_padding_block: 0 0.5rem;
 	--_ui5_daypicker_two_calendar_item_selected_focus_margin_bottom: 0;
-	--_ui5_daypicker_two_calendar_item_selected_focus_padding_right: 0.4375rem;
+	--_ui5_daypicker_two_calendar_item_selected_focus_padding_right: 0.375rem;
 
 	/* ColorPalette */
 	 --_ui5_color-palette-item-height: 1.75rem;
@@ -159,8 +159,8 @@
 	--_ui5_button_icon_font_size: 1rem;
 
 	/* Calendar */
-	--_ui5_calendar_height: 18rem;
-	--_ui5_calendar_width: 17.75rem;
+	--_ui5_calendar_height: 19rem;
+	--_ui5_calendar_width: 19rem;
 	--_ui5_calendar_left_right_padding: 0.25rem;
 	--_ui5_calendar_top_bottom_padding: 0.5rem;
 	--_ui5_calendar_header_height: 2rem;
@@ -169,7 +169,7 @@
 
 	/* Calendar Legend */
 	--_ui5-calendar-legend-root-padding: 0.5rem;
-	--_ui5-calendar-legend-root-width: 16.75rem;
+	--_ui5-calendar-legend-root-width: 18rem;
 
 	/* Calendar Legend Item */
 	--_ui5-calendar-legend-item-box-margin: 0.125rem 0.5rem 0.125rem 0.125rem;
@@ -213,21 +213,21 @@
 	--_ui5_dp_two_calendar_item_primary_text_height: 1rem;
 	--_ui5_dp_two_calendar_item_secondary_text_height: 0.75rem;
 	--_ui5_dp_two_calendar_item_text_padding_top: 0.5rem;
+	--_ui5_day_picker_item_with_secondtype_width_height: 2.25rem;
 
 	--_ui5_daypicker_selected_item_now_special_day_top: 1.5625rem;
 	--_ui5_daypicker_specialday_focused_top: 1.5rem;
 	--_ui5_daypicker_special_day_top: 1.625rem;
 	--_ui5_daypicker_item_now_specialday_top: 1.5rem;
-	--_ui5_daypicker_twocalendar_item_special_day_top: 1.25rem;
-	--_ui5_daypicker_twocalendar_item_special_day_right: 1.25rem;
+	--_ui5_daypicker_twocalendar_item_special_day_top: 1.5rem;
+	--_ui5_daypicker_twocalendar_item_special_day_right: 1.5rem;
 	--_ui5_daypicker_two_calendar_item_margin_bottom: 0;
 	--_ui5_dp_two_calendar_item_secondary_text_padding_block: 0 0.625rem;
-	--_ui5_daypicker_item_now_selected_two_calendar_focus_special_day_top: 1.125rem;
-	--_ui5_daypicker_item_now_selected_two_calendar_focus_special_day_right: 1.125rem;
-	--_ui5_dp_two_calendar_item_secondary_text_padding: 0 0.375rem;
+	--_ui5_daypicker_item_now_selected_two_calendar_focus_special_day_top: 1.375rem; /*1.34375rem;  Results in 21.5px*/
+	--_ui5_daypicker_item_now_selected_two_calendar_focus_special_day_right: 1.375rem; /*1.34375rem;  Results in 21.5px*/
 	--_ui5_daypicker_item_now_selected_two_calendar_focus_secondary_text_padding_block: 0 1rem;
-	--_ui5_daypicker_two_calendar_item_selected_focus_margin_bottom: -0.25rem;
-	--_ui5_daypicker_two_calendar_item_selected_focus_padding_right: 0.4375rem;
+	--_ui5_daypicker_two_calendar_item_selected_focus_margin_bottom: -0.1875rem;
+	--_ui5_daypicker_two_calendar_item_selected_focus_padding_right: 0.5rem;
 
 	/* DateTimePicker */
 	--_ui5_datetime_picker_height: 20.5rem;

--- a/packages/main/src/themes/base/sizes-parameters.css
+++ b/packages/main/src/themes/base/sizes-parameters.css
@@ -160,7 +160,7 @@
 
 	/* Calendar */
 	--_ui5_calendar_height: 19rem;
-	--_ui5_calendar_width: 19rem;
+	--_ui5_calendar_width: 19.5rem;
 	--_ui5_calendar_left_right_padding: 0.25rem;
 	--_ui5_calendar_top_bottom_padding: 0.5rem;
 	--_ui5_calendar_header_height: 2rem;
@@ -169,7 +169,7 @@
 
 	/* Calendar Legend */
 	--_ui5-calendar-legend-root-padding: 0.5rem;
-	--_ui5-calendar-legend-root-width: 18rem;
+	--_ui5-calendar-legend-root-width: 18.5rem;
 
 	/* Calendar Legend Item */
 	--_ui5-calendar-legend-item-box-margin: 0.125rem 0.5rem 0.125rem 0.125rem;

--- a/packages/main/src/themes/sap_horizon/DayPicker-parameters.css
+++ b/packages/main/src/themes/sap_horizon/DayPicker-parameters.css
@@ -8,7 +8,7 @@
 	--_ui5_daypicker_item_selected_focus_color: var(--sapContent_FocusColor);
 	--_ui5_daypicker_item_selected_focus_width: 0.125rem;
 	--_ui5_daypicker_item_no_selected_inset: 0.375rem;
-	--_ui5_daypicker_item_now_border_focus_after: 0.125rem solid var(--sapList_SelectionBorderColor);
+	--_ui5_daypicker_item_now_border_focus_after: 0.125rem solid var(--sapContent_FocusColor);
 	--_ui5_daypicker_item_now_border_radius_focus_after: 0.3125rem;
 	--_ui5_day_picker_item_selected_now_border_focus: 0.125rem solid var(--sapContent_FocusColor);
 	--_ui5_day_picker_item_selected_now_border_radius_focus: 0.1875rem;

--- a/packages/main/src/themes/sap_horizon/sizes-parameters.css
+++ b/packages/main/src/themes/sap_horizon/sizes-parameters.css
@@ -17,7 +17,7 @@
 	--_ui5_dp_two_calendar_item_secondary_text_padding_block: 0 0.5rem;
 	--_ui5_dp_two_calendar_item_secondary_text_padding: 0 0.5rem;
 	--_ui5_daypicker_two_calendar_item_selected_focus_margin_bottom: 0;
-	--_ui5_daypicker_two_calendar_item_selected_focus_padding_right: 0.5rem;
+	--_ui5_daypicker_two_calendar_item_selected_focus_padding_right: 0.375rem;
 }
 
 [data-ui5-compact-size],
@@ -56,7 +56,6 @@
 	--_ui5_daypicker_specialday_focused_border_bottom: 0.25rem;
 	--_ui5_daypicker_item_now_specialday_top: 1.4375rem;
 	--_ui5_dp_two_calendar_item_secondary_text_padding_block: 0 0.375rem;
-	--_ui5_dp_two_calendar_item_secondary_text_padding: 0 0.375rem;
-	--_ui5_daypicker_two_calendar_item_selected_focus_margin_bottom: -0.25rem;
-	--_ui5_daypicker_two_calendar_item_selected_focus_padding_right: 0.4375rem;
+	--_ui5_daypicker_two_calendar_item_selected_focus_margin_bottom: -0.1875rem;
+	--_ui5_daypicker_two_calendar_item_selected_focus_padding_right: 0.5rem;
 }

--- a/packages/main/src/themes/sap_horizon_dark/DayPicker-parameters.css
+++ b/packages/main/src/themes/sap_horizon_dark/DayPicker-parameters.css
@@ -8,7 +8,7 @@
 	--_ui5_daypicker_item_selected_focus_color: var(--sapContent_FocusColor);
 	--_ui5_daypicker_item_selected_focus_width: 0.125rem;
 	--_ui5_daypicker_item_no_selected_inset: 0.375rem;
-	--_ui5_daypicker_item_now_border_focus_after: 0.125rem solid var(--sapList_SelectionBorderColor);
+	--_ui5_daypicker_item_now_border_focus_after: 0.125rem solid var(--sapContent_FocusColor);
 	--_ui5_daypicker_item_now_border_radius_focus_after: 0.3125rem;
 	--_ui5_day_picker_item_selected_now_border_focus: 0.125rem solid var(--sapContent_FocusColor);
 	--_ui5_day_picker_item_selected_now_border_radius_focus: 0.1875rem;

--- a/packages/main/src/themes/sap_horizon_dark/sizes-parameters.css
+++ b/packages/main/src/themes/sap_horizon_dark/sizes-parameters.css
@@ -15,7 +15,7 @@
 	--_ui5_dp_two_calendar_item_secondary_text_padding_block: 0 0.5rem;
 	--_ui5_dp_two_calendar_item_secondary_text_padding: 0 0.5rem;
 	--_ui5_daypicker_two_calendar_item_selected_focus_margin_bottom: 0;
-	--_ui5_daypicker_two_calendar_item_selected_focus_padding_right: 0.5rem;
+	--_ui5_daypicker_two_calendar_item_selected_focus_padding_right: 0.375rem;
 }
 
 [data-ui5-compact-size],
@@ -53,7 +53,6 @@
 	--_ui5_daypicker_specialday_focused_border_bottom: 0.25rem;
 	--_ui5_daypicker_item_now_specialday_top: 1.4375rem;
 	--_ui5_dp_two_calendar_item_secondary_text_padding_block: 0 0.375rem;
-	--_ui5_dp_two_calendar_item_secondary_text_padding: 0 0.375rem;
-	--_ui5_daypicker_two_calendar_item_selected_focus_margin_bottom: -0.25rem;
-	--_ui5_daypicker_two_calendar_item_selected_focus_padding_right: 0.4375rem;
+	--_ui5_daypicker_two_calendar_item_selected_focus_margin_bottom: -0.1875rem;
+	--_ui5_daypicker_two_calendar_item_selected_focus_padding_right: 0.5rem;
 }

--- a/packages/main/src/themes/sap_horizon_dark_exp/DayPicker-parameters.css
+++ b/packages/main/src/themes/sap_horizon_dark_exp/DayPicker-parameters.css
@@ -8,7 +8,7 @@
 	--_ui5_daypicker_item_selected_focus_color: var(--sapContent_FocusColor);
 	--_ui5_daypicker_item_selected_focus_width: 0.125rem;
 	--_ui5_daypicker_item_no_selected_inset: 0.375rem;
-	--_ui5_daypicker_item_now_border_focus_after: 0.125rem solid var(--sapList_SelectionBorderColor);
+	--_ui5_daypicker_item_now_border_focus_after: 0.125rem solid var(--sapContent_FocusColor);
 	--_ui5_daypicker_item_now_border_radius_focus_after: 0.3125rem;
 	--_ui5_day_picker_item_selected_now_border_focus: 0.1875rem solid var(--sapList_SelectionBorderColor);
 	--_ui5_day_picker_item_selected_now_border_radius_focus: 0.1875rem;


### PR DESCRIPTION
We've received a feedback from VD, that our `<ui5-calendar>` component is not compliant according to the latest VD Specification, when having `secondaryCalendarType` provided, in compact mode.

The deltas that are emphasized by VD in compact:

_font-size_: **0.75rem** -> **0.875rem**; // 14px;
_margin-top/right_: **2px** -> **margin: 1px;**

date cells _width and height_: **2rem -> _2.25rem_**; (only when having two calendar types);

The `<ui5-calendar>` width is adjusted as well as the `<ui5-calendar-legend>`'s one.