### PR TITLE
chore: test for missing dependencies

### DIFF
--- a/packages/base/src/decorators/customElement.ts
+++ b/packages/base/src/decorators/customElement.ts
@@ -54,9 +54,9 @@ const customElement = (tagNameOrComponentSettings: string | {
 
 		["renderer", "template", "styles", "dependencies"].forEach((customElementEntity: string) => {
 			const customElementEntityValue = tagNameOrComponentSettings[customElementEntity as keyof typeof tag];
-
 			customElementEntityValue && Object.defineProperty(target, customElementEntity, {
-				get: () => customElementEntityValue,
+				// access the property, because it may be dynamic (f.e. "get dependencies" instead of "dependencies") and may return a different result
+				get: () => tagNameOrComponentSettings[customElementEntity as keyof typeof tag],
 			});
 		});
 	};

--- a/packages/fiori/test/specs/BarcodeScannerDialog.spec.js
+++ b/packages/fiori/test/specs/BarcodeScannerDialog.spec.js
@@ -5,6 +5,11 @@ describe("BarcodeScannerDialog Behavior", () => {
 		await browser.url(`test/pages/BarcodeScannerDialog.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-barcode-scanner-dialog");
+	});
+
 	it("fires scan-error when no permissions granted", async () => {
 		// Setup: deny permissions to access the camera
 		await browser.setPermissions({ name: 'camera' }, 'denied');

--- a/packages/fiori/test/specs/DynamicSideContent.spec.js
+++ b/packages/fiori/test/specs/DynamicSideContent.spec.js
@@ -1,6 +1,12 @@
 import { assert } from "chai";
 
 describe("'sideContentPosition' property: ", () => {
+	it ("Checks for missing dependencies", async() => {
+		await browser.url(`test/pages/DynamicSideContent.html`);
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-dynamic-side-content");
+	});
+
 	it("set to 'End'", async () => {
 		await browser.url(`test/pages/DynamicSideContent.html`);
 		const dynamicSideContent = await browser.$("ui5-dynamic-side-content");

--- a/packages/fiori/test/specs/FCL.spec.js
+++ b/packages/fiori/test/specs/FCL.spec.js
@@ -6,6 +6,11 @@ describe("FlexibleColumnLayout Behavior", () => {
 		await browser.url(`test/pages/FCL.html?sap-ui-animationMode=none`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-flexible-column-layout");
+	});
+
 	it("tests Desktop size 1400px", async () => {
 		// act
 		await browser.setWindowSize(1400, 1080);

--- a/packages/fiori/test/specs/IllustratedMessage.spec.js
+++ b/packages/fiori/test/specs/IllustratedMessage.spec.js
@@ -5,6 +5,11 @@ describe("IllustratedMessage 'design' property", () => {
 		await browser.url(`test/pages/IllustratedMessage.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-illustrated-message");
+	});
+
 	it("should return correct design", async () => {
 		// Arrange
 		const illustratedMsg = await browser.$("#illustratedMsg2");

--- a/packages/fiori/test/specs/MediaGallery.spec.js
+++ b/packages/fiori/test/specs/MediaGallery.spec.js
@@ -6,6 +6,11 @@ describe("MediaGallery general interaction", () => {
 		await browser.url(`test/pages/MediaGallery.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies(["ui5-media-gallery", "ui5-media-gallery-item"]);
+	});
+
 	it("fires selection-change on thumbnail click", async () => {
 		const item = await browser.$$("#mGallery2 ui5-media-gallery-item")[1];
 

--- a/packages/fiori/test/specs/NotificationList.spec.js
+++ b/packages/fiori/test/specs/NotificationList.spec.js
@@ -5,6 +5,11 @@ describe("Notification List Item Tests", () => {
 		await browser.url(`test/pages/NotificationList_test_page.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies(["ui5-li-notification", "ui5-li-notification-group"]);
+	});
+
 	it("tests itemClick fired", async () => {
 		const clickInput = await browser.$("#clickInput");
 		const EXPECTED_RESULT = "New order #2201";

--- a/packages/fiori/test/specs/Page.spec.js
+++ b/packages/fiori/test/specs/Page.spec.js
@@ -5,6 +5,11 @@ describe("Page general interaction", () => {
 		await browser.url(`test/pages/Page.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-page");
+	});
+
 	it("tests initial rendering", async () => {
         const page = await browser.$("#page");
         const header = await page.shadow$(".ui5-page-header-root");

--- a/packages/fiori/test/specs/ProductSwitch.spec.js
+++ b/packages/fiori/test/specs/ProductSwitch.spec.js
@@ -5,6 +5,11 @@ describe("ProductSwitch general interaction", async () => {
 		await browser.url(`test/pages/ProductSwitch.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies(["ui5-product-switch", "ui5-product-switch-item"]);
+	});
+
 	it("tests desktopColumns attribute", async () => {
 		const productSwitchFourColumn = await browser.$("#productSwitchFourColumn");
 		const productSwitchThreeColumn = await browser.$("#productSwitchThreeColumn");

--- a/packages/fiori/test/specs/ShellBar.spec.js
+++ b/packages/fiori/test/specs/ShellBar.spec.js
@@ -24,6 +24,11 @@ describe("Component Behavior", () => {
 		await browser.url(`test/pages/ShellBar.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-shellbar");
+	});
+
 	describe("Accessibility", () => {
 		it("tests accessibilityTexts property", async () => {
 			const PROFILE_BTN_CUSTOM_TOOLTIP = "John Dow";

--- a/packages/fiori/test/specs/SideNavigation.spec.js
+++ b/packages/fiori/test/specs/SideNavigation.spec.js
@@ -23,6 +23,11 @@ describe("Component Behavior", () => {
 		await browser.url(`test/pages/SideNavigation.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies(["ui5-side-navigation", "ui5-side-navigation-item", "ui5-side-navigation-sub-item", "ui5-side-navigation-group"]);
+	});
+
 	describe("Main functionality", async () => {
 		it("Tests selection-change event", async () => {
 			const input = await browser.$("#counter");

--- a/packages/fiori/test/specs/SideNavigation.spec.js
+++ b/packages/fiori/test/specs/SideNavigation.spec.js
@@ -25,7 +25,7 @@ describe("Component Behavior", () => {
 
 	it ("Checks for missing dependencies", async() => {
 		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
-		await checkMissingDependencies(["ui5-side-navigation", "ui5-side-navigation-item", "ui5-side-navigation-sub-item", "ui5-side-navigation-group"]);
+		await checkMissingDependencies(["ui5-side-navigation", "ui5-side-navigation-item", "ui5-side-navigation-sub-item"]);
 	});
 
 	describe("Main functionality", async () => {

--- a/packages/fiori/test/specs/SideNavigationWithGroups.spec.js
+++ b/packages/fiori/test/specs/SideNavigationWithGroups.spec.js
@@ -6,6 +6,11 @@ describe("Component Behavior", () => {
 		await browser.url(`test/pages/SideNavigationWithGroups.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies(["ui5-side-navigation", "ui5-side-navigation-item", "ui5-side-navigation-sub-item", "ui5-side-navigation-group"]);
+	});
+
 	describe("Main functionality", async () => {
 		it("rendering", async () => {
 			const sideNavigation = await browser.$("#sn1");

--- a/packages/fiori/test/specs/Timeline.spec.js
+++ b/packages/fiori/test/specs/Timeline.spec.js
@@ -5,6 +5,11 @@ describe("Timeline general interaction", () => {
 		await browser.url(`test/pages/Timeline.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies(["ui5-timeline", "ui5-timeline-item"]);
+	});
+
 	it("should fire name-click event on a normal item name", async () => {
 		const timelineItemName = await browser.$("ui5-timeline-item").shadow$("ui5-link");
 		const result = await browser.$("#result");

--- a/packages/fiori/test/specs/UploadCollection.spec.js
+++ b/packages/fiori/test/specs/UploadCollection.spec.js
@@ -6,6 +6,11 @@ describe("UploadCollection", () => {
 			await browser.url(`test/pages/UploadCollection.html`);
 		});
 
+		it ("Checks for missing dependencies", async() => {
+			const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+			await checkMissingDependencies(["ui5-upload-collection", "ui5-upload-collection-item"]);
+		});
+
 		it("should show Link when 'fileNameClickable'", async () => {
 			const firstItem = await browser.$("#firstItem");
 			assert.ok(await firstItem.shadow$("ui5-link").isDisplayed(), "Link should be rendered");

--- a/packages/fiori/test/specs/ViewSettingsDialog.spec.js
+++ b/packages/fiori/test/specs/ViewSettingsDialog.spec.js
@@ -5,6 +5,11 @@ describe("ViewSettingsDialog general interaction", () => {
 		await browser.url(`test/pages/ViewSettingsDialog.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-view-settings-dialog");
+	});
+
 	it("test ViewSettingsDialog initial value", async () => {
 		const btnOpenDialog = await browser.$("#btnOpenDialog");
 		const viewSettingsDialog = await browser.$("#vsd");

--- a/packages/fiori/test/specs/Wizard.spec.js
+++ b/packages/fiori/test/specs/Wizard.spec.js
@@ -5,6 +5,11 @@ describe("Wizard general interaction", () => {
 		await browser.url(`test/pages/Wizard_test.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies(["ui5-wizard", "ui5-wizard-tab"]);
+	});
+
 	it("test initial state", async () => {
 		const wiz = await browser.$("#wizTest");
 		const step1 = await browser.$("#st1");

--- a/packages/main/src/MultiComboBox.ts
+++ b/packages/main/src/MultiComboBox.ts
@@ -73,8 +73,6 @@ import StandardListItem from "./StandardListItem.js";
 import ToggleButton from "./ToggleButton.js";
 import * as Filters from "./Filters.js";
 import Button from "./Button.js";
-import Input, { InputEventDetail } from "./Input.js";
-import SuggestionItem from "./SuggestionItem.js";
 import {
 	VALUE_STATE_SUCCESS,
 	VALUE_STATE_ERROR,
@@ -106,6 +104,8 @@ import ComboBoxFilter from "./types/ComboBoxFilter.js";
 import type FormSupportT from "./features/InputElementsFormSupport.js";
 import type ListItemBase from "./ListItemBase.js";
 import CheckBox from "./CheckBox.js";
+import Input, { InputEventDetail } from "./Input.js";
+import SuggestionItem from "./SuggestionItem.js";
 import PopoverHorizontalAlign from "./types/PopoverHorizontalAlign.js";
 
 /**

--- a/packages/main/src/MultiComboBox.ts
+++ b/packages/main/src/MultiComboBox.ts
@@ -73,6 +73,8 @@ import StandardListItem from "./StandardListItem.js";
 import ToggleButton from "./ToggleButton.js";
 import * as Filters from "./Filters.js";
 import Button from "./Button.js";
+import Input, { InputEventDetail } from "./Input.js";
+import SuggestionItem from "./SuggestionItem.js";
 import {
 	VALUE_STATE_SUCCESS,
 	VALUE_STATE_ERROR,
@@ -104,7 +106,6 @@ import ComboBoxFilter from "./types/ComboBoxFilter.js";
 import type FormSupportT from "./features/InputElementsFormSupport.js";
 import type ListItemBase from "./ListItemBase.js";
 import CheckBox from "./CheckBox.js";
-import Input, { InputEventDetail } from "./Input.js";
 import PopoverHorizontalAlign from "./types/PopoverHorizontalAlign.js";
 
 /**
@@ -198,6 +199,8 @@ type MultiComboboxItemWithSelection = {
 		ToggleButton,
 		Button,
 		CheckBox,
+		Input,
+		SuggestionItem,
 	],
 })
 /**

--- a/packages/main/src/MultiComboBox.ts
+++ b/packages/main/src/MultiComboBox.ts
@@ -1851,7 +1851,7 @@ class MultiComboBox extends UI5Element {
 	get _innerInput(): HTMLInputElement {
 		if (isPhone()) {
 			if (this._getRespPopover()?.open) {
-				return this._getRespPopover().querySelector("ui5-input")!.shadowRoot!.querySelector("input")!;
+				return this._getRespPopover().querySelector("[ui5-input]")!.shadowRoot!.querySelector("input")!;
 			}
 		}
 

--- a/packages/main/src/MultiInput.ts
+++ b/packages/main/src/MultiInput.ts
@@ -67,6 +67,7 @@ type MultiInputTokenDeleteEventDetail = {
 	get dependencies() {
 		return [
 			...Input.dependencies,
+			Input,
 			Tokenizer,
 			Token,
 			Icon,

--- a/packages/main/src/MultiInput.ts
+++ b/packages/main/src/MultiInput.ts
@@ -64,12 +64,14 @@ type MultiInputTokenDeleteEventDetail = {
 	renderer: litRender,
 	template: MultiInputTemplate,
 	styles: [Input.styles, styles],
-	dependencies: [
-		...Input.dependencies,
-		Tokenizer,
-		Token,
-		Icon,
-	],
+	get dependencies() {
+		return [
+			...Input.dependencies,
+			Tokenizer,
+			Token,
+			Icon,
+		];
+	},
 })
 /**
  * Fired when the value help icon is pressed

--- a/packages/main/src/TimeSelectionClocks.ts
+++ b/packages/main/src/TimeSelectionClocks.ts
@@ -25,6 +25,7 @@ import TimePickerInternals from "./TimePickerInternals.js";
 import TimePickerClock from "./TimePickerClock.js";
 import ToggleSpinButton from "./ToggleSpinButton.js";
 import SegmentedButton from "./SegmentedButton.js";
+import SegmentedButtonItem from "./SegmentedButtonItem.js";
 import type { TimePickerClockChangeEventDetail } from "./TimePickerClock.js";
 
 // Template
@@ -64,6 +65,7 @@ import TimeSelectionClocksCss from "./generated/themes/TimeSelectionClocks.css.j
 		TimePickerClock,
 		ToggleSpinButton,
 		SegmentedButton,
+		SegmentedButtonItem,
 	],
 })
 

--- a/packages/main/test/specs/Avatar.spec.js
+++ b/packages/main/test/specs/Avatar.spec.js
@@ -5,6 +5,11 @@ describe("Avatar", () => {
 		await browser.url(`test/pages/Avatar.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-avatar");
+	});
+
 	it("tests rendering of image", async () => {
 		const avatar = await browser.$("#myAvatar1");
 		const image = await avatar.shadow$('slot:not([name="badge"])');

--- a/packages/main/test/specs/AvatarGroup.spec.js
+++ b/packages/main/test/specs/AvatarGroup.spec.js
@@ -18,6 +18,11 @@ describe("avatar-group rendering", () => {
 		await browser.url(`test/pages/AvatarGroup.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-avatar-group");
+	});
+
 	it("tests if web component is correctly rendered", async () => {
 		const avatarGroupIndividual = await browser.$("#avatar-group-individual").shadow$("div");
 		const avatarGroupGroup = await browser.$("#avatar-group-group").shadow$("div");

--- a/packages/main/test/specs/Badge.spec.js
+++ b/packages/main/test/specs/Badge.spec.js
@@ -5,6 +5,11 @@ describe("Badge rendering", async () => {
 		await browser.url(`test/pages/Badge.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-badge");
+	});
+
 	it("rendering", async () => {
 		let badgeRoot = await browser.$("#badgeWithTextAndIcon").shadow$(".ui5-badge-root");
 		assert.strictEqual(await badgeRoot.getTagName(), "div", "badge root tag is 'div'.");

--- a/packages/main/test/specs/Breadcrumbs.spec.js
+++ b/packages/main/test/specs/Breadcrumbs.spec.js
@@ -12,6 +12,11 @@ describe("Breadcrumbs general interaction", () => {
 		await browser.url(`test/pages/Breadcrumbs.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-breadcrumbs");
+	});
+
 	it("tests getDomRef", async () => {
 		const res = await browser.executeAsync(async (done) => {
 			const breadCrumbsItemOutOfOverflow = document.getElementById("lastItemWithACCName");

--- a/packages/main/test/specs/BusyIndicator.spec.js
+++ b/packages/main/test/specs/BusyIndicator.spec.js
@@ -6,6 +6,11 @@ describe("BusyIndicator general interaction", () => {
 		await browser.url(`test/pages/BusyIndicator.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-busy-indicator");
+	});
+
 	it("tests event propagation", async () => {
 		const dynamicItem = await browser.$(">>>#busy-tree [ui5-tree-item] ui5-icon.ui5-li-tree-toggle-icon");
 		const input = await browser.$("#tree-input");

--- a/packages/main/test/specs/Button.spec.js
+++ b/packages/main/test/specs/Button.spec.js
@@ -5,6 +5,11 @@ describe("Button general interaction", () => {
 		await browser.url(`test/pages/Button.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-button");
+	});
+
 	it("tests button's text rendering", async () => {
 		const slotsLength = (await browser.$("#button1").shadow$$(".ui5-button-text>bdi>slot")).length;
 

--- a/packages/main/test/specs/Calendar.spec.js
+++ b/packages/main/test/specs/Calendar.spec.js
@@ -7,7 +7,7 @@ describe("Calendar general interaction", () => {
 
 	it ("Checks for missing dependencies", async() => {
 		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
-		await checkMissingDependencies(["ui5-calendar", "ui5-year-picker", "ui5-month-picker", "ui5-day-picker"]);
+		await checkMissingDependencies(["ui5-calendar", "ui5-calendar-header", "ui5-yearpicker", "ui5-monthpicker", "ui5-daypicker"]);
 	});
 
 	it("Calendar is rendered", async () => {

--- a/packages/main/test/specs/Calendar.spec.js
+++ b/packages/main/test/specs/Calendar.spec.js
@@ -5,6 +5,11 @@ describe("Calendar general interaction", () => {
 		await browser.url(`test/pages/Calendar.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies(["ui5-calendar", "ui5-year-picker", "ui5-month-picker", "ui5-day-picker"]);
+	});
+
 	it("Calendar is rendered", async () => {
 		const calendar = await browser.$("#calendar1").shadow$(".ui5-cal-root");
 
@@ -366,7 +371,7 @@ describe("Calendar general interaction", () => {
 
 		const calendar = await browser.$("#calendar6");
 		await calendar.setAttribute("max-date", new Date(Date.UTC(2024, 9, 4, 0, 0, 0)).toISOString().split("T")[0]); // sets the max date to 2024-10-04
-		
+
 		const yearButton = await calendar.shadow$("ui5-calendar-header").shadow$(`div[data-ui5-cal-header-btn-year]`);
 		await yearButton.click();
 

--- a/packages/main/test/specs/CalendarLegend.spec.js
+++ b/packages/main/test/specs/CalendarLegend.spec.js
@@ -5,6 +5,11 @@ describe("Calendar Legend with standard items", () => {
 		await browser.url(`test/pages/CalendarLegend.html`);
 	})
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies(["ui5-calendar-legend", "ui5-calendar-legend-item"]);
+	});
+
 	it("Calendar Legend is rendered", async () => {
 		const legend = await browser.$("#calendarLegend").shadow$(".ui5-calendar-legend-root");
 
@@ -14,10 +19,10 @@ describe("Calendar Legend with standard items", () => {
 	it("Calendar Legend items are rendered", async () => {
 		const legend = await browser.$("#calendarLegend").shadow$(".ui5-calendar-legend-root");
 		const items = await legend.$$("ui5-calendar-legend-item");
-	
+
 		assert.strictEqual(items.length, 4, "Calendar Legend items are rendered");
 	});
-	
+
 
 	it("Calendar legend hides Today, when hideToday property provided", async () => {
 		const legend = await browser.$("#calendarLegend");

--- a/packages/main/test/specs/Card.spec.js
+++ b/packages/main/test/specs/Card.spec.js
@@ -5,6 +5,11 @@ describe("Card general interaction", () => {
 		await browser.url(`test/pages/Card.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies(["ui5-card", "ui5-card-header"]);
+	});
+
 	it("tests initial rendering", async () => {
 		const card = await browser.$("#card");
 

--- a/packages/main/test/specs/Carousel.spec.js
+++ b/packages/main/test/specs/Carousel.spec.js
@@ -5,6 +5,11 @@ describe("Carousel general interaction", () => {
 		await browser.url(`test/pages/Carousel.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-carousel");
+	});
+
 	it("rendering", async () => {
 		const carouselRoot = await browser.$("#carousel1").shadow$(".ui5-carousel-root");
 		const carousel = await browser.$("#carousel1");

--- a/packages/main/test/specs/CheckBox.spec.js
+++ b/packages/main/test/specs/CheckBox.spec.js
@@ -9,6 +9,11 @@ describe("CheckBox general interaction", () => {
 		await browser.url(`test/pages/CheckBox.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-checkbox");
+	});
+
 	it("tests checked default value is false", async () => {
 		const checkBox = await browser.$("#cb1");
 

--- a/packages/main/test/specs/ColorPalette.spec.js
+++ b/packages/main/test/specs/ColorPalette.spec.js
@@ -5,6 +5,11 @@ describe("ColorPalette interactions", () => {
 		await browser.url(`test/pages/ColorPalette.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies(["ui5-color-palette", "ui5-color-palette-item"]);
+	});
+
 	it("Test if selecting element works", async () => {
 		await browser.url(`test/pages/ColorPalette.html`);
 		const colorPalette = await browser.$("#cp1");

--- a/packages/main/test/specs/ColorPalettePopover.spec.js
+++ b/packages/main/test/specs/ColorPalettePopover.spec.js
@@ -19,6 +19,9 @@ describe("ColorPalette interactions", () => {
 		// assert - default btn is focused
 		assert.ok(await defaultButton.matches(":focus"),  "The first element is focused");
 
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-color-palette-popover");
+
 		// act - close popover
 		await defaultButton.click();
 	});

--- a/packages/main/test/specs/ColorPicker.spec.js
+++ b/packages/main/test/specs/ColorPicker.spec.js
@@ -5,6 +5,11 @@ describe("Color Picker general interaction", () => {
 		await browser.url(`test/pages/ColorPicker.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-color-picker");
+	});
+
 	it("tests color picker rendering", async () => {
 		const circle = await browser.$("#cp1").shadow$(".ui5-color-picker-circle");
 

--- a/packages/main/test/specs/ComboBox.mobile.spec.js
+++ b/packages/main/test/specs/ComboBox.mobile.spec.js
@@ -20,6 +20,9 @@ describe("Basic mobile picker rendering and interaction", () => {
 
 		const dialogOkButton = await combo.shadow$("ui5-responsive-popover").$(".ui5-responsive-popover-footer").$("ui5-button");
 		assert.ok(await dialogOkButton.isDisplayed(), "Ok button is displayed");
+
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-combobox");
 	});
 
 	it("Should close the mobile picker dialog when pressing the close button", async () => {

--- a/packages/main/test/specs/ComboBox.spec.js
+++ b/packages/main/test/specs/ComboBox.spec.js
@@ -13,6 +13,9 @@ describe("General interaction", () => {
 
 		await arrow.click();
 
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-combobox");
+
 		assert.ok(await popover.getProperty("open"), "Popover should be displayed")
 	});
 

--- a/packages/main/test/specs/DatePicker.spec.js
+++ b/packages/main/test/specs/DatePicker.spec.js
@@ -6,6 +6,11 @@ describe("Date Picker Tests", () => {
 		await datepicker.open();
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-date-picker");
+	});
+
 	it("input renders", async () => {
 		datepicker.id = "#dp";
 

--- a/packages/main/test/specs/DateRangePicker.spec.js
+++ b/packages/main/test/specs/DateRangePicker.spec.js
@@ -5,6 +5,11 @@ describe("DateRangePicker general interaction", () => {
 		await browser.url(`test/pages/DateRangePicker.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-daterange-picker");
+	});
+
 	it("Custom Validation Error", async () => {
 		const daterangepicker = await browser.$("#daterange-picker3");
 

--- a/packages/main/test/specs/DateTimePicker.spec.js
+++ b/packages/main/test/specs/DateTimePicker.spec.js
@@ -55,6 +55,11 @@ describe("DateTimePicker general interaction", () => {
 		await browser.url(`test/pages/DateTimePicker.html?sap-ui-language=en`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies(["ui5-datetime-picker", "ui5-time-selection-clocks", "ui5-toggle-spin-button"]);
+	});
+
 	it("tests picker opens/closes programmatically", async () => {
 		// act
 		await openPickerById("dt");

--- a/packages/main/test/specs/DateTimePicker.spec.js
+++ b/packages/main/test/specs/DateTimePicker.spec.js
@@ -57,7 +57,7 @@ describe("DateTimePicker general interaction", () => {
 
 	it ("Checks for missing dependencies", async() => {
 		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
-		await checkMissingDependencies(["ui5-datetime-picker", "ui5-time-selection-clocks", "ui5-toggle-spin-button"]);
+		await checkMissingDependencies("ui5-datetime-picker");
 	});
 
 	it("tests picker opens/closes programmatically", async () => {

--- a/packages/main/test/specs/Dialog.spec.js
+++ b/packages/main/test/specs/Dialog.spec.js
@@ -5,6 +5,11 @@ describe("Dialog general interaction", () => {
 		await browser.url(`test/pages/Dialog.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-dialog");
+	});
+
 	it("tests dialog toggling", async () => {
 		const btnOpenDialog = await browser.$("#btnOpenDialog");
 		const btnCloseDialog= await browser.$("#btnCloseDialog");

--- a/packages/main/test/specs/FileUploader.spec.js
+++ b/packages/main/test/specs/FileUploader.spec.js
@@ -5,6 +5,11 @@ describe("API", () => {
 		await browser.url(`test/pages/FileUploader.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-file-uploader");
+	});
+
 	it("Files property", async () => {
 		const fileUploader = await browser.$("ui5-file-uploader");
 		assert.ok(await fileUploader.getProperty("files"), "Property 'files' should return FileList with 0 files.")

--- a/packages/main/test/specs/Input.mobile.spec.js
+++ b/packages/main/test/specs/Input.mobile.spec.js
@@ -8,7 +8,7 @@ describe("Basic mobile picker rendering and interaction", () => {
 
 	it ("Checks for missing dependencies", async() => {
 		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
-		await checkMissingDependencies("ui5-input");
+		await checkMissingDependencies("ui5-input", ["ui5-input"]);
 	});
 
 	it("Should render properly the mobile picker", async () => {

--- a/packages/main/test/specs/Input.mobile.spec.js
+++ b/packages/main/test/specs/Input.mobile.spec.js
@@ -6,6 +6,11 @@ describe("Basic mobile picker rendering and interaction", () => {
 		await browser.emulateDevice('iPhone X');
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-input");
+	});
+
 	it("Should render properly the mobile picker", async () => {
 		const input = await browser.$("#myInput2");
 

--- a/packages/main/test/specs/Input.spec.js
+++ b/packages/main/test/specs/Input.spec.js
@@ -5,6 +5,11 @@ describe("Attributes propagation", () => {
 		await browser.url(`test/pages/Input.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-input");
+	});
+
 	it("Should change the placeholder of the inner input", async () => {
 		const input = await browser.$("#myInput");
 		const sExpected = "New placeholder text";

--- a/packages/main/test/specs/Label.spec.js
+++ b/packages/main/test/specs/Label.spec.js
@@ -5,6 +5,11 @@ describe("General API", () => {
 		await browser.url(`test/pages/Label.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-label");
+	});
+
 	it("tests initial rendering", async () => {
 		const labelRoot = await browser.$("#basic-label").shadow$(".ui5-label-root");
 

--- a/packages/main/test/specs/Link.spec.js
+++ b/packages/main/test/specs/Link.spec.js
@@ -10,6 +10,11 @@ describe("General API", () => {
 		await browser.url(`test/pages/Link.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-link");
+	});
+
 	it("render initially", async () => {
 		const linkRoot = await browser.$("ui5-link").shadow$("ui5-link-root");
 

--- a/packages/main/test/specs/List.spec.js
+++ b/packages/main/test/specs/List.spec.js
@@ -25,6 +25,11 @@ describe("List Tests", () => {
 		await browser.url(`test/pages/List_test_page.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies(["ui5-list", "ui5-li", "ui5-li-custom", "ui5-li-group", "ui5-li-group-header"]);
+	});
+
 	it("List is rendered", async () => {
 		const list = await browser.$("#infiniteScrollEx").shadow$(".ui5-list-root");
 		const loadingInd = await browser.$("#infiniteScrollEx").shadow$(".ui5-list-loading-row");

--- a/packages/main/test/specs/Menu.spec.js
+++ b/packages/main/test/specs/Menu.spec.js
@@ -78,6 +78,11 @@ describe("Menu interaction", () => {
 
 		assert.strictEqual(await submenuList.$$("ui5-menu").length, 2,
 								"Two sub-menus are present");
+
+		// Do the dependency checks after the menu/submenus are open
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-menu", ["ui5-menu", "ui5-menu-item"]); // ui5-menu and ui5-menu-item can appear in the shadow root even though they are not dependencies
+		await checkMissingDependencies("ui5-menu-li");
 	});
 
 	it("Event firing after 'click' on menu item", async () => {

--- a/packages/main/test/specs/MessageStrip.spec.js
+++ b/packages/main/test/specs/MessageStrip.spec.js
@@ -5,6 +5,11 @@ describe("MessageStrip general interaction", () => {
 		await browser.url(`test/pages/MessageStrip.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-message-strip");
+	});
+
 	it("tests close event", async () => {
 
 		const closeButton = await browser.$("#messageStrip").shadow$(".ui5-message-strip-close-button");

--- a/packages/main/test/specs/MultiComboBox.mobile.spec.js
+++ b/packages/main/test/specs/MultiComboBox.mobile.spec.js
@@ -6,6 +6,11 @@ describe("Basic interaction", () => {
 		await browser.emulateDevice('iPhone X');
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-multi-combobox");
+	});
+
 	it("Should render properly the mobile picker", async () => {
 		const multiCombo = await browser.$("#multi1");
 

--- a/packages/main/test/specs/MultiComboBox.spec.js
+++ b/packages/main/test/specs/MultiComboBox.spec.js
@@ -5,6 +5,11 @@ describe("MultiComboBox general interaction", () => {
 		await browser.url(`test/pages/MultiComboBox.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-multi-combobox");
+	});
+
 	describe("toggling", () => {
 		it("opens/closes", async () => {
 			const icon = await $("#multi1").shadow$("[input-icon]");

--- a/packages/main/test/specs/MultiInput.mobile.spec.js
+++ b/packages/main/test/specs/MultiInput.mobile.spec.js
@@ -6,6 +6,11 @@ describe("MultiInput general interaction", () => {
 		await browser.emulateDevice('iPhone X');
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-multi-input");
+	});
+
 	it ("n-more picker dialog is properly rendered", async () => {
 		const mi = await browser.$("#multiInput-warning");
 		const tokenizer = await mi.shadow$("ui5-tokenizer");

--- a/packages/main/test/specs/MultiInput.spec.js
+++ b/packages/main/test/specs/MultiInput.spec.js
@@ -5,6 +5,11 @@ describe("MultiInput general interaction", () => {
 		await browser.url(`test/pages/MultiInput.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-multi-input");
+	});
+
 	it("tests expanding of tokenizer", async () => {
 		const basic = await browser.$("#basic-overflow");
 		const basicInner = await basic.shadow$("input");

--- a/packages/main/test/specs/Panel.spec.js
+++ b/packages/main/test/specs/Panel.spec.js
@@ -5,6 +5,11 @@ describe("Panel general interaction", () => {
 		await browser.url(`test/pages/Panel.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-panel");
+	});
+
 	it("Changing the header text is reflected", async () => {
 		const panel = await browser.$( "#panel-fixed");
 		const title = await panel.shadow$(".ui5-panel-header-title");
@@ -199,7 +204,7 @@ describe("Panel general interaction", () => {
 			const fixedPanelHeader = await fixedPanel.shadow$(".ui5-panel-header");
 			const fixedPanelHeaderTitle = await fixedPanel.shadow$(".ui5-panel-header-title");
 			const fixedPanelHeaderTitleId = await fixedPanelHeaderTitle.getProperty("id");
-			
+
 
 			assert.strictEqual(await nativeHeader.getAttribute("aria-labelledby"),
 				`${panelWithNativeHeaderId}-header-title`, "aria-labelledby is correct");

--- a/packages/main/test/specs/Popover.spec.js
+++ b/packages/main/test/specs/Popover.spec.js
@@ -5,6 +5,11 @@ describe("Attributes propagation", () => {
 		await browser.url(`test/pages/Popover.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-popover");
+	});
+
 	it("Header text attribute is propagated", async () => {
 		const popover = await browser.$("#pop");
 		const selector = "h2=New text";

--- a/packages/main/test/specs/ProgressIndicator.spec.js
+++ b/packages/main/test/specs/ProgressIndicator.spec.js
@@ -5,6 +5,11 @@ describe("API", () => {
 		await browser.url(`test/pages/ProgressIndicator.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-progress-indicator");
+	});
+
 	it("tests value validation", async () => {
 		const progressIndicator = await browser.$("#test-progress-indicator");
 		const negativeButton = await browser.$("#sixthBtn");

--- a/packages/main/test/specs/RadioButton.spec.js
+++ b/packages/main/test/specs/RadioButton.spec.js
@@ -5,6 +5,11 @@ describe("Rendering", () => {
 		await browser.url(`test/pages/RadioButton.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-radio-button");
+	});
+
 	it("DOM structure", async () => {
 		const radioButtonRoot = await browser.$("#testRbtn1").shadow$(".ui5-radio-root");
 		const radioButtonInput = await browser.$("#testRbtn1").shadow$("input");
@@ -238,7 +243,7 @@ describe("RadioButton general interaction", () => {
 		assert.strictEqual(await radioButtonsShadowRoots[1].getAttribute("tabindex"), "-1", `second radio button has tabindex="-1"`);
 		assert.strictEqual(await radioButtonsShadowRoots[2].getAttribute("tabindex"), "-1", `third radio button has tabindex="-1"`);
 	});
-	
+
 	it("tests form interaction", async () => {
 		const rb = await browser.$("#formRadioBtnRequired");
 		let validForm = await browser.executeAsync(done => {

--- a/packages/main/test/specs/RangeSlider.spec.js
+++ b/packages/main/test/specs/RangeSlider.spec.js
@@ -6,6 +6,9 @@ describe("Testing Range Slider interactions", () => {
 		await browser.url(`test/pages/RangeSlider.html`);
 		await browser.setWindowSize(1257, 2000);
 
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-range-slider");
+
 		const rangeSlider = await browser.$("#range-slider-tickmarks");
 		const startHandle = await rangeSlider.shadow$(".ui5-slider-handle--start");
 

--- a/packages/main/test/specs/RatingIndicator.spec.js
+++ b/packages/main/test/specs/RatingIndicator.spec.js
@@ -6,6 +6,11 @@ describe("Rating Indicator general interaction", () => {
 		await browser.url(`test/pages/RatingIndicator.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-rating-indicator");
+	});
+
 	it("Tests basic rating indicator rendering", async () => {
 		const ratingIndicator = await browser.$("#rating-indicator1");
 

--- a/packages/main/test/specs/ResponsivePopover.mobile.spec.js
+++ b/packages/main/test/specs/ResponsivePopover.mobile.spec.js
@@ -6,6 +6,11 @@ describe("ResponsivePopover mobile general interaction", () => {
 		await browser.url(`test/pages/ResponsivePopover.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-responsive-popover");
+	});
+
 	it("tests opening a popover from a responsive popover", async () => {
 		const btnOpenRP = await browser.$("#btnRpWithPopover");
 

--- a/packages/main/test/specs/ResponsivePopover.spec.js
+++ b/packages/main/test/specs/ResponsivePopover.spec.js
@@ -5,6 +5,11 @@ describe("ResponsivePopover general interaction", () => {
 		await browser.url(`test/pages/ResponsivePopover.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-responsive-popover");
+	});
+
 	it("header and footer are displayed by default", async () => {
 		const btnOpenPopover = await browser.$("#btnOpen");
 		const btnClosePopover = await browser.$("#btnClose");

--- a/packages/main/test/specs/SegmentedButton.spec.js
+++ b/packages/main/test/specs/SegmentedButton.spec.js
@@ -7,7 +7,7 @@ describe("SegmentedButton general interaction", () => {
 
 	it ("Checks for missing dependencies", async() => {
 		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
-		await checkMissingDependencies(["segmented-button", "segmented-button-item"]);
+		await checkMissingDependencies(["ui5-segmented-button", "ui5-segmented-button-item"]);
 	});
 
 	it("tests if pressed and tooltip attributes are applied", async () => {

--- a/packages/main/test/specs/SegmentedButton.spec.js
+++ b/packages/main/test/specs/SegmentedButton.spec.js
@@ -5,6 +5,11 @@ describe("SegmentedButton general interaction", () => {
 		await browser.url(`test/pages/SegmentedButton.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies(["segmented-button", "segmented-button-item"]);
+	});
+
 	it("tests if pressed and tooltip attributes are applied", async () => {
 		const segmentedButtonItem =  await browser.$("#segButton1 > ui5-segmented-button-item:first-child");
 		const segmentedButtonItemInner = await segmentedButtonItem.shadow$(".ui5-button-root");

--- a/packages/main/test/specs/Select.mobile.spec.js
+++ b/packages/main/test/specs/Select.mobile.spec.js
@@ -6,6 +6,11 @@ describe("Select mobile general interaction", () => {
 		await browser.url(`test/pages/Select.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-select");
+	});
+
 	it("Changes selection in Dialog", async () => {
 		// assert default
 		const select = await browser.$("#mySelect");

--- a/packages/main/test/specs/Select.spec.js
+++ b/packages/main/test/specs/Select.spec.js
@@ -18,6 +18,11 @@ describe("Select general interaction", () => {
 		await browser.url(`test/pages/Select.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-select");
+	});
+
 	it("fires change on selection", async () => {
 		const select = await browser.$("#mySelect");
 		const selectText = await browser.$("#mySelect").shadow$(".ui5-select-label-root");

--- a/packages/main/test/specs/Slider.spec.js
+++ b/packages/main/test/specs/Slider.spec.js
@@ -8,6 +8,9 @@ describe("Slider basic interactions", () => {
 		const slider = await browser.$("#basic-slider");
 		const sliderHandle = await slider.shadow$(".ui5-slider-handle");
 
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-slider");
+
 		assert.strictEqual((await sliderHandle.getCSSProperty("left")).value, "0px", "Initially if no value is set, the Slider handle is at the beginning of the Slider");
 
 		await browser.setWindowSize(1257, 2000);
@@ -109,7 +112,7 @@ describe("Properties synchronization and normalization", () => {
 		assert.strictEqual((await slider.getProperty("_labels"))[0], "-20", "Initial slider start label is -20.");
 		assert.strictEqual((await slider.getProperty("_labels"))[labelLength - 1], "20", "Initial slider end label is 20.");
 
-		// simulate the synchronous update of min and max made programatically 
+		// simulate the synchronous update of min and max made programatically
 		await browser.executeAsync(done => {
 			const slider = document.getElementById("slider-tickmarks-labels");
 			slider.min = 0;

--- a/packages/main/test/specs/SplitButton.spec.js
+++ b/packages/main/test/specs/SplitButton.spec.js
@@ -3,6 +3,10 @@ import { assert } from "chai";
 describe("Split Button general interaction", () => {
 	it("tests inner buttons design", async () => {
 		await browser.url(`test/pages/SplitButton.html`);
+
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-split-button");
+
 		const sbDefault = await browser.$("#sbDefault");
 		const design = await sbDefault.getAttribute("design");
 		const textButton = await sbDefault.shadow$(".ui5-split-text-button");

--- a/packages/main/test/specs/StepInput.spec.js
+++ b/packages/main/test/specs/StepInput.spec.js
@@ -4,6 +4,10 @@ describe("Attributes propagation", () => {
 
 	it("'placeholder' attribute is propagated properly", async () => {
 		await browser.url(`test/pages/StepInput.html`);
+
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-step-input");
+
 		const siCozy = await browser.$("#stepInputCozy");
 		const sExpected = "New placeholder text";
 

--- a/packages/main/test/specs/Switch.spec.js
+++ b/packages/main/test/specs/Switch.spec.js
@@ -5,6 +5,11 @@ describe("Switch general interaction", async () => {
 		await browser.url(`test/pages/Switch.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-switch");
+	});
+
 	it("tests change event", async () => {
 		const switchEl = await browser.$("#sw");
 		const field = await browser.$("#field");

--- a/packages/main/test/specs/TabContainer.mobile.spec.js
+++ b/packages/main/test/specs/TabContainer.mobile.spec.js
@@ -6,6 +6,11 @@ describe("Mobile: TabContainer general interaction", () => {
 		await browser.emulateDevice("iPhone X");
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies(["ui5-tabcontainer", "ui5-tab"]);
+	});
+
 	it("should close the overflow popover when pressing the cancel button", async () => {
 		const tc = await browser.$("#tabContainerNestedTabs");
 		const moreButton = await tc.shadow$(`[data-ui5-stable="overflow-end"]`);

--- a/packages/main/test/specs/TabContainer.spec.js
+++ b/packages/main/test/specs/TabContainer.spec.js
@@ -8,7 +8,7 @@ describe("TabContainer general interaction", () => {
 
 	it ("Checks for missing dependencies", async() => {
 		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
-		await checkMissingDependencies(["ui5-tab-container", "ui5-tab"]);
+		await checkMissingDependencies(["ui5-tabcontainer", "ui5-tab"]);
 	});
 
 	it("tests initially selected tab", async () => {

--- a/packages/main/test/specs/TabContainer.spec.js
+++ b/packages/main/test/specs/TabContainer.spec.js
@@ -6,6 +6,11 @@ describe("TabContainer general interaction", () => {
 		await browser.url(`test/pages/TabContainer.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies(["ui5-tab-container", "ui5-tab"]);
+	});
+
 	it("tests initially selected tab", async () => {
 		const tabContainer = await browser.$("#tabContainer1");
 		const selectedTab = await tabContainer.$("[selected]");
@@ -481,7 +486,7 @@ describe("TabContainer drag and drop tests", () => {
 	const moveElementById = (items, id1, id2, targetPosition) => {
 		const findAndExecute = (items, matcher, cb) => {
 			const index = items.findIndex(matcher);
-			
+
 			if (index !== -1) {
 				cb(items, index);
 				return;
@@ -646,5 +651,5 @@ describe("TabContainer drag and drop tests", () => {
 		// close the popover
 		await tabContainer.getEndOverflow("tabContainerDnd").click();
 	});
-	
+
 });

--- a/packages/main/test/specs/Table.spec.js
+++ b/packages/main/test/specs/Table.spec.js
@@ -5,6 +5,11 @@ describe("Table general interaction", () => {
 		await browser.url(`test/pages/Table.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies(["ui5-table", "ui5-table-column", "ui5-table-row", "ui5-table-cell"]);
+	});
+
 	it("tests if column disapears when min-width is reacted (650px)", async () => {
 		const btn = await browser.$("#size-btn-650");
 		const headerTableRow = await browser.$("#tbl").shadow$("thead tr");

--- a/packages/main/test/specs/TableGrouping.spec.js
+++ b/packages/main/test/specs/TableGrouping.spec.js
@@ -5,6 +5,11 @@ describe("Table general interaction", () => {
 		await browser.url(`test/pages/TableGrouping.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies(["ui5-table", "ui5-table-column", "ui5-table-row", "ui5-table-group-row", "ui5-table-cell"]);
+	});
+
 	it("Table group rows should be rendered", async () => {
 		const groupRows = await browser.$$("ui5-table-group-row");
 		assert.strictEqual(groupRows.length, 4, "There should be 4 group rows rendered.");

--- a/packages/main/test/specs/Text.spec.js
+++ b/packages/main/test/specs/Text.spec.js
@@ -5,6 +5,11 @@ describe("Text", () => {
 		await browser.url("test/pages/Text.html");
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-text");
+	});
+
 	it("tests root element is bdi", async () => {
 		const rootElement = await browser.$("#text1").shadow$(":first-child");
 

--- a/packages/main/test/specs/TextArea.spec.js
+++ b/packages/main/test/specs/TextArea.spec.js
@@ -8,6 +8,11 @@ describe("Attributes propagation", () => {
 		await browser.url(`test/pages/TextArea.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-textarea");
+	});
+
 	it("Should change the placeholder of the inner textarea", async () => {
 		const textarea = await browser.$("#basic-textarea");
 		const sExpected = "New placeholder text";

--- a/packages/main/test/specs/TimePicker.mobile.spec.js
+++ b/packages/main/test/specs/TimePicker.mobile.spec.js
@@ -25,6 +25,12 @@ describe("TimePicker on phone - general interactions", () => {
 		await browser.emulateDevice('iPhone X');
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies(["ui5-time-picker", "ui5-time-selection-clocks", "ui5-time-picker-clock", "ui5-toggle-spin-button"]);
+	});
+
+
 	it("opening of popover with numeric inputs", async () => {
 		const timePicker = await browser.$("#timepicker");
 		const timePickerPopover = await timePicker.shadow$("ui5-popover");

--- a/packages/main/test/specs/TimePicker.spec.js
+++ b/packages/main/test/specs/TimePicker.spec.js
@@ -5,6 +5,11 @@ describe("TimePicker general interaction", () => {
 		await browser.url(`test/pages/TimePicker.html?sap-ui-language=bg`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies(["ui5-time-picker", "ui5-time-selection-clocks"]);
+	});
+
 	it("input receives value in format pattern depending on the set language", async () => {
 		const timepicker = await browser.$("#timepickerSetTime");
 		const setTimeButton = await browser.$("#setTimeButton");

--- a/packages/main/test/specs/TimePicker.spec.js
+++ b/packages/main/test/specs/TimePicker.spec.js
@@ -7,7 +7,7 @@ describe("TimePicker general interaction", () => {
 
 	it ("Checks for missing dependencies", async() => {
 		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
-		await checkMissingDependencies(["ui5-time-picker", "ui5-time-selection-clocks"]);
+		await checkMissingDependencies(["ui5-time-picker", "ui5-time-selection-clocks", "ui5-toggle-spin-button"]);
 	});
 
 	it("input receives value in format pattern depending on the set language", async () => {

--- a/packages/main/test/specs/TimePicker.spec.js
+++ b/packages/main/test/specs/TimePicker.spec.js
@@ -7,7 +7,7 @@ describe("TimePicker general interaction", () => {
 
 	it ("Checks for missing dependencies", async() => {
 		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
-		await checkMissingDependencies(["ui5-time-picker", "ui5-time-selection-clocks", "ui5-toggle-spin-button"]);
+		await checkMissingDependencies(["ui5-time-picker", "ui5-time-selection-clocks", "ui5-time-picker-clock", "ui5-toggle-spin-button"]);
 	});
 
 	it("input receives value in format pattern depending on the set language", async () => {

--- a/packages/main/test/specs/TimePickerClock.spec.js
+++ b/packages/main/test/specs/TimePickerClock.spec.js
@@ -5,6 +5,11 @@ describe("Clock API", () => {
 		await browser.url(`test/pages/TimePickerClock.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies(["ui5-time-picker", "ui5-time-selection-clocks", "ui5-toggle-spin-button"]);
+	});
+
 	it("'disabled' property", async () => {
 		const hours12 = await browser.$("#myHours12");
 		const hours12Disabled = await browser.$("#myHours12Disabled");

--- a/packages/main/test/specs/TimePickerClock.spec.js
+++ b/packages/main/test/specs/TimePickerClock.spec.js
@@ -7,7 +7,7 @@ describe("Clock API", () => {
 
 	it ("Checks for missing dependencies", async() => {
 		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
-		await checkMissingDependencies(["ui5-time-selection-clocks", "ui5-toggle-spin-button"]);
+		await checkMissingDependencies(["ui5-time-picker-clock"]);
 	});
 
 	it("'disabled' property", async () => {

--- a/packages/main/test/specs/TimePickerClock.spec.js
+++ b/packages/main/test/specs/TimePickerClock.spec.js
@@ -7,7 +7,7 @@ describe("Clock API", () => {
 
 	it ("Checks for missing dependencies", async() => {
 		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
-		await checkMissingDependencies(["ui5-time-picker", "ui5-time-selection-clocks", "ui5-toggle-spin-button"]);
+		await checkMissingDependencies(["ui5-time-selection-clocks", "ui5-toggle-spin-button"]);
 	});
 
 	it("'disabled' property", async () => {

--- a/packages/main/test/specs/TimeSelectionClocks.spec.js
+++ b/packages/main/test/specs/TimeSelectionClocks.spec.js
@@ -5,6 +5,11 @@ describe("Interactions", () => {
 		await browser.url(`test/pages/TimeSelectionClocks.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies(["ui5-time-selection-clocks", "ui5-time-picker-clock", "ui5-toggle-spin-button"]);
+	});
+
 	it("switch active clock", async () => {
 		const clocksComponent = await browser.$("#myClocks");
 		const clocks = await clocksComponent.shadow$$("ui5-time-picker-clock");

--- a/packages/main/test/specs/Title.spec.js
+++ b/packages/main/test/specs/Title.spec.js
@@ -5,6 +5,11 @@ describe("Rendering", () => {
 		await browser.url(`test/pages/Title.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-title");
+	});
+
 	it("h{n} tags rendered correctly", async () => {
 		const titleH1 = await browser.$("#titleH1").shadow$(".ui5-title-root").getHTML();
 		const titleH2 = await browser.$("#titleH2").shadow$(".ui5-title-root").getHTML();

--- a/packages/main/test/specs/Toast.spec.js
+++ b/packages/main/test/specs/Toast.spec.js
@@ -8,6 +8,11 @@ describe("Toast general interaction", () => {
 		await browser.url(`test/pages/Toast.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-toast");
+	});
+
 	it("tests open attribute before show", async () => {
 		const toast = await browser.$("#wcToastME");
 

--- a/packages/main/test/specs/ToggleButton.spec.js
+++ b/packages/main/test/specs/ToggleButton.spec.js
@@ -5,6 +5,11 @@ describe("ToggleButton general interaction", () => {
 		await browser.url(`test/pages/ToggleButton.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies("ui5-toggle-button");
+	});
+
 	it("should fire click event on a normal togglebutton", async () => {
 		const toggleButton = await browser.$("#toggle-button");
 		const result = await browser.$("#click-result");

--- a/packages/main/test/specs/Toolbar.spec.js
+++ b/packages/main/test/specs/Toolbar.spec.js
@@ -5,6 +5,11 @@ describe("Toolbar general interaction", () => {
 		await browser.url(`test/pages/Toolbar.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies(["ui5-toolbar", "ui5-toolbar-button", "ui5-toolbar-select", "ui5-toolbar-select-option", "ui5-toolbar-spacer", "ui5-toolbar-separator"]);
+	});
+
 	it("Should move button with alwaysOverflow priority to overflow popover", async () => {
 
 		const otb = await browser.$("#otb_d");

--- a/packages/main/test/specs/Tree.spec.js
+++ b/packages/main/test/specs/Tree.spec.js
@@ -23,6 +23,11 @@ describe("Tree general interaction", () => {
 		await browser.url(`test/pages/Tree.html`);
 	});
 
+	it ("Checks for missing dependencies", async() => {
+		const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
+		await checkMissingDependencies(["ui5-tree", "ui5-tree-item", "ui5-tree-item-custom"]);
+	});
+
 	it("Tree is rendered", async () => {
 		const treeRoot = await browser.$("#tree").shadow$("ui5-tree-list");
 		assert.ok(await treeRoot.isExisting(), "Tree is rendered.");
@@ -235,7 +240,7 @@ describe("Tree drag and drop tests", () => {
 			...await draggedElement.getLocation(),
 			...await draggedElement.getSize()
 		};
-		
+
 		const dropTargetElementRectangle = {
 			...await dropTargetElement.getLocation(),
 			...await dropTargetElement.getSize()

--- a/packages/tools/lib/scoping/lint-src.js
+++ b/packages/tools/lib/scoping/lint-src.js
@@ -16,7 +16,7 @@ glob.sync(path.join(process.cwd(), "src/**/*.css")).forEach(file => {
 	});
 });
 
-glob.sync(path.join(process.cwd(), "src/**/*.js")).forEach(file => {
+glob.sync(path.join(process.cwd(), "src/**/*.ts")).forEach(file => {
 	let content = String(fs.readFileSync(file));
 	tags.forEach(tag => {
 		if (content.match(new RegExp(`querySelector[A-Za-z]*..${tag}`, "g"))) {

--- a/packages/tools/util/wdio.mjs
+++ b/packages/tools/util/wdio.mjs
@@ -8,6 +8,9 @@ const checkMissingDependencies = async (tags, tagsToIgnore) => {
 	for (const tagIndex in tags) {
 		const tag = tags[tagIndex];
 		const elements = await browser.$$(`>>>${tag}`);
+		if (elements.length === 0) {
+			assert.notOk(true, `No elements found on the test page for ${tag}`);
+		}
 		for (let i = 0; i < elements.length; i++) {
 			const missing = await elements[i].getMissingDependencies(tagsToIgnore);
 			if (missing.length === 0) {

--- a/packages/tools/util/wdio.mjs
+++ b/packages/tools/util/wdio.mjs
@@ -1,0 +1,22 @@
+import { assert } from "chai";
+
+const checkMissingDependencies = async (tags, tagsToIgnore) => {
+	if (Array.isArray(tags) && tags.length > 1 && Array.isArray(tagsToIgnore) && tagsToIgnore.length > 0) {
+		throw new Error(`tagsToIgnore is only allowed if you call checkMissingDependencies for a single tag`);
+	}
+	tags = Array.isArray(tags) ? tags : [tags];
+	for (const tagIndex in tags) {
+		const tag = tags[tagIndex];
+		const elements = await browser.$$(`>>>${tag}`);
+		for (let i = 0; i < elements.length; i++) {
+			const missing = await elements[i].getMissingDependencies(tagsToIgnore);
+			if (missing.length === 0) {
+				assert.ok(true,`${tag} has no missing dependencies.`);
+			} else {
+				assert.notOk(true, `${tag} has missing dependencies: ${missing.join(", ")}`);
+			}
+		}
+	}
+}
+
+export { checkMissingDependencies };


### PR DESCRIPTION
WIP

Changes:
 - Added a custom *element-level* `wdio.js` command called `getMissingDependencies`

Usage:

```js
const button = await browser.$("#myButton");
await button.getMissingDependencies();
```

The command checks all custom elements, found in the shadow root of the component, and returns an array containing those that are not in `static get dependencies`.

- Added a utility `@ui5/webcomponents-tools/util/wdio.mjs` that makes it easier for component developers to test their whole test pages automatically.

Usage:

```js
it ("Checks for missing dependencies", async() => {
	const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
	await checkMissingDependencies("ui5-panel");
});
```

This will find all `ui5-panel` instances throughout the whole page, **even ones in shadow roots**, and will report missing dependencies.

Can also be used for several tags at a time, for example:

```js
it ("Checks for missing dependencies", async() => {
	const { checkMissingDependencies } = await import("@ui5/webcomponents-tools/util/wdio.mjs");
	await checkMissingDependencies(["ui5-calendar", "ui5-year-picker", "ui5-month-picker", "ui5-day-picker"]);
});
```

 - It's also possible to ignore some tags in very special cases (f.e. `ui5-menu` can contain in its shadow root tags that are not its dependencies, because they are added imperatively, and not by `lit-html` (see `Menu.spec.js`)

 - For some components it's best to call the utility after interaction with the test page, so that the shadow root has more components.
