### PR TITLE
chore(ui5-radio-button): deprecate readonly property

### DIFF
--- a/packages/main/src/RadioButton.ts
+++ b/packages/main/src/RadioButton.ts
@@ -102,6 +102,7 @@ class RadioButton extends UI5Element implements IFormInputElement {
 	 *
 	 * **Note:** A read-only component is not editable,
 	 * but still provides visual feedback upon user interaction.
+	 * @deprecated property should be set on radio button group only. role="radio" does not support aria-readonly attribute.
 	 * @default false
 	 * @public
 	 */


### PR DESCRIPTION
Element with role "[radio](https://www.w3.org/TR/wai-aria-1.2/#radio)" does not support [aria-readonly](https://www.w3.org/TR/wai-aria-1.2/#aria-readonly).
Readonly can be set on element with role "radiogroup"


