### PR TITLE
chore: respect hyphenated class members in cem

### DIFF
--- a/packages/tools/lib/cem/custom-elements-manifest.config.mjs
+++ b/packages/tools/lib/cem/custom-elements-manifest.config.mjs
@@ -117,7 +117,7 @@ function processClass(ts, classNode, moduleDoc) {
 	// Slots (with accessor), methods and fields
 	for (let i = 0; i < (currClass.members?.length || 0); i++) {
 		const member = currClass.members[i];
-		const classNodeMember = classNode.members?.find(nodeMember => nodeMember.name?.text === member?.name && nodeMember.jsDoc?.[0]);
+		const classNodeMember = classNode.members?.find(nodeMember => nodeMember.name?.text === member?.name.replace(/^"(.*)"$/, "$1") && nodeMember.jsDoc?.[0]);
 		const classNodeMemberJSdoc = classNodeMember?.jsDoc?.[0];
 
 		if (!classNodeMember || !classNodeMemberJSdoc) continue;


### PR DESCRIPTION
Classes with a hyphenated member (e.g. "header-row") or a string member are not correctly handled by the custom elements manifest.

If these types of members exist and are used as either slot or property, they are not respected as such, as the cem is not able to find a corresponding classNodeMember. This is due to the following:
- member.name contains the unescaped member name, e.g. "header-row"
- classNodeMember.name contains the escaped member name, e.g. header-row

As there is a mismatch, slot assignment is completely skipped.

We've observed this problem in the new Web Component Table (Grid), where one of our members is hyphenated. You can see the problem in the documentation [here](https://donkeyco.github.io/ui5-webcomponents/components/Grid/#header-row).

Solved by removing member.name's quotation marks, when comparing.