### PR TITLE
refactor(ui5-table): rename busy, busyDelay and mode properties, TableMode enum and its values

### DIFF
--- a/packages/main/src/Table.hbs
+++ b/packages/main/src/Table.hbs
@@ -7,7 +7,7 @@
 >
 	<div id="{{_id}}-before" tabindex="0" class="ui5-table-focusarea"></div>
 
-	{{#if busy}}
+	{{#if loading}}
 		{{> busyRow}}
 	{{/if}}
 
@@ -113,7 +113,7 @@
 		<ui5-busy-indicator
 			delay="{{busyDelay}}"
 			class="ui5-table-busy-ind"
-			style="{{styles.busy}}"
+			style="{{styles.loading}}"
 			active
 			data-sap-focus-ref
 		></ui5-busy-indicator>

--- a/packages/main/src/Table.hbs
+++ b/packages/main/src/Table.hbs
@@ -111,7 +111,7 @@
 {{#*inline "busyRow"}}
 	<div tabindex="-1" class="ui5-table-busy-row">
 		<ui5-busy-indicator
-			delay="{{busyDelay}}"
+			delay="{{loadingDelay}}"
 			class="ui5-table-busy-ind"
 			style="{{styles.loading}}"
 			active

--- a/packages/main/src/Table.ts
+++ b/packages/main/src/Table.ts
@@ -320,7 +320,7 @@ class Table extends UI5Element {
 	 * @public
 	 */
 	@property({ validator: Integer, defaultValue: 1000 })
-	busyDelay!: number;
+	loadingDelay!: number;
 
 	/**
 	 * Determines whether the column headers remain fixed at the top of the page during

--- a/packages/main/src/TableGroupRow.ts
+++ b/packages/main/src/TableGroupRow.ts
@@ -8,7 +8,7 @@ import { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import CheckBox from "./CheckBox.js";
 import type { ITableRow, TableColumnInfo } from "./Table.js";
 import TableGroupRowTemplate from "./generated/templates/TableGroupRowTemplate.lit.js";
-import TableMode from "./types/TableMode.js";
+import TableSelectionMode from "./types/TableSelectionMode.js";
 
 // Texts
 import {
@@ -46,12 +46,12 @@ import tableGroupRowStyles from "./generated/themes/TableGroupRow.css.js";
 @event("_focused")
 class TableGroupRow extends UI5Element implements ITableRow {
 	/**
-	 * Defines the mode of the row
+	 * Defines the selection mode of the row
 	 * @default "None"
 	 * @private
 	 */
-	@property({ type: TableMode, defaultValue: TableMode.None })
-	mode!: `${TableMode}`;
+	@property({ type: TableSelectionMode, defaultValue: TableSelectionMode.None })
+	selectionMode!: `${TableSelectionMode}`;
 
 	@property({ type: Object, multiple: true })
 	_columnsInfo!: Array<TableColumnInfo>;
@@ -87,7 +87,7 @@ class TableGroupRow extends UI5Element implements ITableRow {
 			return column.visible ? ++acc : acc;
 		}, 0);
 
-		if (this.mode === TableMode.MultiSelect) {
+		if (this.selectionMode === TableSelectionMode.Multi) {
 			count++;
 		}
 

--- a/packages/main/src/TableRow.ts
+++ b/packages/main/src/TableRow.ts
@@ -20,7 +20,7 @@ import { getEventMark } from "@ui5/webcomponents-base/dist/MarkedEvents.js";
 import type TableCell from "./TableCell.js";
 import type { ITableRow, TableColumnInfo } from "./Table.js";
 import CheckBox from "./CheckBox.js";
-import TableMode from "./types/TableMode.js";
+import TableSelectionMode from "./types/TableSelectionMode.js";
 import TableRowType from "./types/TableRowType.js";
 import TableColumnPopinDisplay from "./types/TableColumnPopinDisplay.js";
 import TableRowTemplate from "./generated/templates/TableRowTemplate.lit.js";
@@ -124,13 +124,13 @@ class TableRow extends UI5Element implements ITableRow {
 	navigated!: boolean;
 
 	/**
-	 * Defines the mode of the row (None, SingleSelect, MultiSelect).
+	 * Defines the selection mode of the row (None, Single, Multi).
 	 * @default "None"
 	 * @since 1.0.0-rc.15
 	 * @private
 	 */
-	@property({ type: TableMode, defaultValue: TableMode.None })
-	mode!: `${TableMode}`;
+	@property({ type: TableSelectionMode, defaultValue: TableSelectionMode.None })
+	selectionMode!: `${TableSelectionMode}`;
 
 	/**
 	 * Indicates if the table row is active.
@@ -401,11 +401,11 @@ class TableRow extends UI5Element implements ITableRow {
 	}
 
 	get isSingleSelect() {
-		return this.mode === TableMode.SingleSelect;
+		return this.selectionMode === TableSelectionMode.Single;
 	}
 
 	get isMultiSelect() {
-		return this.mode === TableMode.MultiSelect;
+		return this.selectionMode === TableSelectionMode.Multi;
 	}
 
 	get root() {

--- a/packages/main/src/themes/Table.css
+++ b/packages/main/src/themes/Table.css
@@ -60,7 +60,7 @@ tr {
 	height: 0px;
 }
 
-:host([busy]) .ui5-table-busy-row {
+:host([loading]) .ui5-table-busy-row {
 	position: absolute;
 	left: 0;
 	right: 0;
@@ -70,7 +70,7 @@ tr {
 	z-index: 100;
 }
 
-:host([busy]) .ui5-table-busy-ind {
+:host([loading]) .ui5-table-busy-ind {
 	position: absolute;
 	top: 50%;
 	left: 50%;
@@ -78,7 +78,7 @@ tr {
 	z-index: 1;
 }
 
-:host([busy]) [growing-button] {
+:host([loading]) [growing-button] {
 	opacity: 0.72;
 }
 

--- a/packages/main/src/themes/TableGroupRow.css
+++ b/packages/main/src/themes/TableGroupRow.css
@@ -2,7 +2,7 @@
     display: contents;
 }
 
-:host([_busy]) .ui5-table-group-row-root {
+:host([_loading]) .ui5-table-group-row-root {
 	opacity: 0.72;
 	pointer-events: none;
 }

--- a/packages/main/src/themes/TableRow.css
+++ b/packages/main/src/themes/TableRow.css
@@ -2,7 +2,7 @@
 	display: contents;
 }
 
-:host([_busy]) .ui5-table-row-root {
+:host([_loading]) .ui5-table-row-root {
 	opacity: 0.72;
 	pointer-events: none;
 }
@@ -31,7 +31,7 @@
 	padding-inline-start: 1rem;
 }
 
-:host([mode="MultiSelect"]) .ui5-table-popin-row td:not(.ui5-table-row-navigated) {
+:host([selection-mode="Multi"]) .ui5-table-popin-row td:not(.ui5-table-row-navigated) {
 	padding-inline-start: var(--ui5_table_multiselect_popin_row_padding);
 }
 
@@ -61,10 +61,10 @@
 	vertical-align: middle;
 }
 
-:host([mode="SingleSelect"]) .ui5-table-row-root {
+:host([selection-mode="Single"]) .ui5-table-row-root {
 	cursor: pointer;
 }
-:host([mode="MultiSelect"]) .ui5-table-row-root .ui5-table-multi-select-cell {
+:host([selection-mode="Multi"]) .ui5-table-row-root .ui5-table-multi-select-cell {
 	cursor: pointer;
 }
 
@@ -72,13 +72,13 @@
 	padding: .25rem .5rem;
 }
 
-:host(:not([mode="MultiSelect"])) ::slotted([ui5-table-cell]:not([popined]):first-child) {
+:host(:not([selection-mode="Multi"])) ::slotted([ui5-table-cell]:not([popined]):first-child) {
 	padding-inline-start: 1rem;
 }
 
 /** Hover **/
 :host([type="Active"]) .ui5-table-row-root:hover,
-:host([mode="SingleSelect"]) .ui5-table-row-root:hover:not(:active) {
+:host([selection-mode="Single"]) .ui5-table-row-root:hover:not(:active) {
 	background-color: var(--sapList_Hover_Background);
 }
 
@@ -104,7 +104,7 @@
 
 /** Hover on Selected **/
 :host([selected][type="Active"]) .ui5-table-row-root:hover:not(:active),
-:host([selected][mode="SingleSelect"]) .ui5-table-row-root:hover:not(:active) {
+:host([selected][selection-mode="Single"]) .ui5-table-row-root:hover:not(:active) {
 	background-color: var(--sapList_Hover_SelectionBackground);
 }
 

--- a/packages/main/src/types/TableSelectionMode.ts
+++ b/packages/main/src/types/TableSelectionMode.ts
@@ -1,8 +1,8 @@
 /**
- * Different table modes.
+ * Different table selection modes.
  * @public
  */
-enum TableMode {
+enum TableSelectionMode {
 	/**
 	 * Default mode (no selection).
 	 * @public
@@ -13,13 +13,13 @@ enum TableMode {
 	 * Single selection mode (only one table row can be selected).
 	 * @public
 	 */
-	SingleSelect = "SingleSelect",
+	Single = "Single",
 
 	/**
 	 * Multi selection mode (more than one table row can be selected).
 	 * @public
 	 */
-	MultiSelect = "MultiSelect",
+	Multi = "Multi",
 }
 
-export default TableMode;
+export default TableSelectionMode;

--- a/packages/main/test/pages/Table.html
+++ b/packages/main/test/pages/Table.html
@@ -88,7 +88,7 @@
 	<br>
 	<br>
 
-	<ui5-table class="no-data-table" id="tableNoData" no-data-text="No Data" busy>
+	<ui5-table class="no-data-table" id="tableNoData" no-data-text="No Data" loading>
 		<ui5-table-column id="column-1" slot="columns">
 			<div class="column-content">
 				<ui5-label>Product</ui5-label>

--- a/packages/main/test/pages/TableAllPopin.html
+++ b/packages/main/test/pages/TableAllPopin.html
@@ -79,7 +79,7 @@
 	<br>
 	<br>
 
-	<ui5-table class="demo-table" id="tbl2" mode="SingleSelect">
+	<ui5-table class="demo-table" id="tbl2" selection-mode="Single">
 		<!-- Columns -->
 		<ui5-table-column slot="columns" style="width: 12rem">
 			<ui5-label>Product</ui5-label>
@@ -161,8 +161,8 @@
 	<br>
 	<br>
 
-	<h2>SingleSelect table (click on an item to set as navigated)</h2>
-	<ui5-table class="demo-table" mode="SingleSelect" id="tbl3">
+	<h2>Single table (click on an item to set as navigated)</h2>
+	<ui5-table class="demo-table" selection-mode="Single" id="tbl3">
 		<!-- Columns -->
 		<ui5-table-column class="title-column" slot="columns">
 			<ui5-label>Product</ui5-label>

--- a/packages/main/test/pages/TableGrouping.html
+++ b/packages/main/test/pages/TableGrouping.html
@@ -63,8 +63,8 @@
 	<hr>
 	<br>
 
-	<ui5-title>MultiSelect Table with grouping:</ui5-title>
-	<ui5-table class="demo-table-multi" id="groupedMultiTable" mode="MultiSelect">
+	<ui5-title>Multi selection table with grouping:</ui5-title>
+	<ui5-table class="demo-table-multi" id="groupedMultiTable" selection-mode="Multi">
 		<ui5-table-column id="column-1" slot="columns">
 			<ui5-label>City</ui5-label>
 		</ui5-table-column>

--- a/packages/main/test/pages/TableGrowingWithButton.html
+++ b/packages/main/test/pages/TableGrowingWithButton.html
@@ -767,7 +767,7 @@
 		var loadMoreTracker = 1;
 
 		function init(tbl, rows) {
-			tbl.busy = true;
+			tbl.loading = true;
 
 			var html = '';
 			products.ProductCollection.slice(0, ROWS).forEach(function (product, index, arr) {
@@ -781,7 +781,7 @@
 			inputLoadMoreCounter.value = loadMoreTracker - 1;
 
 			setTimeout(function() {
-				tbl.busy = false;
+				tbl.loading = false;
 			}, 1500);
 		}
 

--- a/packages/main/test/pages/TableGrowingWithScroll.html
+++ b/packages/main/test/pages/TableGrowingWithScroll.html
@@ -782,7 +782,7 @@
 		}
 
 		function loadMore() {
-			table.busy = true;
+			table.loading = true;
 
 			++loadMoreTracker;
 			inputLoadMoreCounter.value = loadMoreTracker - 1;
@@ -793,7 +793,7 @@
 
 			timeoutTracker = setTimeout(function() {
 				init(table, NEW_ROWS);
-				table.busy = false;
+				table.loading = false;
 			}, 1500);
 		}
 

--- a/packages/main/test/pages/TableSelection.html
+++ b/packages/main/test/pages/TableSelection.html
@@ -27,8 +27,8 @@
 
 	<br>
 
-	<ui5-title>Table in SingleSelect mode</ui5-title>
-	<ui5-table mode="SingleSelect" id="single">
+	<ui5-title>Table in Single selection mode</ui5-title>
+	<ui5-table selection-mode="Single" id="single">
 
 		<ui5-table-column slot="columns">
 			<ui5-label>Product</ui5-label>
@@ -145,8 +145,8 @@
 	<br>
 	<br>
 	<br>
-	<ui5-title>Table in MultiSelect mode</ui5-title>
-	<ui5-table id="multi" mode="MultiSelect" sticky-column-header>
+	<ui5-title>Table in Multi selection mode</ui5-title>
+	<ui5-table id="multi" selection-mode="Multi" sticky-column-header>
 
 		<ui5-table-column slot="columns">
 			<ui5-label>Product</ui5-label>

--- a/packages/main/test/specs/Table.spec.js
+++ b/packages/main/test/specs/Table.spec.js
@@ -499,8 +499,8 @@ describe("Table general interaction", () => {
 			await firstCellFirstRowLabel.click();
 
 			// Check whether the table's and row's selection-mode property is set correctly, as well as the row type property
-			assert.strictEqual(await table.getProperty("selection-mode"), "None", "The table's selection mode is None");
-			assert.strictEqual(await firstRow.getProperty("selection-mode"), "None", "The row's selection mode is None");
+			assert.strictEqual(await table.getProperty("selectionMode"), "None", "The table's selection mode is None");
+			assert.strictEqual(await firstRow.getProperty("selectionMode"), "None", "The row's selection mode is None");
 			assert.strictEqual(await firstRow.getProperty("type"), "Active", "The row's type is Active");
 			assert.strictEqual(await thirdRow.getProperty("type"), "Inactive", "The row's type is Inactive")
 

--- a/packages/main/test/specs/Table.spec.js
+++ b/packages/main/test/specs/Table.spec.js
@@ -208,7 +208,7 @@ describe("Table general interaction", () => {
 	});
 
 	describe("Table selection modes", async () => {
-		it("test click over Active/Inactive row in SingleSelect mode", async () => {
+		it("test click over Active/Inactive row in Single selection mode", async () => {
 			await browser.url("test/pages/TableSelection.html");
 			const table = await browser.$("#single");
 			const firstRow = await browser.$("#firstRowSingleSelect");
@@ -224,9 +224,9 @@ describe("Table general interaction", () => {
 			// act
 			await firstCellFirstRowLabel.click();
 
-			// check whether the table's and row's mode property is set correctly, as well as the row type property
-			assert.strictEqual(await table.getAttribute("mode"), "SingleSelect", "The table's mode is SingleSelect");
-			assert.strictEqual(await firstRow.getAttribute("mode"), "SingleSelect", "The row's mode is SingleSelect");
+			// check whether the table's and row's selection-mode property is set correctly, as well as the row type property
+			assert.strictEqual(await table.getAttribute("selection-mode"), "Single", "The table's selection mode is Single");
+			assert.strictEqual(await firstRow.getAttribute("selection-mode"), "Single", "The row's selection mode is Single");
 			assert.strictEqual(await firstRow.getAttribute("type"), "Active", "The row's type is Active");
 			assert.strictEqual(await thirdRow.getAttribute("type"), "Inactive", "The row's type is Inactive")
 
@@ -254,7 +254,7 @@ describe("Table general interaction", () => {
 			assert.strictEqual(await previouslySelectedRows.getProperty("value"), "firstRowSingleSelect", "The prevously  selected row is not changed");
 		});
 
-		it("test Space/Enter key interaction over Active/Inactive row in SingleSelect mode", async () => {
+		it("test Space/Enter key interaction over Active/Inactive row in Single selection mode", async () => {
 			const firstRow = await browser.$("#firstRowSingleSelect");
 			const secondRow = await browser.$("#secondRowSingleSelect");
 			const thirdRow = await browser.$("#thirdRowSingleSelect");
@@ -328,7 +328,7 @@ describe("Table general interaction", () => {
 			assert.strictEqual(await selectedRow.getProperty("value"), "secondRowSingleSelect", "The selected row is not changed");
 		});
 
-		it("test click over Active/Inactive row in MultiSelect mode", async () => {
+		it("test click over Active/Inactive row in Multi selection mode", async () => {
 			const table = await browser.$("#multi");
 			const firstRow = await browser.$("#firstRowMultiSelect");
 			const thirdRow = await browser.$("#thirdRowMultiSelect");
@@ -344,20 +344,20 @@ describe("Table general interaction", () => {
 			// act
 			await firstCellFirstRowLabel.click();
 
-			// check whether the table's and row's mode property is set correctly, as well as the row type property
-			assert.strictEqual(await table.getAttribute("mode"), "MultiSelect", "The table's mode is MultiSelect");
-			assert.strictEqual(await firstRow.getAttribute("mode"), "MultiSelect", "The row's mode is MultiSelect");
+			// check whether the table's and row's selection-mode property is set correctly, as well as the row type property
+			assert.strictEqual(await table.getAttribute("selection-mode"), "Multi", "The table's selection mode is Multi");
+			assert.strictEqual(await firstRow.getAttribute("selection-mode"), "Multi", "The row's selection mode is Multi");
 			assert.strictEqual(await firstRow.getAttribute("type"), "Active", "The row's type is Active");
 			assert.strictEqual(await thirdRow.getAttribute("type"), "Inactive", "The row's type is Inactive")
 
 			// test row-click and selection-change events over an Active row
 			assert.strictEqual(await rowClickCount.getProperty("value"), "1", "Click over an Active row should trigger row-click event");
-			assert.strictEqual(await selectionChangeCount.getProperty("value"), "", "Click over a row in a MultiSelect mode table should not trigger selection-change event");
+			assert.strictEqual(await selectionChangeCount.getProperty("value"), "", "Click over a row in a Multi selection mode table should not trigger selection-change event");
 
 			// act
 			await checkBoxFirstCell.click();
 
-			// test click over the selection checkbox within each row in MultiSelect mode
+			// test click over the selection checkbox within each row in Multi selection mode
 			assert.strictEqual(await rowClickCount.getProperty("value"), "1", "Click over the selection checkbox should not trigger row-click event");
 			assert.strictEqual(await selectionChangeCount.getProperty("value"), "1", "Click over the selection checkbox should trigger selection-change event");
 			assert.strictEqual(await selectedRow.getProperty("value"), "firstRowMultiSelect", "The first row is selected");
@@ -379,7 +379,7 @@ describe("Table general interaction", () => {
 			assert.strictEqual(await selectionChangeCount.getProperty("value"), "1", "Click over an Inactive row should not trigger selection-change event");
 		});
 
-		it("test Space/Enter key interaction over Active/Inactive row in MultiSelect mode", async () => {
+		it("test Space/Enter key interaction over Active/Inactive row in Multi selection mode", async () => {
 			const firstRow = await browser.$("#firstRowMultiSelect");
 			const secondRow = await browser.$("#secondRowMultiSelect");
 			const thirdRow = await browser.$("#thirdRowMultiSelect");
@@ -413,7 +413,7 @@ describe("Table general interaction", () => {
 			await browser.execute(el => el.focus(), checkBoxFirstCell);
 			await checkBoxFirstCell.keys("Enter");
 
-			// test Space over the selection checkbox within each row in MultiSelect mode
+			// test Space over the selection checkbox within each row in Multi selection mode
 			assert.strictEqual(await rowClickCount.getProperty("value"), "2", "Enter key over the selection checkbox should not trigger row-click event");
 			assert.strictEqual(await selectionChangeCount.getProperty("value"), "2", "Enter key over the selection checkbox should trigger selection-change event");
 			assert.strictEqual(await selectedRow.getProperty("value"), "secondRowMultiSelect", "The second row is currently selected");
@@ -422,7 +422,7 @@ describe("Table general interaction", () => {
 			// act
 			await checkBoxFirstCell.keys("Space");
 
-			// test Space key over the selection checkbox of already selected row in MultiSelect mode
+			// test Space key over the selection checkbox of already selected row in Multi selection mode
 			assert.strictEqual(await rowClickCount.getProperty("value"), "2", "Space key over the selection checkbox should not trigger row-click event");
 			assert.strictEqual(await selectionChangeCount.getProperty("value"), "3", "Space key over the selection checkbox of already selected row should trigger selection-change event");
 			assert.strictEqual(await selectedRow.getProperty("value"), "firstRowMultiSelect", "The second row is not selected");
@@ -456,7 +456,7 @@ describe("Table general interaction", () => {
 			assert.strictEqual(await selectionChangeCount.getProperty("value"), "5",  "Enter key over an already selected row should trigger selection-change event");
 		});
 
-		it("test selectAll functionallity in MultiSelect mode", async () => {
+		it("test selectAll functionallity in Multi selection mode", async () => {
 			await browser.url("test/pages/TableSelection.html");
 			const firstRow = await browser.$("#firstRowMultiSelect");
 			const secondRow = await browser.$("#secondRowMultiSelect");
@@ -498,9 +498,9 @@ describe("Table general interaction", () => {
 			// act
 			await firstCellFirstRowLabel.click();
 
-			// Check whether the table's and row's mode property is set correctly, as well as the row type property
-			assert.strictEqual(await table.getProperty("mode"), "None", "The table's mode is None");
-			assert.strictEqual(await firstRow.getProperty("mode"), "None", "The row's mode is None");
+			// Check whether the table's and row's selection-mode property is set correctly, as well as the row type property
+			assert.strictEqual(await table.getProperty("selection-mode"), "None", "The table's selection mode is None");
+			assert.strictEqual(await firstRow.getProperty("selection-mode"), "None", "The row's selection mode is None");
 			assert.strictEqual(await firstRow.getProperty("type"), "Active", "The row's type is Active");
 			assert.strictEqual(await thirdRow.getProperty("type"), "Inactive", "The row's type is Inactive")
 

--- a/packages/playground/_stories/main/Table/Table.stories.ts
+++ b/packages/playground/_stories/main/Table/Table.stories.ts
@@ -27,7 +27,7 @@ const Template: UI5StoryArgs<Table, StoryArgsSlots> = (args) => html`
 	?hide-no-data="${ifDefined(args.hideNoData)}"
 	growing="${ifDefined(args.growing)}"
 	?loading="${ifDefined(args.loading)}"
-	busy-delay="${ifDefined(args.busyDelay)}"
+	loading-delay="${ifDefined(args.loadingDelay)}"
 	?sticky-column-header="${ifDefined(args.stickyColumnHeader)}"
 	selection-mode="${ifDefined(args.selectionMode)}"
 	accessible-name="${ifDefined(args.accessibleName)}"

--- a/packages/playground/_stories/main/Table/Table.stories.ts
+++ b/packages/playground/_stories/main/Table/Table.stories.ts
@@ -8,7 +8,7 @@ import type Table from "@ui5/webcomponents/dist/Table.js";
 import { ifDefined } from "lit-html/directives/if-defined.js";
 import { unsafeHTML } from "lit-html/directives/unsafe-html.js";
 
-import TableMode from "@ui5/webcomponents/dist/types/TableMode.js";
+import TableSelectionMode from "@ui5/webcomponents/dist/types/TableSelectionMode.js";
 import TableGrowingMode from "@ui5/webcomponents/dist/types/TableGrowingMode.js";
 let index = 0;
 
@@ -26,10 +26,10 @@ const Template: UI5StoryArgs<Table, StoryArgsSlots> = (args) => html`
 	growing-button-subtext="${ifDefined(args.growingButtonSubtext)}"
 	?hide-no-data="${ifDefined(args.hideNoData)}"
 	growing="${ifDefined(args.growing)}"
-	?busy="${ifDefined(args.busy)}"
+	?loading="${ifDefined(args.loading)}"
 	busy-delay="${ifDefined(args.busyDelay)}"
 	?sticky-column-header="${ifDefined(args.stickyColumnHeader)}"
-	mode="${ifDefined(args.mode)}"
+	selection-mode="${ifDefined(args.selectionMode)}"
 	accessible-name="${ifDefined(args.accessibleName)}"
 	accessible-name-ref="${ifDefined(args.accessibleNameRef)}"
 >
@@ -51,7 +51,7 @@ Basic.decorators = [
 	}
 ]
 Basic.args = {
-	mode: TableMode.None,
+	selectionMode: TableSelectionMode.None,
 	columns: `
 		<ui5-table-column slot="columns">
 			<span>Product</span>
@@ -370,12 +370,12 @@ GrowingTableMoreButton.decorators = [
 					growingTable${index}.insertAdjacentHTML('beforeend', result);
 				}
 				const loadMore${index} = () => {
-					growingTable${index}.busy = true;
+					growingTable${index}.loading = true;
 					setTimeout(() => {
 						++loads${index};
 						endSliceIndex${index} = sliceIndex${index} + rows${index};
 						init${index}(rows${index});
-						growingTable${index}.busy = false;
+						growingTable${index}.loading = false;
 					}, 1500);
 				}
 				growingTable${index}.addEventListener("load-more", loadMore${index});
@@ -447,7 +447,7 @@ GrowingTableScroll.decorators = [
 				}
 				const growOnScroll${index} = () => {
 					let timeout${index};
-					growingTableScroll${index}.busy = true;
+					growingTableScroll${index}.loading = true;
 					if (timeout${index}) {
 						clearTimeout(timeout${index});
 					}
@@ -455,7 +455,7 @@ GrowingTableScroll.decorators = [
 						loadsScroll${index}++
 						endSliceIndexScroll${index} = sliceIndexScroll${index} + rowsScroll${index};
 						fill${index}(rowsScroll${index});
-						growingTableScroll${index}.busy = false;
+						growingTableScroll${index}.loading = false;
 					}, 1500);
 				}
 				growingTableScroll${index}.addEventListener("load-more", growOnScroll${index});
@@ -473,7 +473,7 @@ GrowingTableScroll.storyName = "Growing on Scroll";
 
 export const GroupingTableSelect= Template.bind({});
 GroupingTableSelect.args = {
-	mode: TableMode.SingleSelect,
+	selectionMode: TableSelectionMode.Single,
 	columns: `
 		<ui5-table-column id="column-1" slot="columns">
 			<ui5-label>City</ui5-label>

--- a/packages/website/docs/_samples/main/Table/GrowingOnButtonPress/main.js
+++ b/packages/website/docs/_samples/main/Table/GrowingOnButtonPress/main.js
@@ -13,7 +13,7 @@ let endSliceIndex = 2;
 
 // Create handler for the "load-more" event
 const loadMore = () => {
-	growingTable.busy = true;
+	growingTable.loading = true;
 
 	setTimeout(() => {
 		endSliceIndex = sliceIndex + rows;
@@ -28,7 +28,7 @@ const loadMore = () => {
 		sliceIndex += rows;
 		growingTable.insertAdjacentHTML('beforeend', result);
 		growingTable.growingButtonSubtext = (++loads * rows) + " of " + products.length;
-		growingTable.busy = false;
+		growingTable.loading = false;
 
 		if (loads == products.length/2) {
 			growingTable.growing = "None"

--- a/packages/website/docs/_samples/main/Table/GrowingOnButtonPress/sample.html
+++ b/packages/website/docs/_samples/main/Table/GrowingOnButtonPress/sample.html
@@ -9,7 +9,7 @@
 <body style="background-color: var(--sapBackgroundColor);">
 <!-- playground-fold-end -->
 
-<ui5-table growing="Button" growing-button-text="Load More" growing-button-subtext="2 of 10" busy-delay="0">
+<ui5-table growing="Button" growing-button-text="Load More" growing-button-subtext="2 of 10" loading-delay="0">
 
     <ui5-table-column slot="columns" popin-display="Inline">
         <span>Product</span>

--- a/packages/website/docs/_samples/main/Table/GrowingOnScroll/main.js
+++ b/packages/website/docs/_samples/main/Table/GrowingOnScroll/main.js
@@ -12,7 +12,7 @@ let endSliceIndex = 2;
 
 // Create handler for the "load-more" event
 const loadMore = () => {
-	growingTable.busy = true;
+	growingTable.loading = true;
 
 	setTimeout(() => {
 		endSliceIndex = sliceIndex + rows;
@@ -27,7 +27,7 @@ const loadMore = () => {
 		sliceIndex += rows;
 		growingTable.insertAdjacentHTML('beforeend', result);
 		growingTable.growingButtonSubtext = (++loads * rows) + " of " + products.length;
-		growingTable.busy = false;
+		growingTable.loading = false;
 
 		if (loads == products.length/2) {
 			growingTable.growing = "None"

--- a/packages/website/docs/_samples/main/Table/GrowingOnScroll/sample.html
+++ b/packages/website/docs/_samples/main/Table/GrowingOnScroll/sample.html
@@ -10,7 +10,7 @@
 <!-- playground-fold-end -->
 
 <div style="height: 200px; overflow: scroll;">
-    <ui5-table growing="Scroll" busy-delay="0">
+    <ui5-table growing="Scroll" loading-delay="0">
         <ui5-table-column slot="columns">
             <span>Product</span>
         </ui5-table-column>

--- a/packages/website/docs/_samples/main/Table/MultipleSelection/sample.html
+++ b/packages/website/docs/_samples/main/Table/MultipleSelection/sample.html
@@ -9,7 +9,7 @@
 <body style="background-color: var(--sapBackgroundColor);">
 <!-- playground-fold-end -->
 
-<ui5-table mode="MultiSelect">
+<ui5-table selection-mode="Multi">
 
     <ui5-table-column slot="columns" popin-display="Inline">
         <span>Product</span>

--- a/packages/website/docs/_samples/main/Table/SingleSelection/sample.html
+++ b/packages/website/docs/_samples/main/Table/SingleSelection/sample.html
@@ -9,7 +9,7 @@
 <body style="background-color: var(--sapBackgroundColor);">
 <!-- playground-fold-end -->
 
-<ui5-table mode="SingleSelect">
+<ui5-table selection-mode="Single">
 
     <ui5-table-column slot="columns" popin-display="Inline">
         <span>Product</span>


### PR DESCRIPTION
Renames the `busy`, `busyDelay` and `mode` properties of `ui5-table`.
Also renames the `TableMode` enum to `TableSelectionMode` as well as its values from `SingleSelect` to `Single` and from `MultiSelect` to `Multi`.

If you have previously used the `busy`, `busyDelay` and `mode` properties and the TableMode enum:
```html
<ui5-table busy busy-delay="0" mode="SingleSelect"></ui5-table>
```
```js
import TableMode from "@ui5/webcomponents/dist/types/TableMode.js";
```

Now use `loading`, `loadingDelay` and `selectionMode` as well as TableSelectionMode enum instead:
```html
<ui5-table loading loading-delay="0" selectionMode="Single"></ui5-table>
```
```js
import TableSelectionMode from "@ui5/webcomponents/dist/types/TableSelectionMode.js";
```

BREAKING CHANGE: The `busy` and `mode` properties as well as the `TableMode` enum and its values have been renamed.

Related to: https://github.com/SAP/ui5-webcomponents/issues/8461