### PR TITLE
chore(ui5-side-navigation): improve selection

### DIFF
--- a/packages/fiori/src/SideNavigation.ts
+++ b/packages/fiori/src/SideNavigation.ts
@@ -602,7 +602,7 @@ class SideNavigation extends UI5Element {
 	}
 
 	_selectItem(item: SideNavigationSelectableItemBase) {
-		if (item.disabled) {
+		if (item.disabled || !item.canBeSelected) {
 			return;
 		}
 

--- a/packages/fiori/src/SideNavigationItem.ts
+++ b/packages/fiori/src/SideNavigationItem.ts
@@ -213,6 +213,22 @@ class SideNavigationItem extends SideNavigationSelectableItemBase {
 	get isSideNavigationItem() {
 		return true;
 	}
+
+	_activate(e: KeyboardEvent | PointerEvent) {
+		super._activate(e);
+
+		if (!this.canBeSelected) {
+			this.expanded = !this.expanded;
+		}
+	}
+
+	get canBeSelected() {
+		if (this.items.length > 0 && !this.href) {
+			return false;
+		}
+
+		return !this.isExternalLink;
+	}
 }
 
 SideNavigationItem.define();

--- a/packages/fiori/src/SideNavigationSelectableItemBase.ts
+++ b/packages/fiori/src/SideNavigationSelectableItemBase.ts
@@ -173,6 +173,10 @@ class SideNavigationSelectableItemBase extends SideNavigationItemBase {
 		}
 	}
 
+	get canBeSelected() {
+		return !this.isExternalLink;
+	}
+
 	get isSideNavigationSelectableItemBase() {
 		return true;
 	}

--- a/packages/fiori/test/pages/NavigationLayout.html
+++ b/packages/fiori/test/pages/NavigationLayout.html
@@ -26,11 +26,11 @@
 			<!-- Items -->
 			<ui5-side-navigation-item text="Home" href="#home" icon="home"></ui5-side-navigation-item>
 			<ui5-side-navigation-group text="Group 1" expanded>
-				<ui5-side-navigation-item text="Item 1" expanded href="#item1" icon="locate-me">
+				<ui5-side-navigation-item text="Item 1" expanded icon="locate-me">
 					<ui5-side-navigation-sub-item text="Sub Item 1" href="#subitem1"></ui5-side-navigation-sub-item>
 					<ui5-side-navigation-sub-item text="Sub Item 2" href="#subitem2"></ui5-side-navigation-sub-item>
 				</ui5-side-navigation-item>
-				<ui5-side-navigation-item text="Item 2" href="#item2" icon="calendar" expanded>
+				<ui5-side-navigation-item text="Item 2" icon="calendar" expanded>
 					<ui5-side-navigation-sub-item text="Sub Item 3" href="#subitem3"></ui5-side-navigation-sub-item>
 					<ui5-side-navigation-sub-item text="Sub Item 4" href="#subitem4"></ui5-side-navigation-sub-item>
 				</ui5-side-navigation-item>


### PR DESCRIPTION
- If a side-navigation-item has children and it doesn't have a "href", the item is not selectable
- External links are not selectable as well