### PR TITLE
refactor(ui5-li): remove image property and rename imageContent slot

### DIFF
--- a/packages/main/src/StandardListItem.hbs
+++ b/packages/main/src/StandardListItem.hbs
@@ -24,16 +24,10 @@
 {{/inline}}
 
 {{#*inline "imageBegin"}}
-	{{#if hasImageContent}}
-		<div class="ui5-li-imgContent" >
-			<slot name="imageContent"></slot>
+	{{#if hasImage}}
+		<div class="ui5-li-image" >
+			<slot name="image"></slot>
 		</div>
-	{{else}}
-		{{#if displayImage}}
-			<ui5-avatar shape="Square" class="ui5-li-img">
-				<img src="{{image}}" class="ui5-li-img-inner" />
-			</ui5-avatar>
-		{{/if}}
 	{{/if}}
 {{/inline}}
 

--- a/packages/main/src/StandardListItem.ts
+++ b/packages/main/src/StandardListItem.ts
@@ -68,22 +68,11 @@ class StandardListItem extends ListItem implements IAccessibleListItem {
 	/**
 	 * Defines whether the `icon` should be displayed in the beginning of the list item or in the end.
 	 *
-	 * **Note:** If `image` is set, the `icon` would be displayed after the `image`.
 	 * @default false
 	 * @public
 	 */
 	@property({ type: Boolean })
 	iconEnd!: boolean;
-
-	/**
-	 * Defines the `image` source URI.
-	 *
-	 * **Note:** The `image` would be displayed in the beginning of the list item.
-	 * @default ""
-	 * @public
-	 */
-	@property()
-	image!: string;
 
 	/**
 	 * Defines the `additionalText`, displayed in the end of the list item.
@@ -134,7 +123,7 @@ class StandardListItem extends ListItem implements IAccessibleListItem {
 	hasTitle!: boolean;
 
 	@property({ type: Boolean })
-	_hasImageContent!: boolean;
+	_hasImage!: boolean;
 
 	/**
 	 * **Note:** While the slot allows option for setting custom avatar, to match the
@@ -146,16 +135,12 @@ class StandardListItem extends ListItem implements IAccessibleListItem {
 	 * @public
 	 */
 	@slot()
-	imageContent!: Array<HTMLElement>;
+	image!: Array<HTMLElement>;
 
 	onBeforeRendering() {
 		super.onBeforeRendering();
 		this.hasTitle = !!this.textContent;
-		this._hasImageContent = this.hasImageContent;
-	}
-
-	get displayImage(): boolean {
-		return !!this.image;
+		this._hasImage = this.hasImage;
 	}
 
 	get displayIconBegin(): boolean {
@@ -166,8 +151,8 @@ class StandardListItem extends ListItem implements IAccessibleListItem {
 		return !!(this.icon && this.iconEnd);
 	}
 
-	get hasImageContent(): boolean {
-		return !!this.imageContent.length;
+	get hasImage(): boolean {
+		return !!this.image.length;
 	}
 }
 

--- a/packages/main/src/StandardListItem.ts
+++ b/packages/main/src/StandardListItem.ts
@@ -131,7 +131,7 @@ class StandardListItem extends ListItem implements IAccessibleListItem {
 	 *
 	 * **Note:** If bigger `ui5-avatar` needs to be used, then the size of the
 	 * `ui5-li` should be customized in order to fit.
-	 * @since 1.10.0
+	 * @since 2.0.0
 	 * @public
 	 */
 	@slot()

--- a/packages/main/src/themes/ListItem.css
+++ b/packages/main/src/themes/ListItem.css
@@ -71,16 +71,8 @@
 	height: 5rem;
 }
 
-:host([has-title][image]) {
+:host([_has-image]) {
 	height: 5rem;
-}
-
-:host([_has-image-content]) {
-	height: 5rem;
-}
-
-:host([image]) .ui5-li-content {
-	height: 3rem;
 }
 
 :host([description]) .ui5-li-root {
@@ -152,23 +144,12 @@
 	align-self: flex-end;
 }
 
-.ui5-li-img {
-	width: var(--_ui5_list_item_img_size);
-	height: var(--_ui5_list_item_img_size);
-	border-radius: var(--ui5-avatar-border-radius);
-}
-
-.ui5-li-img,
-.ui5-li-imgContent {
+.ui5-li-image {
 	min-width: var(--_ui5_list_item_img_size);
 	min-height: var(--_ui5_list_item_img_size);
 	margin-top: var(--_ui5_list_item_img_top_margin);
 	margin-bottom: var(--_ui5_list_item_img_bottom_margin);
 	margin-inline-end: var(--_ui5_list_item_img_hn_margin);
-}
-
-.ui5-li-img-inner {
-	object-fit: contain;
 }
 
 .ui5-li-icon {

--- a/packages/main/test/pages/Carousel.html
+++ b/packages/main/test/pages/Carousel.html
@@ -380,14 +380,14 @@
 
 		<ui5-list header-text="API: GroupHeaderListItem (2/3)" selection-mode="Multiple">
 			<ui5-li-groupheader>New Items</ui5-li-groupheader>
-			<ui5-li image="./img/HT-1000.jpg" icon="navigation-right-arrow" additional-text="Available">Voluptate do eu cupidatat
+			<ui5-li icon="navigation-right-arrow" additional-text="Available">Voluptate do eu cupidatat
 				elit est culpa. Reprehenderit eiusmod voluptate ex est dolor nostrud Lorem Lorem do nisi laborum veniam.
 				Sint do non culpa aute occaecat labore ipsum veniam minim tempor est. Duis pariatur aute culpa irure ad
 				excepteur pariatur culpa culpa ea duis occaecat aute irure. Ipsum velit culpa non exercitation ex
 				laboris deserunt in eu non officia in. Laborum sunt aliqua labore cupidatat sunt labore.</ui5-li>
-			<ui5-li image="./img/HT-1010.jpg" icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131"
+			<ui5-li icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131"
 				additional-text-state="Error">Laptop Lenovo</ui5-li>
-			<ui5-li image="./img/HT-1022.jpg" icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131"
+			<ui5-li icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131"
 				additional-text-state="Error">IPhone 3</ui5-li>
 		</ui5-list>
 

--- a/packages/main/test/pages/Input_quickview.html
+++ b/packages/main/test/pages/Input_quickview.html
@@ -44,9 +44,9 @@
 			<ui5-li>Audit Log Settings</ui5-li>
 			<ui5-li>OData API Audit</ui5-li>
 			<ui5-li-groupheader>Products</ui5-li-groupheader>
-			<ui5-li image="./img/HT-1010.jpg" icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131" additional-text-state="Error">Laptop Lenovo</ui5-li>
-			<ui5-li image="./img/HT-1022.jpg" icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131"  additional-text-state="Error">IPhone 3</ui5-li>
-			<ui5-li image="./img/HT-1030.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Reuqired" additional-text-state="Error">HP Monitor 24</ui5-li>
+			<ui5-li icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131" additional-text-state="Error">Laptop Lenovo</ui5-li>
+			<ui5-li icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131"  additional-text-state="Error">IPhone 3</ui5-li>
+			<ui5-li icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Reuqired" additional-text-state="Error">HP Monitor 24</ui5-li>
 		</ui5-list>
 	</ui5-popover>
 
@@ -88,9 +88,9 @@
 			<ui5-li>Audit Log Settings</ui5-li>
 			<ui5-li>OData API Audit</ui5-li>
 			<ui5-li-groupheader>Products</ui5-li-groupheader>
-			<ui5-li image="./img/HT-1010.jpg" icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131" additional-text-state="Error">Laptop Lenovo</ui5-li>
-			<ui5-li image="./img/HT-1022.jpg" icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131"  additional-text-state="Error">IPhone 3</ui5-li>
-			<ui5-li image="./img/HT-1030.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Reuqired" additional-text-state="Error">HP Monitor 24</ui5-li>
+			<ui5-li icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131" additional-text-state="Error">Laptop Lenovo</ui5-li>
+			<ui5-li icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131"  additional-text-state="Error">IPhone 3</ui5-li>
+			<ui5-li icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Reuqired" additional-text-state="Error">HP Monitor 24</ui5-li>
 		</ui5-list>
 	</ui5-popover>
 

--- a/packages/main/test/pages/Kitchen.html
+++ b/packages/main/test/pages/Kitchen.html
@@ -91,9 +91,9 @@
 				</ui5-card-header>
 
 				<ui5-list id="myList12" separators="Inner">
-					<ui5-li image="./img/HT-1030.jpg" icon="source-code" icon-end>Java EE</ui5-li>
-					<ui5-li image="./img/HT-1030.jpg" icon="source-code" icon-end>Maven</ui5-li>
-					<ui5-li image="./img/HT-1030.jpg" icon="source-code" icon-end>Cloud computing</ui5-li>
+					<ui5-li icon="source-code" icon-end>Java EE</ui5-li>
+					<ui5-li icon="source-code" icon-end>Maven</ui5-li>
+					<ui5-li icon="source-code" icon-end>Cloud computing</ui5-li>
 				</ui5-list>
 			</ui5-card>
 			<ui5-card
@@ -103,9 +103,9 @@
 				</ui5-card-header>
 
 				<ui5-list id="myList12" separators="Inner">
-					<ui5-li image="./img/HT-1030.jpg" icon="source-code">C/C++</ui5-li>
-					<ui5-li image="./img/HT-1030.jpg" icon="source-code">Phyton</ui5-li>
-					<ui5-li image="./img/HT-1030.jpg" icon="source-code">Node JS</ui5-li>
+					<ui5-li icon="source-code">C/C++</ui5-li>
+					<ui5-li icon="source-code">Phyton</ui5-li>
+					<ui5-li icon="source-code">Node JS</ui5-li>
 				</ui5-list>
 			</ui5-card>
 			<ui5-card

--- a/packages/main/test/pages/Kitchen.openui5.html
+++ b/packages/main/test/pages/Kitchen.openui5.html
@@ -86,9 +86,9 @@
 				</ui5-card-header>
 
 				<ui5-list id="myList12" separators="Inner">
-					<ui5-li image="./img/HT-1030.jpg" icon="source-code" icon-end>Java EE</ui5-li>
-					<ui5-li image="./img/HT-1030.jpg" icon="source-code" icon-end>Maven</ui5-li>
-					<ui5-li image="./img/HT-1030.jpg" icon="source-code" icon-end>Cloud computing</ui5-li>
+					<ui5-li icon="source-code" icon-end>Java EE</ui5-li>
+					<ui5-li icon="source-code" icon-end>Maven</ui5-li>
+					<ui5-li icon="source-code" icon-end>Cloud computing</ui5-li>
 				</ui5-list>
 			</ui5-card>
 			<ui5-card
@@ -98,9 +98,9 @@
 				</ui5-card-header>
 
 				<ui5-list id="myList12" separators="Inner">
-					<ui5-li image="./img/HT-1030.jpg" icon="source-code">C/C++</ui5-li>
-					<ui5-li image="./img/HT-1030.jpg" icon="source-code">Phyton</ui5-li>
-					<ui5-li image="./img/HT-1030.jpg" icon="source-code">Node JS</ui5-li>
+					<ui5-li icon="source-code">C/C++</ui5-li>
+					<ui5-li icon="source-code">Phyton</ui5-li>
+					<ui5-li icon="source-code">Node JS</ui5-li>
 				</ui5-list>
 			</ui5-card>
 			<ui5-card

--- a/packages/main/test/pages/List.html
+++ b/packages/main/test/pages/List.html
@@ -20,19 +20,19 @@
 
 	<ui5-list id="infiniteScrollEx" growing="Scroll" class="list3auto">
 		<ui5-li-groupheader>New Items</ui5-li-groupheader>
-		<ui5-li image="./img/HT-1000.jpg" icon="navigation-right-arrow" additional-text="Available">Voluptate do eu cupidatat elit est culpa. Reprehenderit eiusmod voluptate ex est dolor nostrud Lorem Lorem do nisi laborum veniam. Sint do non culpa aute occaecat labore ipsum veniam minim tempor est. Duis pariatur aute culpa irure ad excepteur pariatur culpa culpa ea duis occaecat aute irure. Ipsum velit culpa non exercitation ex laboris deserunt in eu non officia in. Laborum sunt aliqua labore cupidatat sunt labore.</ui5-li>
-		<ui5-li image="./img/portrait.jpg" icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131" additional-text-state="Error">Laptop Lenovo</ui5-li>
-		<ui5-li image="./img/HT-1022.jpg" icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131"  additional-text-state="Information">IPhone 3</ui5-li>
+		<ui5-li icon="navigation-right-arrow" additional-text="Available">Voluptate do eu cupidatat elit est culpa. Reprehenderit eiusmod voluptate ex est dolor nostrud Lorem Lorem do nisi laborum veniam. Sint do non culpa aute occaecat labore ipsum veniam minim tempor est. Duis pariatur aute culpa irure ad excepteur pariatur culpa culpa ea duis occaecat aute irure. Ipsum velit culpa non exercitation ex laboris deserunt in eu non officia in. Laborum sunt aliqua labore cupidatat sunt labore.</ui5-li>
+		<ui5-li icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131" additional-text-state="Error">Laptop Lenovo</ui5-li>
+		<ui5-li icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131"  additional-text-state="Information">IPhone 3</ui5-li>
 
 		<ui5-li-groupheader>Discounted Items</ui5-li-groupheader>
-		<ui5-li image="./img/HT-1030.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Reuqired" additional-text-state="Error">HP Monitor 24</ui5-li>
-		<ui5-li image="./img/HT-2026.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Available" additional-text-state="Success">Audio cabel</ui5-li>
-		<ui5-li image="./img/HT-2002.jpg"  icon-end icon="navigation-right-arrow" additional-text="Reuqired" additional-text-state="Warning">DVD set</ui5-li>
+		<ui5-li icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Reuqired" additional-text-state="Error">HP Monitor 24</ui5-li>
+		<ui5-li icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Available" additional-text-state="Success">Audio cabel</ui5-li>
+		<ui5-li icon-end icon="navigation-right-arrow" additional-text="Reuqired" additional-text-state="Warning">DVD set</ui5-li>
 
 		<ui5-li-groupheader>Discounted Items</ui5-li-groupheader>
-		<ui5-li image="./img/HT-1030.jpg"  icon="navigation-right-arrow">HP Monitor 24</ui5-li>
-		<ui5-li image="./img/HT-2026.jpg"  icon="navigation-right-arrow">Audio cabel</ui5-li>
-		<ui5-li image="./img/HT-2002.jpg"  icon="navigation-right-arrow">DVD set</ui5-li>
+		<ui5-li icon="navigation-right-arrow">HP Monitor 24</ui5-li>
+		<ui5-li icon="navigation-right-arrow">Audio cabel</ui5-li>
+		<ui5-li icon="navigation-right-arrow">DVD set</ui5-li>
 	</ui5-list>
 
 	<br/><br/>
@@ -40,9 +40,9 @@
 	<h2>List growing="Button" and growing-button-text property used</h2>
 	<ui5-list id="infiniteScrollEx2" growing="Button" growing-button-text="Custom growing-button-text" class="list3auto">
 		<ui5-li-groupheader>New Items</ui5-li-groupheader>
-		<ui5-li image="./img/HT-1000.jpg" icon="navigation-right-arrow" additional-text="Available">Voluptate do eu cupidatat elit est culpa. Reprehenderit eiusmod voluptate ex est dolor nostrud Lorem Lorem do nisi laborum veniam. Sint do non culpa aute occaecat labore ipsum veniam minim tempor est. Duis pariatur aute culpa irure ad excepteur pariatur culpa culpa ea duis occaecat aute irure. Ipsum velit culpa non exercitation ex laboris deserunt in eu non officia in. Laborum sunt aliqua labore cupidatat sunt labore.</ui5-li>
-		<ui5-li image="./img/portrait.jpg" icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131" additional-text-state="Error">Laptop Lenovo</ui5-li>
-		<ui5-li image="./img/HT-1022.jpg" icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131"  additional-text-state="Information">IPhone 3</ui5-li>
+		<ui5-li icon="navigation-right-arrow" additional-text="Available">Voluptate do eu cupidatat elit est culpa. Reprehenderit eiusmod voluptate ex est dolor nostrud Lorem Lorem do nisi laborum veniam. Sint do non culpa aute occaecat labore ipsum veniam minim tempor est. Duis pariatur aute culpa irure ad excepteur pariatur culpa culpa ea duis occaecat aute irure. Ipsum velit culpa non exercitation ex laboris deserunt in eu non officia in. Laborum sunt aliqua labore cupidatat sunt labore.</ui5-li>
+		<ui5-li icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131" additional-text-state="Error">Laptop Lenovo</ui5-li>
+		<ui5-li icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131"  additional-text-state="Information">IPhone 3</ui5-li>
 	</ui5-list>
 
 	<br/><br/>
@@ -51,19 +51,19 @@
 
 	<ui5-list header-text="API: GroupHeaderListItem" selection-mode="Multiple">
 		<ui5-li-groupheader>New Items</ui5-li-groupheader>
-		<ui5-li image="./img/HT-1000.jpg" icon="navigation-right-arrow" additional-text="Available">Voluptate do eu cupidatat elit est culpa. Reprehenderit eiusmod voluptate ex est dolor nostrud Lorem Lorem do nisi laborum veniam. Sint do non culpa aute occaecat labore ipsum veniam minim tempor est. Duis pariatur aute culpa irure ad excepteur pariatur culpa culpa ea duis occaecat aute irure. Ipsum velit culpa non exercitation ex laboris deserunt in eu non officia in. Laborum sunt aliqua labore cupidatat sunt labore.</ui5-li>
-		<ui5-li image="./img/HT-1010.jpg" icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131" additional-text-state="Error">Laptop Lenovo</ui5-li>
-		<ui5-li image="./img/HT-1022.jpg" icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131"  additional-text-state="Error">IPhone 3</ui5-li>
+		<ui5-li icon="navigation-right-arrow" additional-text="Available">Voluptate do eu cupidatat elit est culpa. Reprehenderit eiusmod voluptate ex est dolor nostrud Lorem Lorem do nisi laborum veniam. Sint do non culpa aute occaecat labore ipsum veniam minim tempor est. Duis pariatur aute culpa irure ad excepteur pariatur culpa culpa ea duis occaecat aute irure. Ipsum velit culpa non exercitation ex laboris deserunt in eu non officia in. Laborum sunt aliqua labore cupidatat sunt labore.</ui5-li>
+		<ui5-li icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131" additional-text-state="Error">Laptop Lenovo</ui5-li>
+		<ui5-li icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131"  additional-text-state="Error">IPhone 3</ui5-li>
 
 		<ui5-li-groupheader>Discounted Items</ui5-li-groupheader>
-		<ui5-li image="./img/HT-1030.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Reuqired" additional-text-state="Error">HP Monitor 24</ui5-li>
-		<ui5-li image="./img/HT-2026.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Available" additional-text-state="Success">Audio cabel</ui5-li>
-		<ui5-li image="./img/HT-2002.jpg"  icon-end icon="navigation-right-arrow" additional-text="Reuqired" additional-text-state="Warning">DVD set</ui5-li>
+		<ui5-li icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Reuqired" additional-text-state="Error">HP Monitor 24</ui5-li>
+		<ui5-li icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Available" additional-text-state="Success">Audio cabel</ui5-li>
+		<ui5-li  icon-end icon="navigation-right-arrow" additional-text="Reuqired" additional-text-state="Warning">DVD set</ui5-li>
 
 		<ui5-li-groupheader>Discounted Items</ui5-li-groupheader>
-		<ui5-li image="./img/HT-1030.jpg"  icon="navigation-right-arrow">HP Monitor 24</ui5-li>
-		<ui5-li image="./img/HT-2026.jpg"  icon="navigation-right-arrow">Audio cabel</ui5-li>
-		<ui5-li image="./img/HT-2002.jpg"  icon="navigation-right-arrow">DVD set</ui5-li>
+		<ui5-li icon="navigation-right-arrow">HP Monitor 24</ui5-li>
+		<ui5-li icon="navigation-right-arrow">Audio cabel</ui5-li>
+		<ui5-li icon="navigation-right-arrow">DVD set</ui5-li>
 	</ui5-list>
 
 	<br/><br/>
@@ -77,21 +77,13 @@
 	<br/><br/>
 
 	<ui5-list header-text="API: image">
-		<ui5-li image="./img/HT-1000.jpg" >Laptop HP</ui5-li>
-		<ui5-li image="./img/HT-1010.jpg" >laptop Lenovo</ui5-li>
-		<ui5-li image="./img/HT-1022.jpg" >IPhone 3</ui5-li>
-	</ui5-list>
-
-	<br/><br/>
-
-	<ui5-list header-text="API: imageContent">
-		<ui5-li> Avatar inside imageContent slot
-			<div slot="imageContent">
+		<ui5-li> Avatar inside image slot
+			<div slot="image">
 				<ui5-avatar shape="Square" initials="ABC" color-scheme="Accent2"></ui5-avatar>
 			</div>
 		</ui5-li>
-		<ui5-li> Avatar inside imageContent slot
-			<div slot="imageContent">
+		<ui5-li> Avatar inside image slot
+			<div slot="image">
 				<ui5-avatar >
 					<img src="./img/woman_avatar_5.png" alt="Woman image">
 				</ui5-avatar>
@@ -212,18 +204,18 @@
 	<br/><br/>
 
 	<ui5-list header-text="API: ListItem selected">
-		<ui5-li selected="selected" image="./img/HT-1000.jpg" >Laptop HP</ui5-li>
-		<ui5-li image="./img/HT-1010.jpg" >laptop Lenovo</ui5-li>
-		<ui5-li image="./img/HT-1022.jpg" >IPhone 3</ui5-li>
+		<ui5-li selected="selected" >Laptop HP</ui5-li>
+		<ui5-li >laptop Lenovo</ui5-li>
+		<ui5-li >IPhone 3</ui5-li>
 	</ui5-list>
 
 	<br/><br/>
 
 	<ui5-list header-text="API: Highlight">
-		<ui5-li highlight="Error" image="./img/HT-1000.jpg" >Laptop HP</ui5-li>
-		<ui5-li highlight="Information" image="./img/HT-1010.jpg" >laptop Lenovo</ui5-li>
-		<ui5-li highlight="Success" image="./img/HT-1022.jpg" >IPhone 3</ui5-li>
-		<ui5-li highlight="Warning" image="./img/HT-2002.jpg" >DVD set</ui5-li>
+		<ui5-li highlight="Error" >Laptop HP</ui5-li>
+		<ui5-li highlight="Information" >laptop Lenovo</ui5-li>
+		<ui5-li highlight="Success" >IPhone 3</ui5-li>
+		<ui5-li highlight="Warning" >DVD set</ui5-li>
 	</ui5-list>
 
 	<br/><br/>
@@ -305,7 +297,7 @@
 		<ui5-option>Multiple</ui5-option>
 		<ui5-option>Delete</ui5-option>
 	</ui5-select>
-	<ui5-list id="myList6" header-text="visualization of different combinations of icon / title / description / info / image - (Current selectionMode: None)">
+	<ui5-list id="myList6" header-text="visualization of different combinations of icon / title / description / info - (Current selectionMode: None)">
 		<ui5-li-custom>
 			<div class="list5auto">
 				<ui5-button>Press me</ui5-button>
@@ -320,10 +312,10 @@
 		<ui5-li icon="home" description="Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.">Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.</ui5-li>
 		<ui5-li icon="home" additional-text-state="Error" additional-text="Lorem ipsum">Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.</ui5-li>
 		<ui5-li icon="home" additional-text-state="Error" additional-text="Lorem ipsum" description="Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.">Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.</ui5-li>
-		<ui5-li image="./img/woman_avatar_5.png">Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.</ui5-li>
-		<ui5-li image="./img/woman_avatar_5.png" description="Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.">Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.</ui5-li>
-		<ui5-li image="./img/woman_avatar_5.png" additional-text-state="Error" additional-text="Lorem ipsum">Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.</ui5-li>
-		<ui5-li image="./img/woman_avatar_5.png" additional-text-state="Error" additional-text="Lorem ipsum" description="Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.">Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.</ui5-li>
+		<ui5-li >Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.</ui5-li>
+		<ui5-li description="Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.">Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.</ui5-li>
+		<ui5-li additional-text-state="Error" additional-text="Lorem ipsum">Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.</ui5-li>
+		<ui5-li additional-text-state="Error" additional-text="Lorem ipsum" description="Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.">Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.</ui5-li>
 	</ui5-list>
 
 	<script>

--- a/packages/main/test/pages/List.html
+++ b/packages/main/test/pages/List.html
@@ -21,71 +21,53 @@
 	<ui5-list id="infiniteScrollEx" growing="Scroll" class="list3auto">
 		<ui5-li-groupheader>New Items</ui5-li-groupheader>
 		<ui5-li icon="navigation-right-arrow" additional-text="Available">Voluptate do eu cupidatat elit est culpa. Reprehenderit eiusmod voluptate ex est dolor nostrud Lorem Lorem do nisi laborum veniam. Sint do non culpa aute occaecat labore ipsum veniam minim tempor est. Duis pariatur aute culpa irure ad excepteur pariatur culpa culpa ea duis occaecat aute irure. Ipsum velit culpa non exercitation ex laboris deserunt in eu non officia in. Laborum sunt aliqua labore cupidatat sunt labore.
-			<div slot="image">
-				<ui5-avatar >
-					<img src="./img/HT-1000.jpg" alt="Woman image">
-				</ui5-avatar>
-			</div>
+			<ui5-avatar slot="image">
+				<img src="./img/HT-1000.jpg" alt="Woman image">
+			</ui5-avatar>
 		</ui5-li>
 		<ui5-li icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131" additional-text-state="Error">Laptop Lenovo
-			<div slot="image">
-				<ui5-avatar >
-					<img src="./img/portrait.jpg" alt="Woman image">
-				</ui5-avatar>
-			</div>
+			<ui5-avatar slot="image">
+				<img src="./img/portrait.jpg" alt="Woman image">
+			</ui5-avatar>
 		</ui5-li>
 		<ui5-li icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131"  additional-text-state="Information">IPhone 3
-			<div slot="image">
-				<ui5-avatar >
-					<img src="./img/HT-1022.jpg" alt="Woman image">
-				</ui5-avatar>
-			</div>
+			<ui5-avatar slot="image">
+				<img src="./img/HT-1022.jpg" alt="Woman image">
+			</ui5-avatar>
 		</ui5-li>
 
 		<ui5-li-groupheader>Discounted Items</ui5-li-groupheader>
 		<ui5-li icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Reuqired" additional-text-state="Error">HP Monitor 24
-			<div slot="image">
-				<ui5-avatar >
-					<img src="./img/HT-1030.jpg" alt="Woman image">
-				</ui5-avatar>
-			</div>
+			<ui5-avatar slot="image">
+				<img src="./img/HT-1030.jpg" alt="Woman image">
+			</ui5-avatar>
 		</ui5-li>
 		<ui5-li icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Available" additional-text-state="Success">Audio cabel
-			<div slot="image">
-				<ui5-avatar >
-					<img src="./img/HT-2026.jpg" alt="Woman image">
-				</ui5-avatar>
-			</div>
+			<ui5-avatar slot="image">
+				<img src="./img/HT-2026.jpg" alt="Woman image">
+			</ui5-avatar>
 		</ui5-li>
 		<ui5-li icon-end icon="navigation-right-arrow" additional-text="Reuqired" additional-text-state="Warning">DVD set
-			<div slot="image">
-				<ui5-avatar >
-					<img src="./img/HT-2002.jpg" alt="Woman image">
-				</ui5-avatar>
-			</div>
+			<ui5-avatar slot="image">
+				<img src="./img/HT-2002.jpg" alt="Woman image">
+			</ui5-avatar>
 		</ui5-li>
 
 		<ui5-li-groupheader>Discounted Items</ui5-li-groupheader>
 		<ui5-li icon="navigation-right-arrow">HP Monitor 24
-			<div slot="image">
-				<ui5-avatar >
-					<img src="./img/HT-1030.jpg" alt="Woman image">
-				</ui5-avatar>
-			</div>
+			<ui5-avatar slot="image">
+				<img src="./img/HT-1030.jpg" alt="Woman image">
+			</ui5-avatar>
 		</ui5-li>
 		<ui5-li icon="navigation-right-arrow">Audio cabel
-			<div slot="image">
-				<ui5-avatar >
-					<img src="./img/HT-2026.jpg" alt="Woman image">
-				</ui5-avatar>
-			</div>
+			<ui5-avatar slot="image">
+				<img src="./img/HT-2026.jpg" alt="Woman image">
+			</ui5-avatar>
 		</ui5-li>
 		<ui5-li icon="navigation-right-arrow">DVD set
-			<div slot="image">
-				<ui5-avatar >
-					<img src="./img/HT-2002.jpg" alt="Woman image">
-				</ui5-avatar>
-			</div>
+			<ui5-avatar slot="image">
+				<img src="./img/HT-2002.jpg" alt="Woman image">
+			</ui5-avatar>
 		</ui5-li>
 	</ui5-list>
 
@@ -95,25 +77,19 @@
 	<ui5-list id="infiniteScrollEx2" growing="Button" growing-button-text="Custom growing-button-text" class="list3auto">
 		<ui5-li-groupheader>New Items</ui5-li-groupheader>
 		<ui5-li icon="navigation-right-arrow" additional-text="Available">Voluptate do eu cupidatat elit est culpa. Reprehenderit eiusmod voluptate ex est dolor nostrud Lorem Lorem do nisi laborum veniam. Sint do non culpa aute occaecat labore ipsum veniam minim tempor est. Duis pariatur aute culpa irure ad excepteur pariatur culpa culpa ea duis occaecat aute irure. Ipsum velit culpa non exercitation ex laboris deserunt in eu non officia in. Laborum sunt aliqua labore cupidatat sunt labore.
-			<div slot="image">
-				<ui5-avatar >
-					<img src="./img/HT-1000.jpg" alt="Woman image">
-				</ui5-avatar>
-			</div>
+			<ui5-avatar slot="image">
+				<img src="./img/HT-1000.jpg" alt="Woman image">
+			</ui5-avatar>
 		</ui5-li>
 		<ui5-li icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131" additional-text-state="Error">Laptop Lenovo
-			<div slot="image">
-				<ui5-avatar >
-					<img src="./img/portrait.jpg" alt="Woman image">
-				</ui5-avatar>
-			</div>
+			<ui5-avatar slot="image">
+				<img src="./img/portrait.jpg" alt="Woman image">
+			</ui5-avatar>
 		</ui5-li>
 		<ui5-li icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131"  additional-text-state="Information">IPhone 3
-			<div slot="image">
-				<ui5-avatar >
-					<img src="./img/HT-1022.jpg" alt="Woman image">
-				</ui5-avatar>
-			</div>
+			<ui5-avatar slot="image">
+				<img src="./img/HT-1022.jpg" alt="Woman image">
+			</ui5-avatar>
 		</ui5-li>
 	</ui5-list>
 
@@ -124,71 +100,53 @@
 	<ui5-list header-text="API: GroupHeaderListItem" selection-mode="Multiple">
 		<ui5-li-groupheader>New Items</ui5-li-groupheader>
 		<ui5-li icon="navigation-right-arrow" additional-text="Available">Voluptate do eu cupidatat elit est culpa. Reprehenderit eiusmod voluptate ex est dolor nostrud Lorem Lorem do nisi laborum veniam. Sint do non culpa aute occaecat labore ipsum veniam minim tempor est. Duis pariatur aute culpa irure ad excepteur pariatur culpa culpa ea duis occaecat aute irure. Ipsum velit culpa non exercitation ex laboris deserunt in eu non officia in. Laborum sunt aliqua labore cupidatat sunt labore.
-			<div slot="image">
-				<ui5-avatar >
-					<img src="./img/HT-1000.jpg" alt="Woman image">
-				</ui5-avatar>
-			</div>
+			<ui5-avatar slot="image">
+				<img src="./img/HT-1000.jpg" alt="Woman image">
+			</ui5-avatar>
 		</ui5-li>
 		<ui5-li icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131" additional-text-state="Error">Laptop Lenovo
-			<div slot="image">
-				<ui5-avatar >
-					<img src="./img/HT-1010.jpg" alt="Woman image">
-				</ui5-avatar>
-			</div>
+			<ui5-avatar slot="image">
+				<img src="./img/HT-1010.jpg" alt="Woman image">
+			</ui5-avatar>
 		</ui5-li>
 		<ui5-li icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131"  additional-text-state="Error">IPhone 3
-			<div slot="image">
-				<ui5-avatar >
-					<img src="./img/HT-1022.jpg" alt="Woman image">
-				</ui5-avatar>
-			</div>
+			<ui5-avatar slot="image">
+				<img src="./img/HT-1022.jpg" alt="Woman image">
+			</ui5-avatar>
 		</ui5-li>
 
 		<ui5-li-groupheader>Discounted Items</ui5-li-groupheader>
 		<ui5-li icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Reuqired" additional-text-state="Error">HP Monitor 24
-			<div slot="image">
-				<ui5-avatar >
-					<img src="./img/HT-1030.jpg" alt="Woman image">
-				</ui5-avatar>
-			</div>
+			<ui5-avatar slot="image">
+				<img src="./img/HT-1030.jpg" alt="Woman image">
+			</ui5-avatar>
 		</ui5-li>
 		<ui5-li icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Available" additional-text-state="Success">Audio cabel
-			<div slot="image">
-				<ui5-avatar >
-					<img src="./img/HT-2026.jpg" alt="Woman image">
-				</ui5-avatar>
-			</div>
+			<ui5-avatar slot="image">
+				<img src="./img/HT-2026.jpg" alt="Woman image">
+			</ui5-avatar>
 		</ui5-li>
 		<ui5-li  icon-end icon="navigation-right-arrow" additional-text="Reuqired" additional-text-state="Warning">DVD set
-			<div slot="image">
-				<ui5-avatar >
-					<img src="./img/HT-2002.jpg" alt="Woman image">
-				</ui5-avatar>
-			</div>
+			<ui5-avatar slot="image">
+				<img src="./img/HT-2002.jpg" alt="Woman image">
+			</ui5-avatar>
 		</ui5-li>
 
 		<ui5-li-groupheader>Discounted Items</ui5-li-groupheader>
 		<ui5-li icon="navigation-right-arrow">HP Monitor 24
-			<div slot="image">
-				<ui5-avatar >
-					<img src="./img/HT-1030.jpg" alt="Woman image">
-				</ui5-avatar>
-			</div>
+			<ui5-avatar slot="image">
+				<img src="./img/HT-1030.jpg" alt="Woman image">
+			</ui5-avatar>
 		</ui5-li>
 		<ui5-li icon="navigation-right-arrow">Audio cabel
-			<div slot="image">
-				<ui5-avatar >
-					<img src="./img/HT-2026.jpg" alt="Woman image">
-				</ui5-avatar>
-			</div>
+			<ui5-avatar slot="image">
+				<img src="./img/HT-2026.jpg" alt="Woman image">
+			</ui5-avatar>
 		</ui5-li>
 		<ui5-li icon="navigation-right-arrow">DVD set
-			<div slot="image">
-				<ui5-avatar >
-					<img src="./img/HT-2002.jpg" alt="Woman image">
-				</ui5-avatar>
-			</div>
+			<ui5-avatar slot="image">
+				<img src="./img/HT-2002.jpg" alt="Woman image">
+			</ui5-avatar>
 		</ui5-li>
 	</ui5-list>
 
@@ -204,16 +162,12 @@
 
 	<ui5-list header-text="API: image">
 		<ui5-li> Avatar inside image slot
-			<div slot="image">
-				<ui5-avatar shape="Square" initials="ABC" color-scheme="Accent2"></ui5-avatar>
-			</div>
+			<ui5-avatar slot="image" shape="Square" initials="ABC" color-scheme="Accent2"></ui5-avatar>
 		</ui5-li>
 		<ui5-li> Avatar inside image slot
-			<div slot="image">
-				<ui5-avatar >
-					<img src="./img/woman_avatar_5.png" alt="Woman image">
-				</ui5-avatar>
-			</div>
+			<ui5-avatar slot="image">
+				<img src="./img/woman_avatar_5.png" alt="Woman image">
+			</ui5-avatar>
 		</ui5-li>
 	</ui5-list>
 
@@ -331,25 +285,19 @@
 
 	<ui5-list header-text="API: ListItem selected">
 		<ui5-li selected="selected" >Laptop HP
-			<div slot="image">
-				<ui5-avatar >
-					<img src="./img/HT-1000.jpg" alt="Woman image">
-				</ui5-avatar>
-			</div>
+			<ui5-avatar slot="image">
+				<img src="./img/HT-1000.jpg" alt="Woman image">
+			</ui5-avatar>
 		</ui5-li>
 		<ui5-li >laptop Lenovo
-			<div slot="image">
-				<ui5-avatar >
-					<img src="./img/HT-1010.jpg" alt="Woman image">
-				</ui5-avatar>
-			</div>
+			<ui5-avatar slot="image">
+				<img src="./img/HT-1010.jpg" alt="Woman image">
+			</ui5-avatar>
 		</ui5-li>
 		<ui5-li >IPhone 3
-			<div slot="image">
-				<ui5-avatar >
-					<img src="./img/HT-1022.jpg" alt="Woman image">
-				</ui5-avatar>
-			</div>
+			<ui5-avatar slot="image">
+				<img src="./img/HT-1022.jpg" alt="Woman image">
+			</ui5-avatar>
 		</ui5-li>
 	</ui5-list>
 
@@ -357,32 +305,24 @@
 
 	<ui5-list header-text="API: Highlight">
 		<ui5-li highlight="Error" >Laptop HP
-			<div slot="image">
-				<ui5-avatar >
-					<img src="./img/HT-1000.jpg" alt="Woman image">
-				</ui5-avatar>
-			</div>
+			<ui5-avatar slot="image">
+				<img src="./img/HT-1000.jpg" alt="Woman image">
+			</ui5-avatar>
 		</ui5-li>
 		<ui5-li highlight="Information" >laptop Lenovo
-			<div slot="image">
-				<ui5-avatar >
-					<img src="./img/HT-1010.jpg" alt="Woman image">
-				</ui5-avatar>
-			</div>
+			<ui5-avatar slot="image">
+				<img src="./img/HT-1010.jpg" alt="Woman image">
+			</ui5-avatar>
 		</ui5-li>
 		<ui5-li highlight="Success" >IPhone 3
-			<div slot="image">
-				<ui5-avatar >
-					<img src="./img/HT-1022.jpg" alt="Woman image">
-				</ui5-avatar>
-			</div>
+			<ui5-avatar slot="image">
+				<img src="./img/HT-1022.jpg" alt="Woman image">
+			</ui5-avatar>
 		</ui5-li>
 		<ui5-li highlight="Warning" >DVD set
-			<div slot="image">
-				<ui5-avatar >
-					<img src="./img/HT-2002.jpg" alt="Woman image">
-				</ui5-avatar>
-			</div>
+			<ui5-avatar slot="image">
+				<img src="./img/HT-2002.jpg" alt="Woman image">
+			</ui5-avatar>
 		</ui5-li>
 	</ui5-list>
 
@@ -481,32 +421,24 @@
 		<ui5-li icon="home" additional-text-state="Error" additional-text="Lorem ipsum">Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.</ui5-li>
 		<ui5-li icon="home" additional-text-state="Error" additional-text="Lorem ipsum" description="Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.">Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.</ui5-li>
 		<ui5-li >Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.
-			<div slot="image">
-				<ui5-avatar >
-					<img src="./img/woman_avatar_5.png" alt="Woman image">
-				</ui5-avatar>
-			</div>
+			<ui5-avatar slot="image">
+				<img src="./img/woman_avatar_5.png" alt="Woman image">
+			</ui5-avatar>
 		</ui5-li>
 		<ui5-li description="Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.">Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.
-			<div slot="image">
-				<ui5-avatar >
-					<img src="./img/woman_avatar_5.png" alt="Woman image">
-				</ui5-avatar>
-			</div>
+			<ui5-avatar slot="image">
+				<img src="./img/woman_avatar_5.png" alt="Woman image">
+			</ui5-avatar>
 		</ui5-li>
 		<ui5-li additional-text-state="Error" additional-text="Lorem ipsum">Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.
-			<div slot="image">
-				<ui5-avatar >
-					<img src="./img/woman_avatar_5.png" alt="Woman image">
-				</ui5-avatar>
-			</div>
+			<ui5-avatar slot="image">
+				<img src="./img/woman_avatar_5.png" alt="Woman image">
+			</ui5-avatar>
 		</ui5-li>
 		<ui5-li additional-text-state="Error" additional-text="Lorem ipsum" description="Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.">Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.
-			<div slot="image">
-				<ui5-avatar >
-					<img src="./img/woman_avatar_5.png" alt="Woman image">
-				</ui5-avatar>
-			</div>
+			<ui5-avatar slot="image">
+				<img src="./img/woman_avatar_5.png" alt="Woman image">
+			</ui5-avatar>
 		</ui5-li>
 	</ui5-list>
 

--- a/packages/main/test/pages/List.html
+++ b/packages/main/test/pages/List.html
@@ -20,19 +20,73 @@
 
 	<ui5-list id="infiniteScrollEx" growing="Scroll" class="list3auto">
 		<ui5-li-groupheader>New Items</ui5-li-groupheader>
-		<ui5-li icon="navigation-right-arrow" additional-text="Available">Voluptate do eu cupidatat elit est culpa. Reprehenderit eiusmod voluptate ex est dolor nostrud Lorem Lorem do nisi laborum veniam. Sint do non culpa aute occaecat labore ipsum veniam minim tempor est. Duis pariatur aute culpa irure ad excepteur pariatur culpa culpa ea duis occaecat aute irure. Ipsum velit culpa non exercitation ex laboris deserunt in eu non officia in. Laborum sunt aliqua labore cupidatat sunt labore.</ui5-li>
-		<ui5-li icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131" additional-text-state="Error">Laptop Lenovo</ui5-li>
-		<ui5-li icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131"  additional-text-state="Information">IPhone 3</ui5-li>
+		<ui5-li icon="navigation-right-arrow" additional-text="Available">Voluptate do eu cupidatat elit est culpa. Reprehenderit eiusmod voluptate ex est dolor nostrud Lorem Lorem do nisi laborum veniam. Sint do non culpa aute occaecat labore ipsum veniam minim tempor est. Duis pariatur aute culpa irure ad excepteur pariatur culpa culpa ea duis occaecat aute irure. Ipsum velit culpa non exercitation ex laboris deserunt in eu non officia in. Laborum sunt aliqua labore cupidatat sunt labore.
+			<div slot="image">
+				<ui5-avatar >
+					<img src="./img/HT-1000.jpg" alt="Woman image">
+				</ui5-avatar>
+			</div>
+		</ui5-li>
+		<ui5-li icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131" additional-text-state="Error">Laptop Lenovo
+			<div slot="image">
+				<ui5-avatar >
+					<img src="./img/portrait.jpg" alt="Woman image">
+				</ui5-avatar>
+			</div>
+		</ui5-li>
+		<ui5-li icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131"  additional-text-state="Information">IPhone 3
+			<div slot="image">
+				<ui5-avatar >
+					<img src="./img/HT-1022.jpg" alt="Woman image">
+				</ui5-avatar>
+			</div>
+		</ui5-li>
 
 		<ui5-li-groupheader>Discounted Items</ui5-li-groupheader>
-		<ui5-li icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Reuqired" additional-text-state="Error">HP Monitor 24</ui5-li>
-		<ui5-li icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Available" additional-text-state="Success">Audio cabel</ui5-li>
-		<ui5-li icon-end icon="navigation-right-arrow" additional-text="Reuqired" additional-text-state="Warning">DVD set</ui5-li>
+		<ui5-li icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Reuqired" additional-text-state="Error">HP Monitor 24
+			<div slot="image">
+				<ui5-avatar >
+					<img src="./img/HT-1030.jpg" alt="Woman image">
+				</ui5-avatar>
+			</div>
+		</ui5-li>
+		<ui5-li icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Available" additional-text-state="Success">Audio cabel
+			<div slot="image">
+				<ui5-avatar >
+					<img src="./img/HT-2026.jpg" alt="Woman image">
+				</ui5-avatar>
+			</div>
+		</ui5-li>
+		<ui5-li icon-end icon="navigation-right-arrow" additional-text="Reuqired" additional-text-state="Warning">DVD set
+			<div slot="image">
+				<ui5-avatar >
+					<img src="./img/HT-2002.jpg" alt="Woman image">
+				</ui5-avatar>
+			</div>
+		</ui5-li>
 
 		<ui5-li-groupheader>Discounted Items</ui5-li-groupheader>
-		<ui5-li icon="navigation-right-arrow">HP Monitor 24</ui5-li>
-		<ui5-li icon="navigation-right-arrow">Audio cabel</ui5-li>
-		<ui5-li icon="navigation-right-arrow">DVD set</ui5-li>
+		<ui5-li icon="navigation-right-arrow">HP Monitor 24
+			<div slot="image">
+				<ui5-avatar >
+					<img src="./img/HT-1030.jpg" alt="Woman image">
+				</ui5-avatar>
+			</div>
+		</ui5-li>
+		<ui5-li icon="navigation-right-arrow">Audio cabel
+			<div slot="image">
+				<ui5-avatar >
+					<img src="./img/HT-2026.jpg" alt="Woman image">
+				</ui5-avatar>
+			</div>
+		</ui5-li>
+		<ui5-li icon="navigation-right-arrow">DVD set
+			<div slot="image">
+				<ui5-avatar >
+					<img src="./img/HT-2002.jpg" alt="Woman image">
+				</ui5-avatar>
+			</div>
+		</ui5-li>
 	</ui5-list>
 
 	<br/><br/>
@@ -40,9 +94,27 @@
 	<h2>List growing="Button" and growing-button-text property used</h2>
 	<ui5-list id="infiniteScrollEx2" growing="Button" growing-button-text="Custom growing-button-text" class="list3auto">
 		<ui5-li-groupheader>New Items</ui5-li-groupheader>
-		<ui5-li icon="navigation-right-arrow" additional-text="Available">Voluptate do eu cupidatat elit est culpa. Reprehenderit eiusmod voluptate ex est dolor nostrud Lorem Lorem do nisi laborum veniam. Sint do non culpa aute occaecat labore ipsum veniam minim tempor est. Duis pariatur aute culpa irure ad excepteur pariatur culpa culpa ea duis occaecat aute irure. Ipsum velit culpa non exercitation ex laboris deserunt in eu non officia in. Laborum sunt aliqua labore cupidatat sunt labore.</ui5-li>
-		<ui5-li icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131" additional-text-state="Error">Laptop Lenovo</ui5-li>
-		<ui5-li icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131"  additional-text-state="Information">IPhone 3</ui5-li>
+		<ui5-li icon="navigation-right-arrow" additional-text="Available">Voluptate do eu cupidatat elit est culpa. Reprehenderit eiusmod voluptate ex est dolor nostrud Lorem Lorem do nisi laborum veniam. Sint do non culpa aute occaecat labore ipsum veniam minim tempor est. Duis pariatur aute culpa irure ad excepteur pariatur culpa culpa ea duis occaecat aute irure. Ipsum velit culpa non exercitation ex laboris deserunt in eu non officia in. Laborum sunt aliqua labore cupidatat sunt labore.
+			<div slot="image">
+				<ui5-avatar >
+					<img src="./img/HT-1000.jpg" alt="Woman image">
+				</ui5-avatar>
+			</div>
+		</ui5-li>
+		<ui5-li icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131" additional-text-state="Error">Laptop Lenovo
+			<div slot="image">
+				<ui5-avatar >
+					<img src="./img/portrait.jpg" alt="Woman image">
+				</ui5-avatar>
+			</div>
+		</ui5-li>
+		<ui5-li icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131"  additional-text-state="Information">IPhone 3
+			<div slot="image">
+				<ui5-avatar >
+					<img src="./img/HT-1022.jpg" alt="Woman image">
+				</ui5-avatar>
+			</div>
+		</ui5-li>
 	</ui5-list>
 
 	<br/><br/>
@@ -51,19 +123,73 @@
 
 	<ui5-list header-text="API: GroupHeaderListItem" selection-mode="Multiple">
 		<ui5-li-groupheader>New Items</ui5-li-groupheader>
-		<ui5-li icon="navigation-right-arrow" additional-text="Available">Voluptate do eu cupidatat elit est culpa. Reprehenderit eiusmod voluptate ex est dolor nostrud Lorem Lorem do nisi laborum veniam. Sint do non culpa aute occaecat labore ipsum veniam minim tempor est. Duis pariatur aute culpa irure ad excepteur pariatur culpa culpa ea duis occaecat aute irure. Ipsum velit culpa non exercitation ex laboris deserunt in eu non officia in. Laborum sunt aliqua labore cupidatat sunt labore.</ui5-li>
-		<ui5-li icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131" additional-text-state="Error">Laptop Lenovo</ui5-li>
-		<ui5-li icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131"  additional-text-state="Error">IPhone 3</ui5-li>
+		<ui5-li icon="navigation-right-arrow" additional-text="Available">Voluptate do eu cupidatat elit est culpa. Reprehenderit eiusmod voluptate ex est dolor nostrud Lorem Lorem do nisi laborum veniam. Sint do non culpa aute occaecat labore ipsum veniam minim tempor est. Duis pariatur aute culpa irure ad excepteur pariatur culpa culpa ea duis occaecat aute irure. Ipsum velit culpa non exercitation ex laboris deserunt in eu non officia in. Laborum sunt aliqua labore cupidatat sunt labore.
+			<div slot="image">
+				<ui5-avatar >
+					<img src="./img/HT-1000.jpg" alt="Woman image">
+				</ui5-avatar>
+			</div>
+		</ui5-li>
+		<ui5-li icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131" additional-text-state="Error">Laptop Lenovo
+			<div slot="image">
+				<ui5-avatar >
+					<img src="./img/HT-1010.jpg" alt="Woman image">
+				</ui5-avatar>
+			</div>
+		</ui5-li>
+		<ui5-li icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131"  additional-text-state="Error">IPhone 3
+			<div slot="image">
+				<ui5-avatar >
+					<img src="./img/HT-1022.jpg" alt="Woman image">
+				</ui5-avatar>
+			</div>
+		</ui5-li>
 
 		<ui5-li-groupheader>Discounted Items</ui5-li-groupheader>
-		<ui5-li icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Reuqired" additional-text-state="Error">HP Monitor 24</ui5-li>
-		<ui5-li icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Available" additional-text-state="Success">Audio cabel</ui5-li>
-		<ui5-li  icon-end icon="navigation-right-arrow" additional-text="Reuqired" additional-text-state="Warning">DVD set</ui5-li>
+		<ui5-li icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Reuqired" additional-text-state="Error">HP Monitor 24
+			<div slot="image">
+				<ui5-avatar >
+					<img src="./img/HT-1030.jpg" alt="Woman image">
+				</ui5-avatar>
+			</div>
+		</ui5-li>
+		<ui5-li icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Available" additional-text-state="Success">Audio cabel
+			<div slot="image">
+				<ui5-avatar >
+					<img src="./img/HT-2026.jpg" alt="Woman image">
+				</ui5-avatar>
+			</div>
+		</ui5-li>
+		<ui5-li  icon-end icon="navigation-right-arrow" additional-text="Reuqired" additional-text-state="Warning">DVD set
+			<div slot="image">
+				<ui5-avatar >
+					<img src="./img/HT-2002.jpg" alt="Woman image">
+				</ui5-avatar>
+			</div>
+		</ui5-li>
 
 		<ui5-li-groupheader>Discounted Items</ui5-li-groupheader>
-		<ui5-li icon="navigation-right-arrow">HP Monitor 24</ui5-li>
-		<ui5-li icon="navigation-right-arrow">Audio cabel</ui5-li>
-		<ui5-li icon="navigation-right-arrow">DVD set</ui5-li>
+		<ui5-li icon="navigation-right-arrow">HP Monitor 24
+			<div slot="image">
+				<ui5-avatar >
+					<img src="./img/HT-1030.jpg" alt="Woman image">
+				</ui5-avatar>
+			</div>
+		</ui5-li>
+		<ui5-li icon="navigation-right-arrow">Audio cabel
+			<div slot="image">
+				<ui5-avatar >
+					<img src="./img/HT-2026.jpg" alt="Woman image">
+				</ui5-avatar>
+			</div>
+		</ui5-li>
+		<ui5-li icon="navigation-right-arrow">DVD set
+			<div slot="image">
+				<ui5-avatar >
+					<img src="./img/HT-2002.jpg" alt="Woman image">
+				</ui5-avatar>
+			</div>
+		</ui5-li>
 	</ui5-list>
 
 	<br/><br/>
@@ -204,18 +330,60 @@
 	<br/><br/>
 
 	<ui5-list header-text="API: ListItem selected">
-		<ui5-li selected="selected" >Laptop HP</ui5-li>
-		<ui5-li >laptop Lenovo</ui5-li>
-		<ui5-li >IPhone 3</ui5-li>
+		<ui5-li selected="selected" >Laptop HP
+			<div slot="image">
+				<ui5-avatar >
+					<img src="./img/HT-1000.jpg" alt="Woman image">
+				</ui5-avatar>
+			</div>
+		</ui5-li>
+		<ui5-li >laptop Lenovo
+			<div slot="image">
+				<ui5-avatar >
+					<img src="./img/HT-1010.jpg" alt="Woman image">
+				</ui5-avatar>
+			</div>
+		</ui5-li>
+		<ui5-li >IPhone 3
+			<div slot="image">
+				<ui5-avatar >
+					<img src="./img/HT-1022.jpg" alt="Woman image">
+				</ui5-avatar>
+			</div>
+		</ui5-li>
 	</ui5-list>
 
 	<br/><br/>
 
 	<ui5-list header-text="API: Highlight">
-		<ui5-li highlight="Error" >Laptop HP</ui5-li>
-		<ui5-li highlight="Information" >laptop Lenovo</ui5-li>
-		<ui5-li highlight="Success" >IPhone 3</ui5-li>
-		<ui5-li highlight="Warning" >DVD set</ui5-li>
+		<ui5-li highlight="Error" >Laptop HP
+			<div slot="image">
+				<ui5-avatar >
+					<img src="./img/HT-1000.jpg" alt="Woman image">
+				</ui5-avatar>
+			</div>
+		</ui5-li>
+		<ui5-li highlight="Information" >laptop Lenovo
+			<div slot="image">
+				<ui5-avatar >
+					<img src="./img/HT-1010.jpg" alt="Woman image">
+				</ui5-avatar>
+			</div>
+		</ui5-li>
+		<ui5-li highlight="Success" >IPhone 3
+			<div slot="image">
+				<ui5-avatar >
+					<img src="./img/HT-1022.jpg" alt="Woman image">
+				</ui5-avatar>
+			</div>
+		</ui5-li>
+		<ui5-li highlight="Warning" >DVD set
+			<div slot="image">
+				<ui5-avatar >
+					<img src="./img/HT-2002.jpg" alt="Woman image">
+				</ui5-avatar>
+			</div>
+		</ui5-li>
 	</ui5-list>
 
 	<br/><br/>
@@ -312,10 +480,34 @@
 		<ui5-li icon="home" description="Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.">Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.</ui5-li>
 		<ui5-li icon="home" additional-text-state="Error" additional-text="Lorem ipsum">Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.</ui5-li>
 		<ui5-li icon="home" additional-text-state="Error" additional-text="Lorem ipsum" description="Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.">Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.</ui5-li>
-		<ui5-li >Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.</ui5-li>
-		<ui5-li description="Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.">Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.</ui5-li>
-		<ui5-li additional-text-state="Error" additional-text="Lorem ipsum">Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.</ui5-li>
-		<ui5-li additional-text-state="Error" additional-text="Lorem ipsum" description="Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.">Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.</ui5-li>
+		<ui5-li >Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.
+			<div slot="image">
+				<ui5-avatar >
+					<img src="./img/woman_avatar_5.png" alt="Woman image">
+				</ui5-avatar>
+			</div>
+		</ui5-li>
+		<ui5-li description="Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.">Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.
+			<div slot="image">
+				<ui5-avatar >
+					<img src="./img/woman_avatar_5.png" alt="Woman image">
+				</ui5-avatar>
+			</div>
+		</ui5-li>
+		<ui5-li additional-text-state="Error" additional-text="Lorem ipsum">Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.
+			<div slot="image">
+				<ui5-avatar >
+					<img src="./img/woman_avatar_5.png" alt="Woman image">
+				</ui5-avatar>
+			</div>
+		</ui5-li>
+		<ui5-li additional-text-state="Error" additional-text="Lorem ipsum" description="Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.">Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.
+			<div slot="image">
+				<ui5-avatar >
+					<img src="./img/woman_avatar_5.png" alt="Woman image">
+				</ui5-avatar>
+			</div>
+		</ui5-li>
 	</ui5-list>
 
 	<script>

--- a/packages/main/test/pages/ListGrowing_Button.html
+++ b/packages/main/test/pages/ListGrowing_Button.html
@@ -18,13 +18,13 @@
 	<br>
 	<ui5-list id="infiniteScrollEx" growing="Button">
 		<ui5-li-groupheader>New Items</ui5-li-groupheader>
-		<ui5-li image="./img/HT-1000.jpg" icon="navigation-right-arrow" additional-text="Available">Voluptate do eu cupidatat elit est culpa. Reprehenderit eiusmod voluptate ex est dolor nostrud Lorem Lorem do nisi laborum veniam. Sint do non culpa aute occaecat labore ipsum veniam minim tempor est. Duis pariatur aute culpa irure ad excepteur pariatur culpa culpa ea duis occaecat aute irure. Ipsum velit culpa non exercitation ex laboris deserunt in eu non officia in. Laborum sunt aliqua labore cupidatat sunt labore.</ui5-li>
-		<ui5-li image="./img/portrait.jpg" icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131" additional-text-state="Error">Laptop Lenovo</ui5-li>
-		<ui5-li image="./img/HT-1022.jpg" icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131"  additional-text-state="Information">IPhone 3</ui5-li>
+		<ui5-li icon="navigation-right-arrow" additional-text="Available">Voluptate do eu cupidatat elit est culpa. Reprehenderit eiusmod voluptate ex est dolor nostrud Lorem Lorem do nisi laborum veniam. Sint do non culpa aute occaecat labore ipsum veniam minim tempor est. Duis pariatur aute culpa irure ad excepteur pariatur culpa culpa ea duis occaecat aute irure. Ipsum velit culpa non exercitation ex laboris deserunt in eu non officia in. Laborum sunt aliqua labore cupidatat sunt labore.</ui5-li>
+		<ui5-li icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131" additional-text-state="Error">Laptop Lenovo</ui5-li>
+		<ui5-li icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131"  additional-text-state="Information">IPhone 3</ui5-li>
 		<ui5-li-groupheader>Discounted Items</ui5-li-groupheader>
-		<ui5-li image="./img/HT-1030.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Reuqired" additional-text-state="Error">HP Monitor 24</ui5-li>
-		<ui5-li image="./img/HT-2026.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Available" additional-text-state="Success">Audio cabel</ui5-li>
-		<ui5-li image="./img/HT-2002.jpg"  icon-end icon="navigation-right-arrow" additional-text="Reuqired" additional-text-state="Warning">DVD set</ui5-li>
+		<ui5-li icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Reuqired" additional-text-state="Error">HP Monitor 24</ui5-li>
+		<ui5-li icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Available" additional-text-state="Success">Audio cabel</ui5-li>
+		<ui5-li icon-end icon="navigation-right-arrow" additional-text="Reuqired" additional-text-state="Warning">DVD set</ui5-li>
 	</ui5-list>
 
 	<script>

--- a/packages/main/test/pages/ListGrowing_Scroll.html
+++ b/packages/main/test/pages/ListGrowing_Scroll.html
@@ -20,13 +20,13 @@
 	<section class="listgrowing_scroll2auto">
 		<ui5-list id="infiniteScrollEx" growing="Scroll">
 			<ui5-li-groupheader>New Items</ui5-li-groupheader>
-			<ui5-li image="./img/HT-1000.jpg" icon="navigation-right-arrow" additional-text="Available">Voluptate do eu cupidatat elit est culpa. Reprehenderit eiusmod voluptate ex est dolor nostrud Lorem Lorem do nisi laborum veniam. Sint do non culpa aute occaecat labore ipsum veniam minim tempor est. Duis pariatur aute culpa irure ad excepteur pariatur culpa culpa ea duis occaecat aute irure. Ipsum velit culpa non exercitation ex laboris deserunt in eu non officia in. Laborum sunt aliqua labore cupidatat sunt labore.</ui5-li>
-			<ui5-li image="./img/portrait.jpg" icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131" additional-text-state="Error">Laptop Lenovo</ui5-li>
-			<ui5-li image="./img/HT-1022.jpg" icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131"  additional-text-state="Information">IPhone 3</ui5-li>
+			<ui5-li icon="navigation-right-arrow" additional-text="Available">Voluptate do eu cupidatat elit est culpa. Reprehenderit eiusmod voluptate ex est dolor nostrud Lorem Lorem do nisi laborum veniam. Sint do non culpa aute occaecat labore ipsum veniam minim tempor est. Duis pariatur aute culpa irure ad excepteur pariatur culpa culpa ea duis occaecat aute irure. Ipsum velit culpa non exercitation ex laboris deserunt in eu non officia in. Laborum sunt aliqua labore cupidatat sunt labore.</ui5-li>
+			<ui5-li icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131" additional-text-state="Error">Laptop Lenovo</ui5-li>
+			<ui5-li icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131"  additional-text-state="Information">IPhone 3</ui5-li>
 			<ui5-li-groupheader>Discounted Items</ui5-li-groupheader>
-			<ui5-li image="./img/HT-1030.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Reuqired" additional-text-state="Error">HP Monitor 24</ui5-li>
-			<ui5-li image="./img/HT-2026.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Available" additional-text-state="Success">Audio cabel</ui5-li>
-			<ui5-li image="./img/HT-2002.jpg"  icon-end icon="navigation-right-arrow" additional-text="Reuqired" additional-text-state="Warning">DVD set</ui5-li>
+			<ui5-li icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Reuqired" additional-text-state="Error">HP Monitor 24</ui5-li>
+			<ui5-li icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Available" additional-text-state="Success">Audio cabel</ui5-li>
+			<ui5-li icon-end icon="navigation-right-arrow" additional-text="Reuqired" additional-text-state="Warning">DVD set</ui5-li>
 		</ui5-list>
 	</section>
 
@@ -36,26 +36,26 @@
 	<br><br><br>
 	<ui5-list id="infiniteScrollEx2" growing="Scroll" class="listgrowing_scroll3auto">
 		<ui5-li-groupheader>New Items</ui5-li-groupheader>
-		<ui5-li image="./img/HT-1000.jpg" icon="navigation-right-arrow" additional-text="Available">Voluptate do eu cupidatat elit est culpa. Reprehenderit eiusmod voluptate ex est dolor nostrud Lorem Lorem do nisi laborum veniam. Sint do non culpa aute occaecat labore ipsum veniam minim tempor est. Duis pariatur aute culpa irure ad excepteur pariatur culpa culpa ea duis occaecat aute irure. Ipsum velit culpa non exercitation ex laboris deserunt in eu non officia in. Laborum sunt aliqua labore cupidatat sunt labore.</ui5-li>
-		<ui5-li image="./img/portrait.jpg" icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131" additional-text-state="Error">Laptop Lenovo</ui5-li>
-		<ui5-li image="./img/HT-1022.jpg" icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131"  additional-text-state="Information">IPhone 3</ui5-li>
+		<ui5-li icon="navigation-right-arrow" additional-text="Available">Voluptate do eu cupidatat elit est culpa. Reprehenderit eiusmod voluptate ex est dolor nostrud Lorem Lorem do nisi laborum veniam. Sint do non culpa aute occaecat labore ipsum veniam minim tempor est. Duis pariatur aute culpa irure ad excepteur pariatur culpa culpa ea duis occaecat aute irure. Ipsum velit culpa non exercitation ex laboris deserunt in eu non officia in. Laborum sunt aliqua labore cupidatat sunt labore.</ui5-li>
+		<ui5-li icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131" additional-text-state="Error">Laptop Lenovo</ui5-li>
+		<ui5-li icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131"  additional-text-state="Information">IPhone 3</ui5-li>
 		<ui5-li-groupheader>Discounted Items</ui5-li-groupheader>
-		<ui5-li image="./img/HT-1030.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Reuqired" additional-text-state="Error">HP Monitor 24</ui5-li>
-		<ui5-li image="./img/HT-2026.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Available" additional-text-state="Success">Audio cabel</ui5-li>
-		<ui5-li image="./img/HT-2002.jpg"  icon-end icon="navigation-right-arrow" additional-text="Reuqired" additional-text-state="Warning">DVD set</ui5-li>
+		<ui5-li icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Reuqired" additional-text-state="Error">HP Monitor 24</ui5-li>
+		<ui5-li icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Available" additional-text-state="Success">Audio cabel</ui5-li>
+		<ui5-li icon-end icon="navigation-right-arrow" additional-text="Reuqired" additional-text-state="Warning">DVD set</ui5-li>
 	</ui5-list>
 
 	<ui5-title>List growing="Scroll"</ui5-title>
 	<br><br><br>
 	<ui5-list id="infiniteScrollEx3" growing="Scroll">
 		<ui5-li-groupheader>New Items</ui5-li-groupheader>
-		<ui5-li image="./img/HT-1000.jpg" icon="navigation-right-arrow" additional-text="Available">Voluptate do eu cupidatat elit est culpa. Reprehenderit eiusmod voluptate ex est dolor nostrud Lorem Lorem do nisi laborum veniam. Sint do non culpa aute occaecat labore ipsum veniam minim tempor est. Duis pariatur aute culpa irure ad excepteur pariatur culpa culpa ea duis occaecat aute irure. Ipsum velit culpa non exercitation ex laboris deserunt in eu non officia in. Laborum sunt aliqua labore cupidatat sunt labore.</ui5-li>
-		<ui5-li image="./img/portrait.jpg" icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131" additional-text-state="Error">Laptop Lenovo</ui5-li>
-		<ui5-li image="./img/HT-1022.jpg" icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131"  additional-text-state="Information">IPhone 3</ui5-li>
+		<ui5-li icon="navigation-right-arrow" additional-text="Available">Voluptate do eu cupidatat elit est culpa. Reprehenderit eiusmod voluptate ex est dolor nostrud Lorem Lorem do nisi laborum veniam. Sint do non culpa aute occaecat labore ipsum veniam minim tempor est. Duis pariatur aute culpa irure ad excepteur pariatur culpa culpa ea duis occaecat aute irure. Ipsum velit culpa non exercitation ex laboris deserunt in eu non officia in. Laborum sunt aliqua labore cupidatat sunt labore.</ui5-li>
+		<ui5-li icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131" additional-text-state="Error">Laptop Lenovo</ui5-li>
+		<ui5-li icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131"  additional-text-state="Information">IPhone 3</ui5-li>
 		<ui5-li-groupheader>Discounted Items</ui5-li-groupheader>
-		<ui5-li image="./img/HT-1030.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Reuqired" additional-text-state="Error">HP Monitor 24</ui5-li>
-		<ui5-li image="./img/HT-2026.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Available" additional-text-state="Success">Audio cabel</ui5-li>
-		<ui5-li image="./img/HT-2002.jpg"  icon-end icon="navigation-right-arrow" additional-text="Reuqired" additional-text-state="Warning">DVD set</ui5-li>
+		<ui5-li icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Reuqired" additional-text-state="Error">HP Monitor 24</ui5-li>
+		<ui5-li icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Available" additional-text-state="Success">Audio cabel</ui5-li>
+		<ui5-li icon-end icon="navigation-right-arrow" additional-text="Reuqired" additional-text-state="Warning">DVD set</ui5-li>
 	</ui5-list>
 
 	<script>

--- a/packages/main/test/pages/List_test_page.html
+++ b/packages/main/test/pages/List_test_page.html
@@ -121,22 +121,22 @@
 	<br><br><br>
 	<ui5-list id="list1" header-text="API: GroupHeaderListItem">
 		<ui5-li-groupheader>New Items</ui5-li-groupheader>
-		<ui5-li image="./img/HT-1000.jpg" >Laptop HP</ui5-li>
-		<ui5-li image="./img/HT-1010.jpg" >Laptop Lenovo</ui5-li>
-		<ui5-li image="./img/HT-1022.jpg" >IPhone 3</ui5-li>
+		<ui5-li >Laptop HP</ui5-li>
+		<ui5-li >Laptop Lenovo</ui5-li>
+		<ui5-li >IPhone 3</ui5-li>
 
 		<ui5-li-groupheader>Discounted Items</ui5-li-groupheader>
-		<ui5-li image="./img/HT-1030.jpg"  icon="navigation-right-arrow">HP Monitor 24</ui5-li>
-		<ui5-li image="./img/HT-2026.jpg"  icon="navigation-right-arrow">Audio cabel</ui5-li>
-		<ui5-li image="./img/HT-2002.jpg"  icon="navigation-right-arrow">DVD set</ui5-li>
+		<ui5-li icon="navigation-right-arrow">HP Monitor 24</ui5-li>
+		<ui5-li icon="navigation-right-arrow">Audio cabel</ui5-li>
+		<ui5-li icon="navigation-right-arrow">DVD set</ui5-li>
 	</ui5-list>
 
 	<label id="lblResult">0</label>
 
 	<ui5-list id="listWithDesc">
-		<ui5-li image="./img/HT-1000.jpg"  description="2GB RAM, Intel i7 4.5 GHz">Laptop HP</ui5-li>
-		<ui5-li image="./img/HT-2026.jpg"  description="2GB RAM, Intel i7 4.5 GHz">Audio cabel</ui5-li>
-		<ui5-li image="./img/HT-2002.jpg"  description="2GB RAM, Intel i7 4.5 GHz">DVD set</ui5-li>
+		<ui5-li description="2GB RAM, Intel i7 4.5 GHz">Laptop HP</ui5-li>
+		<ui5-li description="2GB RAM, Intel i7 4.5 GHz">Audio cabel</ui5-li>
+		<ui5-li description="2GB RAM, Intel i7 4.5 GHz">DVD set</ui5-li>
 	</ui5-list>
 
 	<ui5-list id="listMultiSel" selection-mode="Multiple">
@@ -202,9 +202,9 @@
 	<br/><br/>
 
 	<ui5-list>
-		<ui5-li id="imageContent-slot-li"> Avatar inside imageContent slot
-			<div slot="imageContent">
-				<ui5-avatar id="imageContent-slot-avatar">
+		<ui5-li id="image-slot-li"> Avatar inside image slot
+			<div slot="image">
+				<ui5-avatar id="image-slot-avatar">
 					<img src="./img/woman_avatar_5.png" alt="Woman image">
 				</ui5-avatar>
 			</div>
@@ -324,10 +324,10 @@
 	</ui5-list>
 
 	<ui5-list id="highlight">
-		<ui5-li highlight="Error" image="./img/HT-1000.jpg" >Laptop HP</ui5-li>
-		<ui5-li highlight="Information" image="./img/HT-1010.jpg" >laptop Lenovo</ui5-li>
-		<ui5-li highlight="Success" image="./img/HT-1022.jpg" >IPhone 3</ui5-li>
-		<ui5-li highlight="Warning" image="./img/HT-2002.jpg" >DVD set</ui5-li>
+		<ui5-li highlight="Error" >Laptop HP</ui5-li>
+		<ui5-li highlight="Information" >laptop Lenovo</ui5-li>
+		<ui5-li highlight="Success" >IPhone 3</ui5-li>
+		<ui5-li highlight="Warning" >DVD set</ui5-li>
 	</ui5-list>
 
 	<input id="customListItemSelectResult" value="0"/>
@@ -449,13 +449,13 @@
 
 	<ui5-list growing="Scroll">
 		<ui5-li-groupheader>New Items</ui5-li-groupheader>
-		<ui5-li image="./img/HT-1000.jpg" icon="navigation-right-arrow" additional-text="Available">Voluptate do eu cupidatat elit est culpa.</ui5-li>
-		<ui5-li image="./img/portrait.jpg" icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131" additional-text-state="Error">Laptop Lenovo</ui5-li>
-		<ui5-li id="listItem" image="./img/HT-1022.jpg" icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131"  additional-text-state="Information">IPhone 3</ui5-li>
+		<ui5-li icon="navigation-right-arrow" additional-text="Available">Voluptate do eu cupidatat elit est culpa.</ui5-li>
+		<ui5-li icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131" additional-text-state="Error">Laptop Lenovo</ui5-li>
+		<ui5-li id="listItem" icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131"  additional-text-state="Information">IPhone 3</ui5-li>
 		<ui5-li-groupheader>Discounted Items</ui5-li-groupheader>
-		<ui5-li image="./img/HT-1030.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Reuqired" additional-text-state="Error">HP Monitor 24</ui5-li>
-		<ui5-li image="./img/HT-2026.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Available" additional-text-state="Success">Audio cabel</ui5-li>
-		<ui5-li image="./img/HT-2002.jpg"  icon-end icon="navigation-right-arrow" additional-text="Reuqired" additional-text-state="Warning">DVD set</ui5-li>
+		<ui5-li icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Reuqired" additional-text-state="Error">HP Monitor 24</ui5-li>
+		<ui5-li icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Available" additional-text-state="Success">Audio cabel</ui5-li>
+		<ui5-li icon-end icon="navigation-right-arrow" additional-text="Reuqired" additional-text-state="Warning">DVD set</ui5-li>
 	</ui5-list>
 
 	<script>

--- a/packages/main/test/pages/Popover.html
+++ b/packages/main/test/pages/Popover.html
@@ -342,9 +342,9 @@ z-index: 1;
 			<ui5-li>Audit Log Settings</ui5-li>
 			<ui5-li>OData API Audit</ui5-li>
 			<ui5-li-groupheader>Products</ui5-li-groupheader>
-			<ui5-li image="./img/HT-1010.jpg" icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131" additional-text-state="Error">Laptop Lenovo</ui5-li>
-			<ui5-li image="./img/HT-1022.jpg" icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131"  additional-text-state="Error">IPhone 3</ui5-li>
-			<ui5-li image="./img/HT-1030.jpg"  icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Reuqired" additional-text-state="Error">HP Monitor 24</ui5-li>
+			<ui5-li icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131" additional-text-state="Error">Laptop Lenovo</ui5-li>
+			<ui5-li icon="navigation-right-arrow" additional-text="Re-stock" description="#12331232131"  additional-text-state="Error">IPhone 3</ui5-li>
+			<ui5-li icon-end icon="navigation-right-arrow" description="#12331232131"  additional-text="Reuqired" additional-text-state="Error">HP Monitor 24</ui5-li>
 		</ui5-list>
 	</ui5-popover>
 

--- a/packages/main/test/specs/List.spec.js
+++ b/packages/main/test/specs/List.spec.js
@@ -138,12 +138,12 @@ describe("List Tests", () => {
 		assert.strictEqual(listItemsLength, 3, "List items are rendered");
 	});
 
-	it("Tests rendering of imageContent slot", async () => {
-		const imageContentSlot = await browser.executeAsync(done => {
-			done(document.getElementById("imageContent-slot-li").shadowRoot.querySelector("slot[name='imageContent']").assignedNodes()[0].querySelector("#imageContent-slot-avatar"));
+	it("Tests rendering of image slot", async () => {
+		const imageSlot = await browser.executeAsync(done => {
+			done(document.getElementById("image-slot-li").shadowRoot.querySelector("slot[name='image']").assignedNodes()[0].querySelector("#image-slot-avatar"));
 		});
 
-		assert.ok(imageContentSlot, "the content of imageContent slot is rendered");
+		assert.ok(imageSlot, "the content of image slot is rendered");
 	});
 
 	it("Clicking on inactive items does not change single selection", async () => {

--- a/packages/playground/_stories/main/Card/Card.stories.ts
+++ b/packages/playground/_stories/main/Card/Card.stories.ts
@@ -63,9 +63,9 @@ export const InteractiveHeader = Template.bind({});
 InteractiveHeader.args = {
 	header: header("This header is interactive", "Click, press Enter or Space", "3 of 6", [], `<ui5-icon name="group" slot="avatar"></ui5-icon>`, true),
 	default: `<ui5-list separators="None" style="margin-block-end: 0.75rem;">
-	<ui5-li image="../assets/images/avatars/man_avatar_2.png" description="Software Architect">Richard Wilson</ui5-li>
-	<ui5-li image="../assets/images/avatars/woman_avatar_3.png" description="Visual Designer">Elena Petrova</ui5-li>
-	<ui5-li image="../assets/images/avatars/man_avatar_3.png" description="Quality Specialist">John Miller</ui5-li>
+	<ui5-li description="Software Architect">Richard Wilson</ui5-li>
+	<ui5-li description="Visual Designer">Elena Petrova</ui5-li>
+	<ui5-li description="Quality Specialist">John Miller</ui5-li>
 </ui5-list>`
 };
 InteractiveHeader.decorators = [setWidth("22rem")];
@@ -74,9 +74,9 @@ export const WithList = Template.bind({});
 WithList.args = {
 	header: header("Team Space", "Direct Reports", "3 of 10", ["View All"], `<ui5-icon name="group" slot="avatar"></ui5-icon>`),
 	default: `<ui5-list separators="None" style="margin-block-end: 0.75rem;">
-	<ui5-li image="../assets/images/avatars/man_avatar_1.png" description="User Researcher">Alain Chevalier</ui5-li>
-	<ui5-li image="../assets/images/avatars/woman_avatar_1.png" description="Artist">Monique Legrand</ui5-li>
-	<ui5-li image="../assets/images/avatars/woman_avatar_2.png" description="UX Specialist">Isabella Adams</ui5-li>
+	<ui5-li description="User Researcher">Alain Chevalier</ui5-li>
+	<ui5-li description="Artist">Monique Legrand</ui5-li>
+	<ui5-li description="UX Specialist">Isabella Adams</ui5-li>
 </ui5-list>`,
 };
 WithList.decorators = [setWidth("22rem")];

--- a/packages/playground/_stories/main/Card/CardHeader/CardHeader.stories.ts
+++ b/packages/playground/_stories/main/Card/CardHeader/CardHeader.stories.ts
@@ -27,9 +27,9 @@ const Template: UI5StoryArgs<CardHeader, StoryArgsSlots> = (args) => {
 	${unsafeHTML(args.action)}
 	</ui5-card-header>
 		<ui5-list separators="None" style="margin-block-end: 0.75rem;">
-		<ui5-li image="../assets/images/avatars/man_avatar_2.png" description="Software Architect">Richard Wilson</ui5-li>
-		<ui5-li image="../assets/images/avatars/woman_avatar_3.png" description="Visual Designer">Elena Petrova</ui5-li>
-		<ui5-li image="../assets/images/avatars/man_avatar_3.png" description="Quality Specialist">John Miller</ui5-li>
+		<ui5-li description="Software Architect">Richard Wilson</ui5-li>
+		<ui5-li description="Visual Designer">Elena Petrova</ui5-li>
+		<ui5-li description="Quality Specialist">John Miller</ui5-li>
 	</ui5-list>
 </ui5-card>
 	`;

--- a/packages/playground/_stories/main/Carousel/Carousel.stories.ts
+++ b/packages/playground/_stories/main/Carousel/Carousel.stories.ts
@@ -77,9 +77,9 @@ MultipleItemsPerPage.args = {
 		<ui5-icon name="group" slot="avatar"></ui5-icon>
 	</ui5-card-header>
 	<ui5-list separators="None">
-		<ui5-li image="../assets/images/avatars/man_avatar_1.png" description="User Researcher">Alain Chevalier</ui5-li>
-		<ui5-li image="../assets/images/avatars/woman_avatar_1.png" description="Artist">Monique Legrand</ui5-li>
-		<ui5-li image="../assets/images/avatars/woman_avatar_2.png" description="UX Specialist">Michael Adams</ui5-li>
+		<ui5-li description="User Researcher">Alain Chevalier</ui5-li>
+		<ui5-li description="Artist">Monique Legrand</ui5-li>
+		<ui5-li description="UX Specialist">Michael Adams</ui5-li>
 	</ui5-list>
 </ui5-card>
 <ui5-card class="medium">
@@ -87,9 +87,9 @@ MultipleItemsPerPage.args = {
 		<ui5-icon name="group" slot="avatar"></ui5-icon>
 	</ui5-card-header>
 	<ui5-list separators="None">
-		<ui5-li image="../assets/images/avatars/man_avatar_2.png" description="Software Architect">Richard Wilson</ui5-li>
-		<ui5-li image="../assets/images/avatars/woman_avatar_3.png" description="Visual Designer">Elena Petrova</ui5-li>
-		<ui5-li image="../assets/images/avatars/man_avatar_3.png" description="Quality Specialist">John Miller</ui5-li>
+		<ui5-li description="Software Architect">Richard Wilson</ui5-li>
+		<ui5-li description="Visual Designer">Elena Petrova</ui5-li>
+		<ui5-li description="Quality Specialist">John Miller</ui5-li>
 	</ui5-list>
 </ui5-card>`
 };

--- a/packages/playground/_stories/main/List/GroupHeaderListItem/GroupHeaderListItem.stories.ts
+++ b/packages/playground/_stories/main/List/GroupHeaderListItem/GroupHeaderListItem.stories.ts
@@ -24,19 +24,16 @@ const Template: UI5StoryArgs<GroupHeaderListItem, StoryArgsSlots> = (args) => {
     ${unsafeHTML(args.default)}
   </ui5-li-groupheader>
   <ui5-li
-  image="../assets/images/avatars/woman_avatar_3.png"
   icon="navigation-right-arrow"
   icon-end=""
   >Jennifer</ui5-li
 >
 <ui5-li
-  image="../assets/images/avatars/woman_avatar_4.png"
   icon="navigation-right-arrow"
   icon-end=""
   >Lora</ui5-li
 >
 <ui5-li
-  image="../assets/images/avatars/woman_avatar_5.png"
   icon="navigation-right-arrow"
   icon-end=""
   >Carlotta</ui5-li

--- a/packages/playground/_stories/main/List/List.stories.ts
+++ b/packages/playground/_stories/main/List/List.stories.ts
@@ -162,38 +162,32 @@ GroupHeaders.args = {
 	>Front End Developers</ui5-li-groupheader
 	>
 	<ui5-li
-		image="../assets/images/avatars/woman_avatar_3.png"
 		icon="navigation-right-arrow"
 		icon-end=""
 		>Jennifer</ui5-li
 	>
 	<ui5-li
-		image="../assets/images/avatars/woman_avatar_4.png"
 		icon="navigation-right-arrow"
 		icon-end=""
 		>Lora</ui5-li
 	>
 	<ui5-li
-		image="../assets/images/avatars/woman_avatar_5.png"
 		icon="navigation-right-arrow"
 		icon-end=""
 		>Carlotta</ui5-li
 	>
 	<ui5-li-groupheader>Back End Developers</ui5-li-groupheader>
 	<ui5-li
-		image="../assets/images/avatars/man_avatar_1.png"
 		icon="navigation-right-arrow"
 		icon-end=""
 	>Clark</ui5-li
 	>
 	<ui5-li
-		image="../assets/images/avatars/woman_avatar_1.png"
 		icon="navigation-right-arrow"
 		icon-end=""
 	>Ellen</ui5-li
 	>
 	<ui5-li
-		image="../assets/images/avatars/man_avatar_2.png"
 		icon="navigation-right-arrow"
 		icon-end=""
 	>Adam</ui5-li

--- a/packages/playground/_stories/main/List/StandardListItem/StandardListItem.stories.ts
+++ b/packages/playground/_stories/main/List/StandardListItem/StandardListItem.stories.ts
@@ -24,7 +24,6 @@ const Template: UI5StoryArgs<StandardListItem, StoryArgsSlots> = (args) => {
     additional-text-state="${ifDefined(args.additionalTextState)}"
     accessible-name="${ifDefined(args.accessibleName)}"
     ?icon-end="${ifDefined(args.iconEnd)}"
-    image="${ifDefined(args.image)}"
     accessibility-attributes="${ifDefined(args.accessibilityAttributes)}"
     ?navigated="${ifDefined(args.navigated)}"
     type="${ifDefined(args.type)}"
@@ -32,7 +31,7 @@ const Template: UI5StoryArgs<StandardListItem, StoryArgsSlots> = (args) => {
 	tooltip="${ifDefined(args.tooltip)}"
   >
     ${unsafeHTML(args.default)}
-    ${unsafeHTML(args.imageContent)}
+    ${unsafeHTML(args.image)}
     ${unsafeHTML(args.deleteButton)}
   </ui5-li>
   </ui5-list>`;

--- a/packages/website/docs/_samples/main/Card/Basic/sample.html
+++ b/packages/website/docs/_samples/main/Card/Basic/sample.html
@@ -18,12 +18,27 @@
             <ui5-icon name="group" slot="avatar"></ui5-icon>
         </ui5-card-header>
         <ui5-list separators="None" style="margin-block-end: 0.75rem;">
-            <ui5-li description="Software Architect">Richard
-                Wilson</ui5-li>
-            <ui5-li description="Visual Designer">Elena
-                Petrova</ui5-li>
-            <ui5-li description="Quality Specialist">John
-                Miller</ui5-li>
+            <ui5-li description="Software Architect">Richard Wilson
+                <div slot="image">
+                    <ui5-avatar >
+                        <img src="../assets/images/avatars/man_avatar_2.png" alt="Woman image">
+                    </ui5-avatar>
+                </div>
+            </ui5-li>
+            <ui5-li description="Visual Designer">Elena Petrova
+                <div slot="image">
+                    <ui5-avatar >
+                        <img src="../assets/images/avatars/woman_avatar_3.png" alt="Woman image">
+                    </ui5-avatar>
+                </div>
+            </ui5-li>
+            <ui5-li description="Quality Specialist">John Miller
+                <div slot="image">
+                    <ui5-avatar >
+                        <img src="../assets/images/avatars/man_avatar_3.png" alt="Woman image">
+                    </ui5-avatar>
+                </div>
+            </ui5-li>
         </ui5-list>
     </ui5-card>
     <!-- playground-fold -->

--- a/packages/website/docs/_samples/main/Card/Basic/sample.html
+++ b/packages/website/docs/_samples/main/Card/Basic/sample.html
@@ -18,11 +18,11 @@
             <ui5-icon name="group" slot="avatar"></ui5-icon>
         </ui5-card-header>
         <ui5-list separators="None" style="margin-block-end: 0.75rem;">
-            <ui5-li image="../assets/images/avatars/man_avatar_2.png" description="Software Architect">Richard
+            <ui5-li description="Software Architect">Richard
                 Wilson</ui5-li>
-            <ui5-li image="../assets/images/avatars/woman_avatar_3.png" description="Visual Designer">Elena
+            <ui5-li description="Visual Designer">Elena
                 Petrova</ui5-li>
-            <ui5-li image="../assets/images/avatars/man_avatar_3.png" description="Quality Specialist">John
+            <ui5-li description="Quality Specialist">John
                 Miller</ui5-li>
         </ui5-list>
     </ui5-card>

--- a/packages/website/docs/_samples/main/Card/Basic/sample.html
+++ b/packages/website/docs/_samples/main/Card/Basic/sample.html
@@ -19,25 +19,19 @@
         </ui5-card-header>
         <ui5-list separators="None" style="margin-block-end: 0.75rem;">
             <ui5-li description="Software Architect">Richard Wilson
-                <div slot="image">
-                    <ui5-avatar >
-                        <img src="../assets/images/avatars/man_avatar_2.png" alt="Woman image">
-                    </ui5-avatar>
-                </div>
+                <ui5-avatar slot="image">
+                    <img src="../assets/images/avatars/man_avatar_2.png" alt="Woman image">
+                </ui5-avatar>
             </ui5-li>
             <ui5-li description="Visual Designer">Elena Petrova
-                <div slot="image">
-                    <ui5-avatar >
-                        <img src="../assets/images/avatars/woman_avatar_3.png" alt="Woman image">
-                    </ui5-avatar>
-                </div>
+                <ui5-avatar slot="image">
+                    <img src="../assets/images/avatars/woman_avatar_3.png" alt="Woman image">
+                </ui5-avatar>
             </ui5-li>
             <ui5-li description="Quality Specialist">John Miller
-                <div slot="image">
-                    <ui5-avatar >
-                        <img src="../assets/images/avatars/man_avatar_3.png" alt="Woman image">
-                    </ui5-avatar>
-                </div>
+                <ui5-avatar slot="image">
+                    <img src="../assets/images/avatars/man_avatar_3.png" alt="Woman image">
+                </ui5-avatar>
             </ui5-li>
         </ui5-list>
     </ui5-card>

--- a/packages/website/docs/_samples/main/Card/WithList/sample.html
+++ b/packages/website/docs/_samples/main/Card/WithList/sample.html
@@ -19,25 +19,20 @@
         </ui5-card-header>
         <ui5-list separators="None" style="margin-block-end: 0.75rem;">
             <ui5-li description="User Researcher">Alain Chevalier
-                <div slot="image">
-                    <ui5-avatar >
-                        <img src="../assets/images/avatars/man_avatar_1.png" alt="Woman image">
-                    </ui5-avatar>
-                </div>
+                <ui5-avatar slot="image">
+                    <img src="../assets/images/avatars/man_avatar_1.png" alt="Woman image">
+                </ui5-avatar>
             </ui5-li>
             <ui5-li description="Artist">Monique Legrand
-                <div slot="image">
-                    <ui5-avatar >
-                        <img src="../assets/images/avatars/woman_avatar_1.png" alt="Woman image">
-                    </ui5-avatar>
-                </div>
+                <ui5-avatar slot="image">
+                    <img src="../assets/images/avatars/woman_avatar_1.png" alt="Woman image">
+                </ui5-avatar>
             </ui5-li>
             <ui5-li description="UX Specialist">Isabella Adams
-                <div slot="image">
-                    <ui5-avatar >
-                        <img src="../assets/images/avatars/woman_avatar_2.png" alt="Woman image">
-                    </ui5-avatar>
-                </div></ui5-li>
+                <ui5-avatar slot="image">
+                    <img src="../assets/images/avatars/woman_avatar_2.png" alt="Woman image">
+                </ui5-avatar>
+            </ui5-li>
         </ui5-list>
     </ui5-card>
     <!-- playground-fold -->

--- a/packages/website/docs/_samples/main/Card/WithList/sample.html
+++ b/packages/website/docs/_samples/main/Card/WithList/sample.html
@@ -18,11 +18,26 @@
             <ui5-button design="Transparent" slot="action">View All</ui5-button>
         </ui5-card-header>
         <ui5-list separators="None" style="margin-block-end: 0.75rem;">
-            <ui5-li description="User Researcher">Alain
-                Chevalier</ui5-li>
-            <ui5-li description="Artist">Monique Legrand</ui5-li>
-            <ui5-li description="UX Specialist">Isabella
-                Adams</ui5-li>
+            <ui5-li description="User Researcher">Alain Chevalier
+                <div slot="image">
+                    <ui5-avatar >
+                        <img src="../assets/images/avatars/man_avatar_1.png" alt="Woman image">
+                    </ui5-avatar>
+                </div>
+            </ui5-li>
+            <ui5-li description="Artist">Monique Legrand
+                <div slot="image">
+                    <ui5-avatar >
+                        <img src="../assets/images/avatars/woman_avatar_1.png" alt="Woman image">
+                    </ui5-avatar>
+                </div>
+            </ui5-li>
+            <ui5-li description="UX Specialist">Isabella Adams
+                <div slot="image">
+                    <ui5-avatar >
+                        <img src="../assets/images/avatars/woman_avatar_2.png" alt="Woman image">
+                    </ui5-avatar>
+                </div></ui5-li>
         </ui5-list>
     </ui5-card>
     <!-- playground-fold -->

--- a/packages/website/docs/_samples/main/Card/WithList/sample.html
+++ b/packages/website/docs/_samples/main/Card/WithList/sample.html
@@ -18,10 +18,10 @@
             <ui5-button design="Transparent" slot="action">View All</ui5-button>
         </ui5-card-header>
         <ui5-list separators="None" style="margin-block-end: 0.75rem;">
-            <ui5-li image="../assets/images/avatars/man_avatar_1.png" description="User Researcher">Alain
+            <ui5-li description="User Researcher">Alain
                 Chevalier</ui5-li>
-            <ui5-li image="../assets/images/avatars/woman_avatar_1.png" description="Artist">Monique Legrand</ui5-li>
-            <ui5-li image="../assets/images/avatars/woman_avatar_2.png" description="UX Specialist">Isabella
+            <ui5-li description="Artist">Monique Legrand</ui5-li>
+            <ui5-li description="UX Specialist">Isabella
                 Adams</ui5-li>
         </ui5-list>
     </ui5-card>

--- a/packages/website/docs/_samples/main/Carousel/MultipleItemsPerPage/sample.html
+++ b/packages/website/docs/_samples/main/Carousel/MultipleItemsPerPage/sample.html
@@ -74,25 +74,19 @@
             </ui5-card-header>
             <ui5-list separators="None">
                 <ui5-li description="Software Architect">Richard Wilson
-                    <div slot="image">
-                        <ui5-avatar >
-                            <img src="../assets/images/avatars/man_avatar_2.png" alt="Woman image">
-                        </ui5-avatar>
-                    </div>
+                    <ui5-avatar slot="image">
+                        <img src="../assets/images/avatars/man_avatar_2.png" alt="Woman image">
+                    </ui5-avatar>
                 </ui5-li>
                 <ui5-li description="Visual Designer">Elena Petrova
-                    <div slot="image">
-                        <ui5-avatar >
-                            <img src="../assets/images/avatars/woman_avatar_3.png" alt="Woman image">
-                        </ui5-avatar>
-                    </div>
+                    <ui5-avatar slot="image">
+                        <img src="../assets/images/avatars/woman_avatar_3.png" alt="Woman image">
+                    </ui5-avatar>
                 </ui5-li>
                 <ui5-li description="Quality Specialist">John Miller
-                    <div slot="image">
-                        <ui5-avatar >
-                            <img src="../assets/images/avatars/man_avatar_3.png" alt="Woman image">
-                        </ui5-avatar>
-                    </div>
+                    <ui5-avatar slot="image">
+                        <img src="../assets/images/avatars/man_avatar_3.png" alt="Woman image">
+                    </ui5-avatar>
                 </ui5-li>
             </ui5-list>
         </ui5-card>

--- a/packages/website/docs/_samples/main/Carousel/MultipleItemsPerPage/sample.html
+++ b/packages/website/docs/_samples/main/Carousel/MultipleItemsPerPage/sample.html
@@ -12,7 +12,7 @@
 <body style="background-color: var(--sapBackgroundColor)">
     <!-- playground-fold-end -->
 
-    <ui5-carousel 
+    <ui5-carousel
         cyclic
         items-per-page-s="1"
         items-per-page-m="2"
@@ -44,11 +44,11 @@
                 <ui5-icon name="group" slot="avatar"></ui5-icon>
             </ui5-card-header>
             <ui5-list separators="None">
-                <ui5-li image="../assets/images/avatars/man_avatar_1.png" description="User Researcher">Alain
+                <ui5-li description="User Researcher">Alain
                     Chevalier</ui5-li>
-                <ui5-li image="../assets/images/avatars/woman_avatar_1.png" description="Artist">Monique
+                <ui5-li description="Artist">Monique
                     Legrand</ui5-li>
-                <ui5-li image="../assets/images/avatars/woman_avatar_2.png" description="UX Specialist">Michael
+                <ui5-li description="UX Specialist">Michael
                     Adams</ui5-li>
             </ui5-list>
         </ui5-card>
@@ -58,11 +58,11 @@
                 <ui5-icon name="group" slot="avatar"></ui5-icon>
             </ui5-card-header>
             <ui5-list separators="None">
-                <ui5-li image="../assets/images/avatars/man_avatar_2.png" description="Software Architect">Richard
+                <ui5-li description="Software Architect">Richard
                     Wilson</ui5-li>
-                <ui5-li image="../assets/images/avatars/woman_avatar_3.png" description="Visual Designer">Elena
+                <ui5-li description="Visual Designer">Elena
                     Petrova</ui5-li>
-                <ui5-li image="../assets/images/avatars/man_avatar_3.png" description="Quality Specialist">John
+                <ui5-li description="Quality Specialist">John
                     Miller</ui5-li>
             </ui5-list>
         </ui5-card>

--- a/packages/website/docs/_samples/main/Carousel/MultipleItemsPerPage/sample.html
+++ b/packages/website/docs/_samples/main/Carousel/MultipleItemsPerPage/sample.html
@@ -44,12 +44,27 @@
                 <ui5-icon name="group" slot="avatar"></ui5-icon>
             </ui5-card-header>
             <ui5-list separators="None">
-                <ui5-li description="User Researcher">Alain
-                    Chevalier</ui5-li>
-                <ui5-li description="Artist">Monique
-                    Legrand</ui5-li>
-                <ui5-li description="UX Specialist">Michael
-                    Adams</ui5-li>
+                <ui5-li description="User Researcher">Alain Chevalier
+                    <div slot="image">
+                        <ui5-avatar >
+                            <img src="../assets/images/avatars/man_avatar_1.png" alt="Woman image">
+                        </ui5-avatar>
+                    </div>
+                </ui5-li>
+                <ui5-li description="Artist">Monique Legrand
+                    <div slot="image">
+                        <ui5-avatar >
+                            <img src="../assets/images/avatars/woman_avatar_1.png" alt="Woman image">
+                        </ui5-avatar>
+                    </div>
+                </ui5-li>
+                <ui5-li description="UX Specialist">Michael Adams
+                    <div slot="image">
+                        <ui5-avatar >
+                            <img src="../assets/images/avatars/woman_avatar_2.png" alt="Woman image">
+                        </ui5-avatar>
+                    </div>
+                </ui5-li>
             </ui5-list>
         </ui5-card>
         <ui5-card class="medium">
@@ -58,12 +73,27 @@
                 <ui5-icon name="group" slot="avatar"></ui5-icon>
             </ui5-card-header>
             <ui5-list separators="None">
-                <ui5-li description="Software Architect">Richard
-                    Wilson</ui5-li>
-                <ui5-li description="Visual Designer">Elena
-                    Petrova</ui5-li>
-                <ui5-li description="Quality Specialist">John
-                    Miller</ui5-li>
+                <ui5-li description="Software Architect">Richard Wilson
+                    <div slot="image">
+                        <ui5-avatar >
+                            <img src="../assets/images/avatars/man_avatar_2.png" alt="Woman image">
+                        </ui5-avatar>
+                    </div>
+                </ui5-li>
+                <ui5-li description="Visual Designer">Elena Petrova
+                    <div slot="image">
+                        <ui5-avatar >
+                            <img src="../assets/images/avatars/woman_avatar_3.png" alt="Woman image">
+                        </ui5-avatar>
+                    </div>
+                </ui5-li>
+                <ui5-li description="Quality Specialist">John Miller
+                    <div slot="image">
+                        <ui5-avatar >
+                            <img src="../assets/images/avatars/man_avatar_3.png" alt="Woman image">
+                        </ui5-avatar>
+                    </div>
+                </ui5-li>
             </ui5-list>
         </ui5-card>
     </ui5-carousel>

--- a/packages/website/docs/_samples/main/List/GroupHeaders/sample.html
+++ b/packages/website/docs/_samples/main/List/GroupHeaders/sample.html
@@ -15,14 +15,40 @@
         <ui5-li-groupheader>Front End Developers</ui5-li-groupheader>
         <ui5-li icon="navigation-right-arrow"
             icon-end>Jennifer</ui5-li>
-        <ui5-li icon="navigation-right-arrow" icon-end>Lora</ui5-li>
-        <ui5-li icon="navigation-right-arrow"
-            icon-end>Carlotta</ui5-li>
+        <ui5-li icon="navigation-right-arrow" icon-end>Lora
+            <div slot="image">
+                <ui5-avatar >
+                    <img src="../assets/images/avatars/woman_avatar_4.png" alt="Woman image">
+                </ui5-avatar>
+            </div>
+        </ui5-li>
+        <ui5-li icon="navigation-right-arrow" icon-end>Carlotta
+            <div slot="image">
+                <ui5-avatar >
+                    <img src="../assets/images/avatars/woman_avatar_5.png" alt="Woman image">
+                </ui5-avatar>
+            </div></ui5-li>
         <ui5-li-groupheader>Back End Developers</ui5-li-groupheader>
-        <ui5-li icon="navigation-right-arrow" icon-end>Clark</ui5-li>
-        <ui5-li icon="navigation-right-arrow"
-            icon-end>Ellen</ui5-li>
-        <ui5-li icon="navigation-right-arrow" icon-end>Adam</ui5-li>
+        <ui5-li icon="navigation-right-arrow" icon-end>Clark
+            <div slot="image">
+                <ui5-avatar >
+                    <img src="../assets/images/avatars/man_avatar_1.png" alt="Woman image">
+                </ui5-avatar>
+            </div>
+        </ui5-li>
+        <ui5-li icon="navigation-right-arrow" icon-end>Ellen
+            <div slot="image">
+                <ui5-avatar >
+                    <img src="../assets/images/avatars/woman_avatar_1.png" alt="Woman image">
+                </ui5-avatar>
+            </div></ui5-li>
+        <ui5-li icon="navigation-right-arrow" icon-end>Adam
+            <div slot="image">
+                <ui5-avatar >
+                    <img src="../assets/images/avatars/man_avatar_2.png" alt="Woman image">
+                </ui5-avatar>
+            </div>
+        </ui5-li>
     </ui5-list>
     <!-- playground-fold -->
     <script type="module" src="main.js"></script>

--- a/packages/website/docs/_samples/main/List/GroupHeaders/sample.html
+++ b/packages/website/docs/_samples/main/List/GroupHeaders/sample.html
@@ -13,16 +13,16 @@
 
     <ui5-list selection-mode="Multiple">
         <ui5-li-groupheader>Front End Developers</ui5-li-groupheader>
-        <ui5-li image="../assets/images/avatars/woman_avatar_3.png" icon="navigation-right-arrow"
+        <ui5-li icon="navigation-right-arrow"
             icon-end>Jennifer</ui5-li>
-        <ui5-li image="../assets/images/avatars/woman_avatar_4.png" icon="navigation-right-arrow" icon-end>Lora</ui5-li>
-        <ui5-li image="../assets/images/avatars/woman_avatar_5.png" icon="navigation-right-arrow"
+        <ui5-li icon="navigation-right-arrow" icon-end>Lora</ui5-li>
+        <ui5-li icon="navigation-right-arrow"
             icon-end>Carlotta</ui5-li>
         <ui5-li-groupheader>Back End Developers</ui5-li-groupheader>
-        <ui5-li image="../assets/images/avatars/man_avatar_1.png" icon="navigation-right-arrow" icon-end>Clark</ui5-li>
-        <ui5-li image="../assets/images/avatars/woman_avatar_1.png" icon="navigation-right-arrow"
+        <ui5-li icon="navigation-right-arrow" icon-end>Clark</ui5-li>
+        <ui5-li icon="navigation-right-arrow"
             icon-end>Ellen</ui5-li>
-        <ui5-li image="../assets/images/avatars/man_avatar_2.png" icon="navigation-right-arrow" icon-end>Adam</ui5-li>
+        <ui5-li icon="navigation-right-arrow" icon-end>Adam</ui5-li>
     </ui5-list>
     <!-- playground-fold -->
     <script type="module" src="main.js"></script>

--- a/packages/website/docs/_samples/main/List/GroupHeaders/sample.html
+++ b/packages/website/docs/_samples/main/List/GroupHeaders/sample.html
@@ -16,38 +16,30 @@
         <ui5-li icon="navigation-right-arrow"
             icon-end>Jennifer</ui5-li>
         <ui5-li icon="navigation-right-arrow" icon-end>Lora
-            <div slot="image">
-                <ui5-avatar >
-                    <img src="../assets/images/avatars/woman_avatar_4.png" alt="Woman image">
-                </ui5-avatar>
-            </div>
+            <ui5-avatar slot="image">
+                <img src="../assets/images/avatars/woman_avatar_4.png" alt="Woman image">
+            </ui5-avatar>
         </ui5-li>
         <ui5-li icon="navigation-right-arrow" icon-end>Carlotta
-            <div slot="image">
-                <ui5-avatar >
-                    <img src="../assets/images/avatars/woman_avatar_5.png" alt="Woman image">
-                </ui5-avatar>
-            </div></ui5-li>
+            <ui5-avatar slot="image">
+                <img src="../assets/images/avatars/woman_avatar_5.png" alt="Woman image">
+            </ui5-avatar>
+        </ui5-li>
         <ui5-li-groupheader>Back End Developers</ui5-li-groupheader>
         <ui5-li icon="navigation-right-arrow" icon-end>Clark
-            <div slot="image">
-                <ui5-avatar >
-                    <img src="../assets/images/avatars/man_avatar_1.png" alt="Woman image">
-                </ui5-avatar>
-            </div>
+            <ui5-avatar slot="image">
+                <img src="../assets/images/avatars/man_avatar_1.png" alt="Woman image">
+            </ui5-avatar>
         </ui5-li>
         <ui5-li icon="navigation-right-arrow" icon-end>Ellen
-            <div slot="image">
-                <ui5-avatar >
-                    <img src="../assets/images/avatars/woman_avatar_1.png" alt="Woman image">
-                </ui5-avatar>
-            </div></ui5-li>
+            <ui5-avatar slot="image">
+                <img src="../assets/images/avatars/woman_avatar_1.png" alt="Woman image">
+            </ui5-avatar>
+        </ui5-li>
         <ui5-li icon="navigation-right-arrow" icon-end>Adam
-            <div slot="image">
-                <ui5-avatar >
-                    <img src="../assets/images/avatars/man_avatar_2.png" alt="Woman image">
-                </ui5-avatar>
-            </div>
+            <ui5-avatar slot="image">
+                <img src="../assets/images/avatars/man_avatar_2.png" alt="Woman image">
+            </ui5-avatar>
         </ui5-li>
     </ui5-list>
     <!-- playground-fold -->


### PR DESCRIPTION
Removes the `image` property  of  the `ui5-li` and renames the `imageContent` slot is renamed to `image`

BREAKING CHANGE: The `image` property of the `ui5-li` is removed and the `imageContent` slot is renamed to `image`.
If you have previously used the `image` property:
```html
<ui5-li image="./img/HT-1022.jpg">Standard List Item</ui5-li>
```
it will no longer work for the component.

If you have previously used the `imageContent` slot:
```html
<ui5-li> Avatar inside imageContent slot
	<ui5-avatar slot="imageContent" shape="Square" initials="ABC" color-scheme="Accent2"></ui5-avatar>
</ui5-li>
```


Now use `image`  instead:
```html
<ui5-li> Avatar inside image slot
	<ui5-avatar slot="image" shape="Square" initials="ABC" color-scheme="Accent2"></ui5-avatar>
</ui5-li>

```


Related to https://github.com/SAP/ui5-webcomponents/issues/8461, https://github.com/SAP/ui5-webcomponents/issues/7887