### PR TITLE
fix(ui5-badge): correct hover background color for Set 2 Color Scheme 9

### DIFF
--- a/packages/main/src/themes/Badge.css
+++ b/packages/main/src/themes/Badge.css
@@ -566,6 +566,16 @@
 	color: var(--ui5-badge-set2-color-scheme-9-color);
 }
 
+:host([interactive][design="Set2"][color-scheme="9"]) .ui5-badge-root:hover {
+	background-color: var(--ui5-badge-set2-color-scheme-9-hover-background);
+}
+
+:host([interactive][design="Set2"][color-scheme="9"]) .ui5-badge-root:active {
+	background-color: var(--ui5-badge-set2-color-scheme-9-active-background);
+	border-color: var(--ui5-badge-set2-color-scheme-9-active-border);
+	color: var(--ui5-badge-set2-color-scheme-9-active-color);
+}
+
 :host([interactive][design="Set2"][color-scheme="10"]) .ui5-badge-root:hover {
 	background-color: var(--ui5-badge-set2-color-scheme-10-hover-background);
 }


### PR DESCRIPTION
fixes: #10164
downport of https://github.com/SAP/ui5-webcomponents/pull/10229