### PR TITLE
chore: enable TS exactOptionalPropertyTypes

### DIFF
--- a/packages/base/src/UI5Element.ts
+++ b/packages/base/src/UI5Element.ts
@@ -55,7 +55,7 @@ type ChangeInfo = {
 	type: "property" | "slot",
 	name: string,
 	reason?: string,
-	child?: SlotValue,
+	child?: SlotValue | undefined,
 	target?: UI5Element,
 	newValue?: PropertyValue,
 	oldValue?: PropertyValue,
@@ -112,7 +112,10 @@ function getPropertyDescriptor(proto: any, name: PropertyKey): PropertyDescripto
  * @public
  */
 abstract class UI5Element extends HTMLElement {
-	__id?: string;
+	/**
+	 * @deprecated - This property is not guaranteed in future release
+	 */
+	_id: string = `ui5wc_${++autoId}`;
 	_suppressInvalidation: boolean;
 	_changedState: Array<ChangeInfo>;
 	_invalidationEventProvider: EventProvider<InvalidationInfo, void>;
@@ -121,7 +124,7 @@ abstract class UI5Element extends HTMLElement {
 	_fullyConnected: boolean;
 	_childChangeListeners: Map<string, ChildChangeListener>;
 	_slotChangeListeners: Map<string, SlotChangeListener>;
-	_domRefReadyPromise: Promise<void> & { _deferredResolve?: PromiseResolve };
+	_domRefReadyPromise: Promise<void> & { _deferredResolve?: PromiseResolve | undefined };
 	_doNotSyncAttributes: Set<string>;
 	_state: State;
 	_getRealDomRef?: () => HTMLElement;
@@ -158,20 +161,6 @@ abstract class UI5Element extends HTMLElement {
 			const defaultOptions = { mode: "open" } as ShadowRootInit;
 			this.attachShadow({ ...defaultOptions, ...ctor.getMetadata().getShadowRootOptions() });
 		}
-	}
-
-	/**
-	 * Returns a unique ID for this UI5 Element
-	 *
-	 * @deprecated - This property is not guaranteed in future releases
-	 * @protected
-	 */
-	get _id() {
-		if (!this.__id) {
-			this.__id = `ui5wc_${++autoId}`;
-		}
-
-		return this.__id;
 	}
 
 	render() {
@@ -826,7 +815,7 @@ abstract class UI5Element extends HTMLElement {
 
 	_fireEvent<T>(name: string, data?: T, cancelable = false, bubbles = true) {
 		const noConflictEvent = new CustomEvent<T>(`ui5-${name}`, {
-			detail: data,
+			detail: data as Exclude<typeof data, undefined>,
 			composed: false,
 			bubbles,
 			cancelable,
@@ -840,7 +829,7 @@ abstract class UI5Element extends HTMLElement {
 		}
 
 		const normalEvent = new CustomEvent<T>(name, {
-			detail: data,
+			detail: data as Exclude<typeof data, undefined>,
 			composed: false,
 			bubbles,
 			cancelable,

--- a/packages/base/src/asset-registries/Icons.ts
+++ b/packages/base/src/asset-registries/Icons.ts
@@ -27,10 +27,10 @@ type IconData = {
 	collection: string,
 	packageName: string,
 	pathData: string | Array<string>,
-	ltr?: boolean,
-	accData?: I18nText,
-	customTemplate?: TemplateFunction,
-	viewBox?: string,
+	ltr?: boolean | undefined,
+	accData?: I18nText | undefined,
+	customTemplate?: TemplateFunction | undefined,
+	viewBox?: string | undefined,
 };
 
 const loaders = new Map<string, IconLoader>();

--- a/packages/base/src/delegate/ScrollEnablement.ts
+++ b/packages/base/src/delegate/ScrollEnablement.ts
@@ -23,8 +23,8 @@ class ScrollEnablement extends EventProvider<ScrollEnablementEventListenerParam,
 	_container?: HTMLElement;
 	supportsTouch = supportsTouch();
 	_canScroll?: boolean;
-	_prevDragX?: number;
-	_prevDragY?: number;
+	_prevDragX?: number | undefined;
+	_prevDragY?: number | undefined;
 
 	constructor(containerComponent: UI5Element) {
 		super();

--- a/packages/base/tsconfig.json
+++ b/packages/base/tsconfig.json
@@ -15,6 +15,7 @@
       "moduleResolution": "node",
       "composite": true,
       "rootDir": "src",
+      "exactOptionalPropertyTypes": true,
       "tsBuildInfoFile": "dist/.tsbuildinfo",
     },
 }

--- a/packages/create-package/template/tsconfig.json
+++ b/packages/create-package/template/tsconfig.json
@@ -10,6 +10,7 @@
       "sourceMap": true,
       "inlineSources": true,
       "strict": true,
+      "exactOptionalPropertyTypes": true,
       "moduleResolution": "node",
       "experimentalDecorators": true,
     },

--- a/packages/fiori/src/ShellBar.ts
+++ b/packages/fiori/src/ShellBar.ts
@@ -998,7 +998,7 @@ class ShellBar extends UI5Element {
 				return {
 					icon: item.icon,
 					id: item._id,
-					count: item.count || undefined,
+					count: item.count,
 					refItemid: item._id,
 					text: item.text,
 					classes: "ui5-shellbar-custom-item ui5-shellbar-button",

--- a/packages/fiori/src/ShellBar.ts
+++ b/packages/fiori/src/ShellBar.ts
@@ -111,13 +111,13 @@ type ShellBarCoPilot = {
 	animationValues?: string,
 };
 
-interface IShelBarItemInfo {
+interface IShellBarItemInfo {
 	id: string,
 	icon?: string,
 	text: string,
 	priority: number,
 	show: boolean,
-	count?: string,
+	count?: string | undefined,
 	custom?: boolean,
 	title?: string,
 	stableDomRef?: string,
@@ -422,7 +422,7 @@ class ShellBar extends UI5Element {
 	withLogo!: boolean;
 
 	@property({ type: Object })
-	_itemsInfo!: Array<IShelBarItemInfo>;
+	_itemsInfo!: Array<IShellBarItemInfo>;
 
 	@property({ type: Object, multiple: true })
 	_menuPopoverItems: Array<HTMLElement>;
@@ -517,7 +517,7 @@ class ShellBar extends UI5Element {
 	coPilot?: ShellBarCoPilot;
 	_coPilotIcon: string;
 	_debounceInterval?: Timeout | null;
-	_hiddenIcons: Array<IShelBarItemInfo>;
+	_hiddenIcons: Array<IShellBarItemInfo>;
 	_handleResize: ResizeObserverCallback;
 	_headerPress: () => void;
 
@@ -717,7 +717,7 @@ class ShellBar extends UI5Element {
 	_handleSizeS() {
 		const hasIcons = this.showNotifications || this.showProductSwitch || !!this.searchField.length || !!this.items.length;
 
-		const newItems = this._getAllItems(hasIcons).map((info): IShelBarItemInfo => {
+		const newItems = this._getAllItems(hasIcons).map((info): IShellBarItemInfo => {
 			const isOverflowIcon = info.classes.indexOf("ui5-shellbar-overflow-button") !== -1;
 			const isImageIcon = info.classes.indexOf("ui5-shellbar-image-button") !== -1;
 			const shouldStayOnScreen = isOverflowIcon || (isImageIcon && this.hasProfile);
@@ -979,7 +979,7 @@ class ShellBar extends UI5Element {
 			show: !!this.searchField.length,
 		};
 
-		const items: Array<IShelBarItemInfo> = [
+		const items: Array<IShellBarItemInfo> = [
 			{
 				icon: this._coPilotIcon,
 				text: this._copilotText,
@@ -1074,7 +1074,7 @@ class ShellBar extends UI5Element {
 		return items;
 	}
 
-	_updateItemsInfo(newItems: Array<IShelBarItemInfo>) {
+	_updateItemsInfo(newItems: Array<IShellBarItemInfo>) {
 		const isDifferent = JSON.stringify(this._itemsInfo) !== JSON.stringify(newItems);
 		if (isDifferent) {
 			this._itemsInfo = newItems;

--- a/packages/fiori/src/ShellBarItem.ts
+++ b/packages/fiori/src/ShellBarItem.ts
@@ -62,8 +62,8 @@ class ShellBarItem extends UI5Element {
 	 * @since 1.0.0-rc.6
 	 * @public
 	 */
-	@property()
-	count!: string;
+	@property({ type: String, defaultValue: undefined })
+	count?: string | undefined;
 
 	get stableDomRef() {
 		return this.getAttribute("stable-dom-ref") || `${this._id}-stable-dom-ref`;

--- a/packages/fiori/tsconfig.json
+++ b/packages/fiori/tsconfig.json
@@ -14,6 +14,7 @@
       "experimentalDecorators": true,
       "importsNotUsedAsValues": "preserve",
       "ignoreDeprecations": "5.0",
+      "exactOptionalPropertyTypes": true,
       "paths": {
         "@ui5/webcomponents-base/dist/*": ["../base/src/*"],
         "@ui5/webcomponents/dist/*": ["../main/src/*"],

--- a/packages/icons-business-suite/tsconfig.json
+++ b/packages/icons-business-suite/tsconfig.json
@@ -14,6 +14,7 @@
       	"moduleResolution": "node",
 		"resolveJsonModule": true,
 		"allowSyntheticDefaultImports": true,
+		"exactOptionalPropertyTypes": true,
 		"composite": true,
 		"rootDir": "src",
 		"tsBuildInfoFile": "dist/.tsbuildinfo",

--- a/packages/icons-tnt/tsconfig.json
+++ b/packages/icons-tnt/tsconfig.json
@@ -14,6 +14,7 @@
       	"moduleResolution": "node",
 		"resolveJsonModule": true,
 		"allowSyntheticDefaultImports": true,
+		"exactOptionalPropertyTypes": true,
 		"composite": true,
 		"rootDir": "src",
 		"tsBuildInfoFile": "dist/.tsbuildinfo",

--- a/packages/icons/tsconfig.json
+++ b/packages/icons/tsconfig.json
@@ -14,6 +14,7 @@
       	"moduleResolution": "node",
 		"resolveJsonModule": true,
 		"allowSyntheticDefaultImports": true,
+		"exactOptionalPropertyTypes": true,
 		"composite": true,
 		"rootDir": "src",
 		"tsBuildInfoFile": "dist/.tsbuildinfo",

--- a/packages/localization/tsconfig.json
+++ b/packages/localization/tsconfig.json
@@ -13,6 +13,7 @@
 		"moduleResolution": "node",
 		"composite": true,
 		"rootDir": "src",
+		"exactOptionalPropertyTypes": true,
 		"tsBuildInfoFile": "dist/.tsbuildinfo",
 		"paths": {
 			"@ui5/webcomponents-base/dist/*": ["../base/src/*"],

--- a/packages/main/src/Avatar.ts
+++ b/packages/main/src/Avatar.ts
@@ -226,7 +226,7 @@ class Avatar extends UI5Element implements ITabbable, IAvatarGroupItem {
 	@slot()
 	badge!: Array<HTMLElement>;
 
-	_onclick?: (e: MouseEvent) => void;
+	_onclick: ((e: MouseEvent) => void) | undefined;
 	static i18nBundle: I18nBundle;
 	_handleResizeBound: ResizeObserverCallback;
 

--- a/packages/main/src/Button.ts
+++ b/packages/main/src/Button.ts
@@ -269,7 +269,7 @@ class Button extends UI5Element implements IFormElement, IButton {
 	 * @private
 	 */
 	@property({ noAttribute: true })
-	buttonTitle?: string;
+	buttonTitle: string | undefined;
 
 	/**
 	 * @private

--- a/packages/main/src/Calendar.ts
+++ b/packages/main/src/Calendar.ts
@@ -391,7 +391,7 @@ class Calendar extends CalendarPart {
 		this._previousButtonDisabled = !this._currentPickerDOM._hasPreviousPage();
 		this._nextButtonDisabled = !this._currentPickerDOM._hasNextPage();
 
-		const yearFormat = DateFormat.getDateInstance({ format: "y", calendarType: this.primaryCalendarType });
+		const yearFormat = DateFormat.getDateInstance({ format: "y", calendarType: this.primaryCalendarType as Exclude<typeof this.primaryCalendarType, undefined> });
 		const localeData = getCachedLocaleDataInstance(getLocale());
 		this._headerMonthButtonText = localeData.getMonthsStandAlone("wide", this.primaryCalendarType)[this._calendarDate.getMonth()];
 
@@ -461,7 +461,7 @@ class Calendar extends CalendarPart {
 	}
 
 	_setSecondaryCalendarTypeButtonText() {
-		const yearFormatSecType = DateFormat.getDateInstance({ format: "y", calendarType: this._secondaryCalendarType });
+		const yearFormatSecType = DateFormat.getDateInstance({ format: "y", calendarType: this._secondaryCalendarType as Exclude<typeof this.secondaryCalendarType, undefined> });
 
 		if (this._currentPicker === "year") {
 			const rangeStart = new CalendarDateComponent(this._calendarDate, this._primaryCalendarType);
@@ -485,7 +485,7 @@ class Calendar extends CalendarPart {
 		}
 
 		const localDate = new Date(this._timestamp * 1000);
-		const secondYearFormat = DateFormat.getDateInstance({ format: "y", calendarType: this._secondaryCalendarType });
+		const secondYearFormat = DateFormat.getDateInstance({ format: "y", calendarType: this._secondaryCalendarType as Exclude<typeof this.secondaryCalendarType, undefined> });
 		const dateInSecType = transformDateToSecondaryType(this._primaryCalendarType, this._secondaryCalendarType, this._timestamp);
 		const secondMonthInfo = convertMonthNumbersToMonthNames(dateInSecType.firstDate.getMonth(), dateInSecType.lastDate.getMonth(), this._secondaryCalendarType);
 		const secondYearText = secondYearFormat.format(localDate, true);

--- a/packages/main/src/CalendarPart.ts
+++ b/packages/main/src/CalendarPart.ts
@@ -24,10 +24,14 @@ class CalendarPart extends DateComponentBase {
 	 * @protected
 	 */
 	@property({ validator: Integer })
-	timestamp?: number;
+	timestamp?: number | undefined;
 
 	get _minTimestamp() {
 		return this._minDate.valueOf() / 1000;
+	}
+
+	get test(): boolean {
+		return "timestamp" in this;
 	}
 
 	get _maxTimestamp() {

--- a/packages/main/src/DateTimePicker.ts
+++ b/packages/main/src/DateTimePicker.ts
@@ -41,8 +41,8 @@ import CalendarPickersMode from "./types/CalendarPickersMode.js";
 const PHONE_MODE_BREAKPOINT = 640; // px
 
 type PreviewValues = {
-	timeSelectionValue?: string,
-	calendarTimestamp?: number,
+	timeSelectionValue?: string | undefined,
+	calendarTimestamp?: number | undefined,
 	calendarValue?: string,
 }
 

--- a/packages/main/src/DayPicker.ts
+++ b/packages/main/src/DayPicker.ts
@@ -72,7 +72,7 @@ type Day = {
 	ariaSelected: string,
 	ariaDisabled: string | undefined,
 	disabled: boolean,
-	secondDay?: number,
+	secondDay: number | undefined,
 	weekNum?: number,
 	isHidden?: boolean,
 	type?: string,
@@ -87,7 +87,7 @@ type Week = Array<Day | WeekNumber>;
 
 type DayPickerChangeEventDetail = {
 	dates: Array<number>,
-	timestamp?: number,
+	timestamp: number | undefined,
 }
 
 type DayPickerNavigateEventDetail = {
@@ -182,7 +182,7 @@ class DayPicker extends CalendarPart implements ICalendarPicker {
 	 * @private
 	 */
 	 @property()
-	_secondTimestamp?: number;
+	_secondTimestamp: number | undefined;
 
 	/**
 	 * Array of special calendar dates (if such are passed) from the calendar.

--- a/packages/main/src/Icon.ts
+++ b/packages/main/src/Icon.ts
@@ -206,7 +206,7 @@ class Icon extends UI5Element implements IIcon {
 	 * @private
 	 */
 	@property({ type: Object, defaultValue: undefined, noAttribute: true })
-	accData?: I18nText;
+	accData: I18nText | undefined;
 
 	/**
 	 * @private
@@ -224,15 +224,15 @@ class Icon extends UI5Element implements IIcon {
 	 * @private
 	 */
 	@property({ noAttribute: true, defaultValue: undefined })
-	effectiveAccessibleName?: string;
+	effectiveAccessibleName: string | undefined;
 
-	ltr?: boolean;
+	ltr: boolean | undefined;
 	packageName?: string;
 	viewBox?: string;
 	customSvg?: object;
 
-	_onfocusout?: ((event: FocusEvent) => void);
-	_onfocusin?: ((event: FocusEvent) => void);
+	_onfocusout: ((event: FocusEvent) => void) | undefined;
+	_onfocusin: ((event: FocusEvent) => void) | undefined;
 
 	_onFocusInHandler() {
 		if (this.interactive) {

--- a/packages/main/src/Input.ts
+++ b/packages/main/src/Input.ts
@@ -504,7 +504,7 @@ class Input extends UI5Element implements SuggestionComponent, IFormElement {
 	 * @private
 	 */
 	@property({ type: String, noAttribute: true, defaultValue: undefined })
-	_associatedLabelsTexts?: string;
+	_associatedLabelsTexts: string | undefined;
 
 	/**
 	 * Constantly updated value of texts collected from the accessibleNameRef elements
@@ -587,7 +587,7 @@ class Input extends UI5Element implements SuggestionComponent, IFormElement {
 	_selectedText?: string;
 	_clearIconClicked?: boolean;
 	_focusedAfterClear: boolean;
-	_performTextSelection?: boolean;
+	_performTextSelection: boolean = false;
 	_previewItem?: SuggestionListItem;
 	static i18nBundle: I18nBundle;
 

--- a/packages/main/src/Input.ts
+++ b/packages/main/src/Input.ts
@@ -96,8 +96,8 @@ interface IInputSuggestionItem extends UI5Element {
 	description?: string;
 	image?: string;
 	icon?: string;
-	additionalText: string;
-	additionalTextState: `${ValueState}`;
+	additionalText?: string;
+	additionalTextState?: `${ValueState}`;
 	type?: `${ListItemType}`;
 }
 

--- a/packages/main/src/Input.ts
+++ b/packages/main/src/Input.ts
@@ -96,8 +96,8 @@ interface IInputSuggestionItem extends UI5Element {
 	description?: string;
 	image?: string;
 	icon?: string;
-	additionalText?: string;
-	additionalTextState?: `${ValueState}`;
+	additionalText: string;
+	additionalTextState: `${ValueState}`;
 	type?: `${ListItemType}`;
 }
 

--- a/packages/main/src/List.ts
+++ b/packages/main/src/List.ts
@@ -70,7 +70,7 @@ type ListSelectionChangeEventDetail = {
 	previouslySelectedItems: Array<ListItemBase>;
 	selectionComponentPressed: boolean;
 	targetItem: ListItemBase;
-	key?: string;
+	key: string | undefined;
 }
 
 type ListItemDeleteEventDetail = {

--- a/packages/main/src/ListItem.ts
+++ b/packages/main/src/ListItem.ts
@@ -56,14 +56,14 @@ type AccInfo = {
 	ariaLevel?: number;
 	ariaLabel: string;
 	ariaLabelRadioButton: string;
-	ariaSelectedText?: string;
-	ariaHaspopup?: `${Lowercase<HasPopup>}`;
-	posinset?: number;
-	setsize?: number;
+	ariaSelectedText: string | undefined;
+	ariaHaspopup?: `${Lowercase<HasPopup>}` | undefined;
+	posinset: number | undefined;
+	setsize: number | undefined;
 	ariaSelected?: boolean;
 	ariaChecked?: boolean;
-	listItemAriaLabel?: string;
-	ariaOwns?: string;
+	listItemAriaLabel?: string | undefined;
+	ariaOwns?: string | undefined;
 	tooltip?: string;
 }
 
@@ -502,12 +502,10 @@ abstract class ListItem extends ListItemBase {
 	get _accInfo(): AccInfo {
 		return {
 			role: this.accessibleRole || this.role,
-			ariaExpanded: undefined,
-			ariaLevel: undefined,
 			ariaLabel: ListItem.i18nBundle.getText(ARIA_LABEL_LIST_ITEM_CHECKBOX),
 			ariaLabelRadioButton: ListItem.i18nBundle.getText(ARIA_LABEL_LIST_ITEM_RADIO_BUTTON),
 			ariaSelectedText: this.ariaSelectedText,
-			ariaHaspopup: this.ariaHaspopup?.toLowerCase() as Lowercase<HasPopup> || undefined,
+			ariaHaspopup: this.ariaHaspopup?.toLowerCase() as Lowercase<HasPopup>,
 			setsize: this.accessibilityAttributes.ariaSetsize,
 			posinset: this.accessibilityAttributes.ariaPosinset,
 			tooltip: this.tooltip || this.title,

--- a/packages/main/src/ListItem.ts
+++ b/packages/main/src/ListItem.ts
@@ -52,7 +52,7 @@ type PressEventDetail = {
 
 type AccInfo = {
 	role: string;
-	ariaExpanded?: boolean;
+	ariaExpanded?: boolean | null;
 	ariaLevel?: number;
 	ariaLabel: string;
 	ariaLabelRadioButton: string;

--- a/packages/main/src/Menu.ts
+++ b/packages/main/src/Menu.ts
@@ -296,19 +296,19 @@ class Menu extends UI5Element {
 	 * Stores parent menu item (if there is such).
 	 */
 	@property({ type: Object, defaultValue: undefined })
-	_parentMenuItem?: MenuItem;
+	_parentMenuItem?: MenuItem | undefined;
 
 	/**
 	 * Stores parent menu item DOM representation (if there is such).
 	 */
 	@property({ type: Object, defaultValue: undefined })
-	_opener?: HTMLElement;
+	_opener?: HTMLElement | undefined;
 
 	/**
 	 * Stores menu item that have sub-menu opened.
 	 */
 	@property({ type: Object, defaultValue: undefined })
-	_openedSubMenuItem?: MenuItem;
+	_openedSubMenuItem?: MenuItem | undefined;
 
 	/**
 	 * Defines the items of this component.

--- a/packages/main/src/MultiComboBox.ts
+++ b/packages/main/src/MultiComboBox.ts
@@ -455,10 +455,10 @@ class MultiComboBox extends UI5Element {
 	_shouldAutocomplete?: boolean;
 	_preventTokenizerToggle?: boolean;
 	_isOpenedByKeyboard?: boolean;
-	_itemToFocus?: IMultiComboBoxItem;
+	_itemToFocus?: IMultiComboBoxItem | undefined;
 	_itemsBeforeOpen: Array<MultiComboboxItemWithSelection>;
 	selectedItems: Array<IMultiComboBoxItem>;
-	FormSupport?: typeof FormSupportT;
+	FormSupport: typeof FormSupportT | undefined;
 	static i18nBundle: I18nBundle;
 
 	constructor() {

--- a/packages/main/src/RangeSlider.ts
+++ b/packages/main/src/RangeSlider.ts
@@ -114,14 +114,14 @@ class RangeSlider extends SliderBase {
 	@property({ type: Boolean })
 	rangePressed!: boolean;
 
-	_startValueInitial?: number;
-	_endValueInitial?: number;
-	_valueAffected?: AffectedValue;
+	_startValueInitial?: number | undefined;
+	_endValueInitial?: number | undefined;
+	_valueAffected?: AffectedValue | undefined;
 	_isPressInCurrentRange = false;
 	_handeIsPressed = false;
 	_initialPageXPosition?: number;
-	_startValueAtBeginningOfAction?: number;
-	_endValueAtBeginningOfAction?: number;
+	_startValueAtBeginningOfAction?: number | undefined;
+	_endValueAtBeginningOfAction?: number | undefined;
 	_initialStartHandlePageX?: number;
 	_firstHandlePositionFromStart?: number;
 	_secondHandlePositionFromStart?: number;

--- a/packages/main/src/Select.ts
+++ b/packages/main/src/Select.ts
@@ -422,7 +422,7 @@ class Select extends UI5Element implements IFormElement {
 			menu.value = this.value;
 			// To cause invalidation when the menu is used for another Select that could have the same value as the previous.
 			// Otherwise, the menu won't re-render.
-			menu.selectId = this.__id;
+			menu.selectId = this._id;
 		} else {
 			this._syncSelection();
 		}

--- a/packages/main/src/SelectMenu.ts
+++ b/packages/main/src/SelectMenu.ts
@@ -208,7 +208,7 @@ class SelectMenu extends UI5Element {
 
 	_onOptionClick(e: CustomEvent) {
 		const option = e.detail.item;
-		const optionIndex = this.options.findIndex(_option => option.__id === _option.__id);
+		const optionIndex = this.options.findIndex(_option => option.__id === _option._id);
 
 		this.fireEvent<SelectMenuOptionClick>("option-click", {
 			option,

--- a/packages/main/src/SelectMenu.ts
+++ b/packages/main/src/SelectMenu.ts
@@ -207,8 +207,8 @@ class SelectMenu extends UI5Element {
 	}
 
 	_onOptionClick(e: CustomEvent) {
-		const option = e.detail.item;
-		const optionIndex = this.options.findIndex(_option => option.__id === _option._id);
+		const option = e.detail.item as SelectMenuOption;
+		const optionIndex = this.options.findIndex(_option => option._id === _option._id);
 
 		this.fireEvent<SelectMenuOptionClick>("option-click", {
 			option,

--- a/packages/main/src/Slider.ts
+++ b/packages/main/src/Slider.ts
@@ -86,8 +86,8 @@ class Slider extends SliderBase {
 	@property({ validator: Float, defaultValue: 0 })
 	value!: number;
 
-	_valueInitial?: number;
-	_valueOnInteractionStart?: number;
+	_valueInitial?: number | undefined;
+	_valueOnInteractionStart?: number | undefined;
 	_progressPercentage = 0;
 	_handlePositionFromStart = 0;
 

--- a/packages/main/src/Tab.ts
+++ b/packages/main/src/Tab.ts
@@ -187,12 +187,12 @@ class Tab extends UI5Element implements ITabbable, ITab {
 	})
 	items!: Array<ITab>
 
-	_isInline?: boolean;
-	_forcedMixedMode?: boolean;
+	_isInline: boolean = false;
+	_forcedMixedMode: boolean = false;
 	_getElementInStrip?: () => HTMLElement | undefined;
 	_individualSlot!: string;
-	_forcedPosinset?: number;
-	_forcedSetsize?: number;
+	_forcedPosinset?: number | undefined;
+	_forcedSetsize?: number | undefined;
 	_forcedStyleInOverflow?: Record<string, any>;
 
 	static i18nBundle: I18nBundle;
@@ -265,8 +265,8 @@ class Tab extends UI5Element implements ITabbable, ITab {
 		this._getElementInStrip = getElementInStrip;
 		this._forcedPosinset = posinset;
 		this._forcedSetsize = setsize;
-		this._forcedMixedMode = mixedMode;
-		this._isInline = isInline;
+		this._forcedMixedMode = mixedMode ?? false;
+		this._isInline = isInline ?? false;
 		this._isTopLevelTab = !!isTopLevelTab;
 	}
 

--- a/packages/main/src/TabContainer.ts
+++ b/packages/main/src/TabContainer.ts
@@ -455,7 +455,7 @@ class TabContainer extends UI5Element {
 		ResizeHandler.deregister(this._getHeader(), this._handleResizeBound);
 		DragRegistry.unsubscribe(this);
 		DragRegistry.removeSelfManagedArea(this);
-		this._setDraggedElement = undefined;
+		delete this._setDraggedElement;
 	}
 
 	_handleResize() {
@@ -816,7 +816,7 @@ class TabContainer extends UI5Element {
 	}
 
 	_onItemSelect(selectedTabId: string) {
-		const selectedTabIndex = this._itemsFlat!.findIndex(item => item.__id === selectedTabId);
+		const selectedTabIndex = this._itemsFlat!.findIndex(item => item._id === selectedTabId);
 		const selectedTab = this._itemsFlat![selectedTabIndex] as Tab;
 
 		const selectionSuccessful = this.selectTab(selectedTab, selectedTabIndex);

--- a/packages/main/src/Table.ts
+++ b/packages/main/src/Table.ts
@@ -86,7 +86,7 @@ type TableColumnInfo = {
 	text?: string | null,
 	visible?: boolean,
 	demandPopin?: boolean,
-	popinText?: string,
+	popinText?: string | undefined,
 	popinDisplay?: `${TableColumnPopinDisplay}`,
 	popinDisplayInline?: boolean,
 	classes?: string,

--- a/packages/main/src/TextArea.ts
+++ b/packages/main/src/TextArea.ts
@@ -51,9 +51,9 @@ type IndexedTokenizedText = Array<{
 }>;
 
 type ExceededText = {
-	exceededText?: string;
-	leftCharactersCount?: number;
-	calcedMaxLength?: number;
+	exceededText?: string | undefined;
+	leftCharactersCount?: number | undefined;
+	calcedMaxLength?: number | undefined;
 };
 
 /**

--- a/packages/main/src/TimePickerBase.ts
+++ b/packages/main/src/TimePickerBase.ts
@@ -182,7 +182,7 @@ class TimePickerBase extends UI5Element {
 	@slot()
 	valueStateMessage!: Array<HTMLElement>;
 
-	tempValue?: string;
+	tempValue?: string | undefined;
 
 	static i18nBundle: I18nBundle;
 
@@ -461,11 +461,11 @@ class TimePickerBase extends UI5Element {
 
 		if (this._isPattern) {
 			dateFormat = DateFormat.getDateInstance({
-				pattern: this._formatPattern,
+				pattern: this._formatPattern as Exclude<typeof this._formatPattern, undefined>,
 			});
 		} else {
 			dateFormat = DateFormat.getDateInstance({
-				style: this._formatPattern,
+				style: this._formatPattern as Exclude<typeof this._formatPattern, undefined>,
 			});
 		}
 

--- a/packages/main/src/TimePickerClock.ts
+++ b/packages/main/src/TimePickerClock.ts
@@ -20,9 +20,9 @@ type TimePickerClockChangeEventDetail = {
 }
 
 type TimePickerClockItem = {
-	angle?: number,
+	angle?: number | undefined,
 	item?: string,
-	innerItem?: string,
+	innerItem?: string | undefined,
 	outerStyles?: object,
 	innerStyles?: object,
 }

--- a/packages/main/src/TimePickerInternals.ts
+++ b/packages/main/src/TimePickerInternals.ts
@@ -157,14 +157,14 @@ class TimePickerInternals extends UI5Element {
 	 * @private
 	 */
 	@property({ validator: Integer, noAttribute: true })
-	_typeCooldownId?: ReturnType<typeof setTimeout>;
+	_typeCooldownId: ReturnType<typeof setTimeout> | undefined;
 
 	/**
 	 * Exact match number buffer
 	 * @private
 	 */
 	@property({ validator: Integer, noAttribute: true })
-	_exactMatch?: number;
+	_exactMatch?: number | undefined;
 
 	/**
 	 * Buffer for entered by keyboard numbers

--- a/packages/main/src/TreeItemBase.ts
+++ b/packages/main/src/TreeItemBase.ts
@@ -249,14 +249,14 @@ class TreeItemBase extends ListItem {
 	get _accInfo() {
 		const accInfoSettings = {
 			role: "treeitem",
-			ariaExpanded: this.showToggleButton ? this.expanded : undefined,
+			ariaExpanded: this.showToggleButton ? this.expanded : false,
 			ariaLevel: this.level,
 			posinset: this.forcedPosinset,
 			setsize: this.forcedSetsize,
 			ariaSelectedText: this.ariaSelectedText,
 			listItemAriaLabel: !this.accessibleName ? this._ariaLabel : undefined,
 			ariaOwns: this.expanded ? `${this._id}-subtree` : undefined,
-			ariaHaspopup: this.ariaHaspopup?.toLowerCase() as Lowercase<HasPopup> || undefined,
+			ariaHaspopup: this.ariaHaspopup?.toLowerCase() as Lowercase<HasPopup>,
 		};
 
 		return { ...super._accInfo, ...accInfoSettings };

--- a/packages/main/src/TreeItemBase.ts
+++ b/packages/main/src/TreeItemBase.ts
@@ -249,7 +249,7 @@ class TreeItemBase extends ListItem {
 	get _accInfo() {
 		const accInfoSettings = {
 			role: "treeitem",
-			ariaExpanded: this.showToggleButton ? this.expanded : false,
+			ariaExpanded: this.showToggleButton ? this.expanded : null,
 			ariaLevel: this.level,
 			posinset: this.forcedPosinset,
 			setsize: this.forcedSetsize,

--- a/packages/main/src/YearPicker.ts
+++ b/packages/main/src/YearPicker.ts
@@ -134,7 +134,7 @@ class YearPicker extends CalendarPart implements ICalendarPicker {
 		const pageSize = this._getPageSize();
 		const locale = getLocale() as unknown as LocaleT;
 		const oYearFormat = DateFormat.getDateInstance({ format: "y", calendarType: this._primaryCalendarType }, locale);
-		const oYearFormatInSecType = DateFormat.getDateInstance({ format: "y", calendarType: this.secondaryCalendarType }, locale);
+		const oYearFormatInSecType = DateFormat.getDateInstance({ format: "y", calendarType: this.secondaryCalendarType as Exclude<typeof this.secondaryCalendarType, undefined> }, locale);
 		this._calculateFirstYear();
 		this._lastYear = this._firstYear! + pageSize - 1;
 

--- a/packages/main/src/features/InputSuggestions.ts
+++ b/packages/main/src/features/InputSuggestions.ts
@@ -47,8 +47,8 @@ type InputSuggestion = {
 	image?: string | undefined;
 	icon?: string | undefined;
 	type?: `${ListItemType}` | undefined;
-	additionalText: string;
-	additionalTextState?: `${ValueState}`;
+	additionalText?: string | undefined;
+	additionalTextState?: `${ValueState}` | undefined;
 	groupItem: boolean;
 	key: number;
 }

--- a/packages/main/src/features/InputSuggestions.ts
+++ b/packages/main/src/features/InputSuggestions.ts
@@ -47,7 +47,7 @@ type InputSuggestion = {
 	image?: string | undefined;
 	icon?: string | undefined;
 	type?: `${ListItemType}` | undefined;
-	additionalText?: string;
+	additionalText: string;
 	additionalTextState?: `${ValueState}`;
 	groupItem: boolean;
 	key: number;
@@ -121,9 +121,14 @@ class Suggestions {
 			const description = highlight ? this.getHighlightedDesc(suggestion, hightlightValue) : this.getRowDesc(suggestion);
 
 			return suggestions.push({
-				...suggestion,
 				text,
 				description,
+				image: suggestion.image,
+				icon: suggestion.icon,
+				type: suggestion.type,
+				additionalText: suggestion.additionalText,
+				additionalTextState: suggestion.additionalTextState,
+				groupItem: suggestion.groupItem,
 				key: idx,
 			});
 		});

--- a/packages/main/src/features/InputSuggestions.ts
+++ b/packages/main/src/features/InputSuggestions.ts
@@ -44,9 +44,9 @@ interface SuggestionComponent extends UI5Element {
 type InputSuggestion = {
 	text: string;
 	description?: string;
-	image?: string;
-	icon?: string;
-	type?: `${ListItemType}`;
+	image?: string | undefined;
+	icon?: string | undefined;
+	type?: `${ListItemType}` | undefined;
 	additionalText?: string;
 	additionalTextState?: `${ValueState}`;
 	groupItem: boolean;
@@ -73,7 +73,7 @@ class Suggestions {
 	handleFocus: boolean;
 	highlight: boolean;
 	selectedItemIndex: number;
-	accInfo?: SuggestionsAccInfo;
+	accInfo?: SuggestionsAccInfo | undefined;
 	responsivePopover?: ResponsivePopover;
 	_scrollContainer?: HTMLElement;
 	_handledPress?: boolean;
@@ -121,14 +121,9 @@ class Suggestions {
 			const description = highlight ? this.getHighlightedDesc(suggestion, hightlightValue) : this.getRowDesc(suggestion);
 
 			return suggestions.push({
+				...suggestion,
 				text,
 				description,
-				image: suggestion.image || undefined,
-				icon: suggestion.icon || undefined,
-				type: suggestion.type || undefined,
-				additionalText: suggestion.additionalText || undefined,
-				additionalTextState: suggestion.additionalTextState,
-				groupItem: suggestion.groupItem,
 				key: idx,
 			});
 		});

--- a/packages/main/test/specs/CalendarLegend.spec.js
+++ b/packages/main/test/specs/CalendarLegend.spec.js
@@ -14,10 +14,10 @@ describe("Calendar Legend with standard items", () => {
 	it("Calendar Legend items are rendered", async () => {
 		const legend = await browser.$("#calendarLegend").shadow$(".ui5-calendar-legend-root");
 		const items = await legend.$$("ui5-calendar-legend-item");
-	
+
 		assert.strictEqual(items.length, 4, "Calendar Legend items are rendered");
 	});
-	
+
 
 	it("Calendar legend hides Today, when hideToday property provided", async () => {
 		const legend = await browser.$("#calendarLegend");
@@ -46,14 +46,13 @@ describe("Calendar Legend with standard items", () => {
 	it("Focusing item in Calendar Legend filter the corresponding days in Calendar", async () => {
 		const legend = await browser.$("#calendarLegend");
 		const items = await legend.shadow$(".ui5-calendar-legend-root").$$("ui5-calendar-legend-item");
-		const calendar = await browser.$("#calendar1").shadow$(".ui5-cal-root");
 
 		await items[0].click();
 		await browser.keys("ArrowDown");
 		await browser.keys("ArrowDown");
 		await browser.keys("ArrowDown");
 
-		const dayPicker = await calendar.$("#ui5wc_22-daypicker");
+		const dayPicker = await browser.$("#calendar1").shadow$("ui5-daypicker");
 		const filteredDays = await dayPicker.shadow$$("[special-day]");
 
 		assert.strictEqual(filteredDays.length, 1, "Only one day is filtered");
@@ -70,7 +69,7 @@ describe("Calendar Legend with standard items", () => {
 		await browser.keys("ArrowDown");
 		await browser.keys("ArrowDown");
 
-		const dayPicker = await calendar.$("#ui5wc_22-daypicker");
+		const dayPicker = await browser.$("#calendar1").shadow$("ui5-daypicker");
 		let filteredDays = await dayPicker.shadow$$("[special-day]");
 
 		assert.strictEqual(filteredDays.length, 1, "Days are filtered");

--- a/packages/main/tsconfig.json
+++ b/packages/main/tsconfig.json
@@ -18,6 +18,7 @@
       "importsNotUsedAsValues": "preserve",
       "ignoreDeprecations": "5.0",
       // "verbatimModuleSyntax": true,
+      "exactOptionalPropertyTypes": true,
       "paths": {
         "@ui5/webcomponents-base/dist/*": ["../base/src/*"],
         "@ui5/webcomponents-localization/dist/*": ["../localization/src/*"],

--- a/packages/theming/tsconfig.json
+++ b/packages/theming/tsconfig.json
@@ -12,6 +12,7 @@
       "strict": true,
       "moduleResolution": "node",
       "experimentalDecorators": true,
+      "exactOptionalPropertyTypes": true,
       "composite": true,
       "rootDir": "src",
       "tsBuildInfoFile": "dist/.tsbuildinfo",


### PR DESCRIPTION
TypeScript description of the flag:
https://www.typescriptlang.org/tsconfig#exactOptionalPropertyTypes

This change is a preparation for introduction of property initializers. The goal is when a component property is defined as optional with a default value
`prop?: string = "default value"`

This will be interpreted such that the value can be left out when using it from JSX (and it will get the default), but assigning `undefined` is forbidden and not handled by the component.

Enabling `exactOptionalPropertyTypes` is a preparation inside the project for this usage.