### PR TITLE
fix(ui5-table): remove focus outline for selection cell

### DIFF
--- a/packages/main/src/themes/TableRowBase.css
+++ b/packages/main/src/themes/TableRowBase.css
@@ -26,9 +26,15 @@
 }
 
 /** Focus outline for the selection cell */
-:host([tabindex]:focus) #selection-cell {
+:host([tabindex]:focus) #selection-cell:not(:has(~ #popin-cell)) {
     outline: none;
     box-shadow: var(--_ui5_table_shadow_border_top),
 				var(--_ui5_table_shadow_border_left),
 				var(--_ui5_table_shadow_border_bottom); /* There is a 1px difference between row and cell, therefore the outline is also 1px difference between their outline offsets */
+}
+
+:host([tabindex]:focus) #selection-cell:has(~ #popin-cell) {
+    outline: none;
+    box-shadow: var(--_ui5_table_shadow_border_top),
+				var(--_ui5_table_shadow_border_left);
 }

--- a/packages/main/test/pages/Table.html
+++ b/packages/main/test/pages/Table.html
@@ -23,7 +23,7 @@
 			label-interval="0"></ui5-slider>
 	</ui5-bar>
 
-	<ui5-table id="table" overflow-mode="Scroll" accessible-name-ref="title">
+	<ui5-table id="table" overflow-mode="Popin" accessible-name-ref="title">
 		<ui5-table-growing id="growing" type="Scroll" slot="features"></ui5-table-growing>
 		<ui5-table-selection id="selection" selected="0 2" slot="features"></ui5-table-selection>
 		<ui5-table-header-row slot="headerRow" sticky>


### PR DESCRIPTION
When a popin exists and a row is focused, the selection cell shows a bottom-border, which should not be the case.