### PR TITLE
fix(ui5-input, ui5-multi-input): fire change event properly on mobile devices

### DIFF
--- a/packages/main/src/Input.ts
+++ b/packages/main/src/Input.ts
@@ -1137,6 +1137,13 @@ class Input extends UI5Element implements SuggestionComponent, IFormInputElement
 
 	_closePicker() {
 		this.open = false;
+		this._handleChange();
+	}
+
+	_cancelChange() {
+		this.open = false;
+		this._changeToBeFired = false;
+		this.value = this.previousValue;
 	}
 
 	_afterOpenPicker() {
@@ -1236,6 +1243,7 @@ class Input extends UI5Element implements SuggestionComponent, IFormInputElement
 			// value might change in the change event handler
 			this.typedInValue = this.value;
 			this.previousValue = this.value;
+			this._changeToBeFired = false;
 		}
 
 		this.valueBeforeSelectionStart = "";

--- a/packages/main/src/InputPopover.hbs
+++ b/packages/main/src/InputPopover.hbs
@@ -22,7 +22,7 @@
 					class="ui5-responsive-popover-close-btn"
 					icon="decline"
 					design="Transparent"
-					@click="{{_closePicker}}"
+					@click="{{_cancelChange}}"
 				>
 				</ui5-button>
 			</div>
@@ -35,7 +35,6 @@
 						?show-clear-icon={{showClearIcon}}
 						placeholder="{{placeholder}}"
 						@ui5-input="{{_handleInput}}"
-						@ui5-change="{{_handleChange}}"
 					></ui5-input>
 				</div>
 			</div>

--- a/packages/main/test/pages/MultiInput.html
+++ b/packages/main/test/pages/MultiInput.html
@@ -288,6 +288,8 @@
 			<ui5-suggestion-item text="excepteur"></ui5-suggestion-item>
 		</ui5-multi-input>
 
+		<ui5-input id="suggestion-token-counter" type="Number" value="0"></ui5-input>
+
 		<ui5-dialog id="dialog" header-text="Add Competency">
 
 			<ui5-list id="tokens-list">
@@ -445,6 +447,8 @@
 		});
 
 		document.getElementById("suggestion-token").addEventListener("ui5-change", function (event) {
+			document.querySelector("#suggestion-token-counter").value++;
+
 			var text = event.target.value;
 
 			addTokenToMI(createTokenFromText(text), "suggestion-token");

--- a/packages/main/test/pages/MultiInput_Suggestions.html
+++ b/packages/main/test/pages/MultiInput_Suggestions.html
@@ -32,6 +32,8 @@
 			<ui5-suggestion-item text="excepteur"></ui5-suggestion-item>
 		</ui5-multi-input>
 
+		<ui5-input id="suggestion-token-counter" type="Number" value="0"></ui5-input>
+
 		<ui5-dialog id="dialog" header-text="Add Competency">
 
 			<ui5-list id="tokens-list">
@@ -95,6 +97,10 @@
 			});
 
 			document.getElementById("dialog").open = true;
+		});
+
+		document.getElementById("suggestion-token").addEventListener("ui5-change", () => {
+			document.getElementById("suggestion-token-counter").value++;
 		});
 
 		document.getElementById("suggestion-token").addEventListener("ui5-selection-change", function (event) {

--- a/packages/main/test/specs/MultiInput.mobile.spec.js
+++ b/packages/main/test/specs/MultiInput.mobile.spec.js
@@ -1,0 +1,42 @@
+import { assert } from "chai";
+
+describe("MultiInput events", () => {
+	before(async () => {
+		await browser.emulateDevice('iPhone X');
+	});
+
+	it("Selecting an item from the suggestion list fires change event only once", async () => {
+		await browser.url(`test/pages/MultiInput.html`);
+
+		const mi = await browser.$("#suggestion-token");
+
+		await mi.scrollIntoView();
+		await mi.click();
+		await mi.keys("A");
+
+		await mi.$$("ui5-suggestion-item")[0].click();
+
+		const counter = await browser.$("#suggestion-token-counter");
+
+		//assert
+		assert.strictEqual(await counter.getValue(), "1", "The change event is fired once");
+	});
+
+	it("Cancelling input does not fire a change event", async () => {
+		await browser.url(`test/pages/MultiInput_Suggestions.html`);
+
+		const mi = await browser.$("#suggestion-token");
+
+		await mi.click();
+		await mi.keys("A");
+
+		const popover = await mi.shadow$("ui5-responsive-popover");
+		const closeButton = popover.$(".ui5-responsive-popover-close-btn");
+		await closeButton.click();
+
+		const counter = await browser.$("#suggestion-token-counter");
+
+		//assert
+		assert.strictEqual(await counter.getValue(), "0", "The change event is not fired");
+	});
+});

--- a/packages/main/test/specs/MultiInput.mobile.spec.js
+++ b/packages/main/test/specs/MultiInput.mobile.spec.js
@@ -1,0 +1,41 @@
+import { assert } from "chai";
+
+describe("MultiInput events", () => {
+	before(async () => {
+		await browser.emulateDevice('iPhone X');
+	});
+
+	it("Selecting an item from the suggestion list fires change event only once", async () => {
+		await browser.url(`test/pages/MultiInput.html`);
+
+		const mi = await browser.$("#suggestion-token");
+
+		await mi.scrollIntoView();
+		await mi.click();
+		await mi.keys("A");
+
+		await mi.$$("ui5-suggestion-item")[0].click();
+
+		const counter = await browser.$("#suggestion-token-counter");
+
+		//assert
+		assert.strictEqual(await counter.getValue(), "1", "The change event is fired once");
+	});
+
+	it("Cancelling input does not fire a change event", async () => {
+		await browser.url(`test/pages/MultiInput_Suggestions.html`);
+
+		const mi = await browser.$("#suggestion-token");
+
+		await mi.click();
+		await mi.keys("A");
+
+		const closeButton = await mi.shadow$("ui5-responsive-popover").$(".ui5-responsive-popover-close-btn");
+		await  closeButton.click();
+
+		const counter = await browser.$("#suggestion-token-counter");
+
+		//assert
+		assert.strictEqual(await counter.getValue(), "0", "The change event is not fired");
+	});
+});


### PR DESCRIPTION
Fire change event only once when a user selects a suggestion. 
Do not fire change event if the user closes the suggestions dialog from the "x" button. 

Fixes #9453

