### PR TITLE
refactor(ui5-li, ui5-list): changes accessibleRole type

### DIFF
--- a/packages/main/src/List.hbs
+++ b/packages/main/src/List.hbs
@@ -35,7 +35,7 @@
 
 		<ul id="{{_id}}-listUl"
 			class="ui5-list-ul"
-			role="{{_accessibleRole}}"
+			role="{{listAccessibleRole}}"
 			aria-label="{{ariaLabelTxt}}"
 			aria-labelledby="{{ariaLabelledBy}}"
 			aria-roledescription="{{accessibleRoleDescription}}"

--- a/packages/main/src/List.hbs
+++ b/packages/main/src/List.hbs
@@ -35,7 +35,7 @@
 
 		<ul id="{{_id}}-listUl"
 			class="ui5-list-ul"
-			role="{{accessibleRole}}"
+			role="{{_accessibleRole}}"
 			aria-label="{{ariaLabelTxt}}"
 			aria-labelledby="{{ariaLabelledBy}}"
 			aria-roledescription="{{accessibleRoleDescription}}"

--- a/packages/main/src/List.ts
+++ b/packages/main/src/List.ts
@@ -39,6 +39,7 @@ import type {
 } from "./ListItem.js";
 import ListSeparators from "./types/ListSeparators.js";
 import BusyIndicator from "./BusyIndicator.js";
+import ListAccessibleRole from "./types/ListAccessibleRole.js";
 
 // Template
 import ListTemplate from "./generated/templates/ListTemplate.lit.js";
@@ -402,8 +403,8 @@ class List extends UI5Element {
 	 * @default "list"
 	 * @since 1.0.0-rc.15
 	 */
-	@property({ defaultValue: "list" })
-	accessibleRole!: string;
+	@property({ type: ListAccessibleRole, defaultValue: ListAccessibleRole.List })
+	accessibleRole!: `${ListAccessibleRole}`;
 
 	/**
 	 * Defines the description for the accessible role of the component.

--- a/packages/main/src/List.ts
+++ b/packages/main/src/List.ts
@@ -689,6 +689,10 @@ class List extends UI5Element {
 		};
 	}
 
+	get _accessibleRole() {
+		return this.accessibleRole.toLowerCase();
+	}
+
 	get classes(): ClassMap {
 		return {
 			root: {

--- a/packages/main/src/List.ts
+++ b/packages/main/src/List.ts
@@ -689,7 +689,7 @@ class List extends UI5Element {
 		};
 	}
 
-	get _accessibleRole() {
+	get listAccessibleRole() {
 		return this.accessibleRole.toLowerCase();
 	}
 

--- a/packages/main/src/ListItem.ts
+++ b/packages/main/src/ListItem.ts
@@ -213,7 +213,7 @@ abstract class ListItem extends ListItemBase {
 	 * @since 1.3.0
 	 *
 	 */
-	@property({ type: ListItemAccessibleRole, defaultValue: ListItemAccessibleRole.ListItem })
+	@property({ type: ListItemAccessibleRole })
 	accessibleRole!: `${ListItemAccessibleRole}`;
 
 	@property({ type: ListSelectionMode, defaultValue: ListSelectionMode.None })
@@ -480,6 +480,10 @@ abstract class ListItem extends ListItemBase {
 		return undefined;
 	}
 
+	get _accessibleRole() {
+		return this.accessibleRole.toLowerCase();
+	}
+
 	get ariaSelectedText() {
 		let ariaSelectedText;
 
@@ -514,7 +518,7 @@ abstract class ListItem extends ListItemBase {
 
 	get _accInfo(): AccInfo {
 		return {
-			role: this.accessibleRole || this.role,
+			role: this._accessibleRole || this.role,
 			ariaExpanded: undefined,
 			ariaLevel: undefined,
 			ariaLabel: ListItem.i18nBundle.getText(ARIA_LABEL_LIST_ITEM_CHECKBOX),

--- a/packages/main/src/ListItem.ts
+++ b/packages/main/src/ListItem.ts
@@ -480,8 +480,8 @@ abstract class ListItem extends ListItemBase {
 		return undefined;
 	}
 
-	get _accessibleRole() {
-		return this.accessibleRole.toLowerCase();
+	get listItemAccessibleRole() {
+		return this.accessibleRole?.toLowerCase();
 	}
 
 	get ariaSelectedText() {
@@ -518,7 +518,7 @@ abstract class ListItem extends ListItemBase {
 
 	get _accInfo(): AccInfo {
 		return {
-			role: this._accessibleRole || this.role,
+			role: this.listItemAccessibleRole || this.role,
 			ariaExpanded: undefined,
 			ariaLevel: undefined,
 			ariaLabel: ListItem.i18nBundle.getText(ARIA_LABEL_LIST_ITEM_CHECKBOX),

--- a/packages/main/src/ListItem.ts
+++ b/packages/main/src/ListItem.ts
@@ -27,6 +27,7 @@ import {
 	LIST_ITEM_SELECTED,
 	LIST_ITEM_NOT_SELECTED,
 } from "./generated/i18n/i18n-defaults.js";
+import ListItemAccessibleRole from "./types/ListItemAccessibleRole.js";
 
 // Styles
 import styles from "./generated/themes/ListItem.css.js";
@@ -212,8 +213,8 @@ abstract class ListItem extends ListItemBase {
 	 * @since 1.3.0
 	 *
 	 */
-	@property()
-	accessibleRole!: string;
+	@property({ type: ListItemAccessibleRole, defaultValue: ListItemAccessibleRole.ListItem })
+	accessibleRole!: `${ListItemAccessibleRole}`;
 
 	@property({ type: ListSelectionMode, defaultValue: ListSelectionMode.None })
 	_selectionMode!: `${ListSelectionMode}`;

--- a/packages/main/src/Menu.hbs
+++ b/packages/main/src/Menu.hbs
@@ -53,7 +53,7 @@
 			?loading="{{loading}}"
 			loading-delay="{{loadingDelay}}"
 			separators="None"
-			accessible-role="menu"
+			accessible-role="Menu"
 			@ui5-item-click={{_itemClick}}
 			@mouseover="{{_loadingMouseOver}}"
 		>
@@ -64,7 +64,7 @@
 				id="{{../_id}}-menu-item-{{@index}}"
 				.icon="{{this.item.icon}}"
 				accessible-name={{this.item.ariaLabelledByText}}
-				accessible-role="menuitem"
+				accessible-role="MenuItem"
 				.additionalText="{{this.item._additionalText}}"
 				tooltip="{{this.item.tooltip}}"
 				selected="{{this.item.subMenuOpened}}"

--- a/packages/main/src/NavigationMenu.hbs
+++ b/packages/main/src/NavigationMenu.hbs
@@ -47,7 +47,7 @@
 	>
 	{{#if _currentItems.length}}
 		<ui5-list
-			accessible-role="tree"
+			accessible-role="Tree"
 			id="{{_id}}-menu-list"
 			selection-mode="None"
 			?loading="{{loading}}"
@@ -63,7 +63,7 @@
 					id="{{../_id}}-menu-item-{{@index}}"
 					.icon="{{this.item.icon}}"
 					accessible-name={{this.item.ariaLabelledByText}}
-					accessible-role="none"
+					accessible-role="None"
 					.additionalText="{{this.item._additionalText}}"
 					.ariaHasPopup={{this.ariaHasPopup}}
 					?disabled={{this.item.disabled}}
@@ -104,7 +104,7 @@
 					id="{{../_id}}-menu-item-{{@index}}"
 					.icon="{{this.item.icon}}"
 					accessible-name={{this.item.ariaLabelledByText}}
-					accessible-role="treeitem"
+					accessible-role="TreeItem"
 					.additionalText="{{this.item._additionalText}}"
 					.ariaHasPopup={{this.ariaHasPopup}}
 					?disabled={{this.item.disabled}}

--- a/packages/main/src/Tree.ts
+++ b/packages/main/src/Tree.ts
@@ -336,7 +336,7 @@ class Tree extends UI5Element {
 	}
 
 	get _role() {
-		return "tree";
+		return "Tree";
 	}
 
 	get _label() {

--- a/packages/main/src/types/ListAccessibleRole.ts
+++ b/packages/main/src/types/ListAccessibleRole.ts
@@ -1,0 +1,27 @@
+/**
+ * List accessible roles.
+ * @public
+ */
+enum ListAccessibleRole {
+
+	/**
+	 * Represents the ARIA role "list". (by default)
+	 * @public
+	 */
+	List = "List",
+
+	/**
+	 * Represents the ARIA role "menu".
+	 * @public
+	 */
+	Menu = "Menu",
+
+	/**
+	 * Represents the ARIA role "tree".
+	 * @public
+	 */
+	Tree = "Tree"
+
+}
+
+export default ListAccessibleRole;

--- a/packages/main/src/types/ListAccessibleRole.ts
+++ b/packages/main/src/types/ListAccessibleRole.ts
@@ -8,19 +8,25 @@ enum ListAccessibleRole {
 	 * Represents the ARIA role "list". (by default)
 	 * @public
 	 */
-	List = "List",
+	List = "list",
 
 	/**
 	 * Represents the ARIA role "menu".
 	 * @public
 	 */
-	Menu = "Menu",
+	Menu = "menu",
 
 	/**
 	 * Represents the ARIA role "tree".
 	 * @public
 	 */
-	Tree = "Tree"
+	Tree = "tree",
+
+	/**
+	 * Represents the ARIA role "listbox".
+	 * @public
+	 */
+	Listbox = "listbox"
 
 }
 

--- a/packages/main/src/types/ListAccessibleRole.ts
+++ b/packages/main/src/types/ListAccessibleRole.ts
@@ -8,25 +8,25 @@ enum ListAccessibleRole {
 	 * Represents the ARIA role "list". (by default)
 	 * @public
 	 */
-	List = "list",
+	List = "List",
 
 	/**
 	 * Represents the ARIA role "menu".
 	 * @public
 	 */
-	Menu = "menu",
+	Menu = "Menu",
 
 	/**
 	 * Represents the ARIA role "tree".
 	 * @public
 	 */
-	Tree = "tree",
+	Tree = "Tree",
 
 	/**
 	 * Represents the ARIA role "listbox".
 	 * @public
 	 */
-	Listbox = "listbox"
+	ListBox = "ListBox"
 
 }
 

--- a/packages/main/src/types/ListItemAccessibleRole.ts
+++ b/packages/main/src/types/ListItemAccessibleRole.ts
@@ -1,0 +1,33 @@
+/**
+ * ListItem accessible roles.
+ * @public
+ */
+enum ListItemAccessibleRole {
+
+	/**
+	 * Represents the ARIA role "listitem". (by default)
+	 * @public
+	 */
+	ListItem = "ListItem",
+
+	/**
+	 * Represents the ARIA role "menuitem".
+	 * @public
+	 */
+	MenuItem = "MenuItem",
+
+	/**
+	 * Represents the ARIA role "treeitem".
+	 * @public
+	 */
+	TreeItem = "TreeItem",
+
+	/**
+	 * Represents the ARIA role "none".
+	 * @public
+	 */
+	None = "None"
+
+}
+
+export default ListItemAccessibleRole;

--- a/packages/main/src/types/ListItemAccessibleRole.ts
+++ b/packages/main/src/types/ListItemAccessibleRole.ts
@@ -8,31 +8,31 @@ enum ListItemAccessibleRole {
 	 * Represents the ARIA role "listitem". (by default)
 	 * @public
 	 */
-	ListItem = "listitem",
+	ListItem = "ListItem",
 
 	/**
 	 * Represents the ARIA role "menuitem".
 	 * @public
 	 */
-	MenuItem = "menuitem",
+	MenuItem = "MenuItem",
 
 	/**
 	 * Represents the ARIA role "treeitem".
 	 * @public
 	 */
-	TreeItem = "treeitem",
+	TreeItem = "TreeItem",
 
 	/**
 	 * Represents the ARIA role "option".
 	 * @public
 	 */
-	Option = "option",
+	Option = "Option",
 
 	/**
 	 * Represents the ARIA role "none".
 	 * @public
 	 */
-	None = "none"
+	None = "None"
 
 }
 

--- a/packages/main/src/types/ListItemAccessibleRole.ts
+++ b/packages/main/src/types/ListItemAccessibleRole.ts
@@ -8,25 +8,31 @@ enum ListItemAccessibleRole {
 	 * Represents the ARIA role "listitem". (by default)
 	 * @public
 	 */
-	ListItem = "ListItem",
+	ListItem = "listitem",
 
 	/**
 	 * Represents the ARIA role "menuitem".
 	 * @public
 	 */
-	MenuItem = "MenuItem",
+	MenuItem = "menuitem",
 
 	/**
 	 * Represents the ARIA role "treeitem".
 	 * @public
 	 */
-	TreeItem = "TreeItem",
+	TreeItem = "treeitem",
+
+	/**
+	 * Represents the ARIA role "option".
+	 * @public
+	 */
+	Option = "option",
 
 	/**
 	 * Represents the ARIA role "none".
 	 * @public
 	 */
-	None = "None"
+	None = "none"
 
 }
 


### PR DESCRIPTION
Changes the type of `accessibleRole` property  for both `ui5-li` and `ui5-list`.

The `accessibleRole` property for both `ui5-li` and `ui5-list` has been updated from a string type to an enum type. 
Additionally, the new enums `ListItemAccessibleRole` and `ListAccessibleRole` have been introduced for these properties respectively.

Related to https://github.com/SAP/ui5-webcomponents/issues/8461, https://github.com/SAP/ui5-webcomponents/issues/7887