### PR TITLE
feat(framework): support function properties

### DIFF
--- a/packages/base/src/UI5ElementMetadata.ts
+++ b/packages/base/src/UI5ElementMetadata.ts
@@ -19,7 +19,7 @@ type Slot = {
 type SlotValue = Node;
 
 type Property = {
-	type?: BooleanConstructor | StringConstructor | ObjectConstructor | NumberConstructor | ArrayConstructor,
+	type?: BooleanConstructor | StringConstructor | ObjectConstructor | NumberConstructor | ArrayConstructor| FunctionConstructor,
 	noAttribute?: boolean,
 	converter?: {
 		fromAttribute(value: string | null, type: unknown): string | number | boolean | null | undefined,
@@ -27,7 +27,8 @@ type Property = {
 	}
 }
 
-type PropertyValue = boolean | number | string | object | undefined | null;
+// eslint-disable-next-line
+type PropertyValue = boolean | number | string | object | Function | undefined | null;
 
 type EventData = Record<string, { detail?: Record<string, object>, cancelable?: boolean, bubbles?: boolean }>;
 
@@ -141,7 +142,7 @@ class UI5ElementMetadata {
 	 */
 	hasAttribute(propName: string): boolean {
 		const propData = this.getProperties()[propName];
-		return propData.type !== Object && propData.type !== Array && !propData.noAttribute;
+		return propData.type !== Object && propData.type !== Array && propData.type !== Function && !propData.noAttribute;
 	}
 
 	/**


### PR DESCRIPTION
*Note: this feature will not be documented yet*

@nnaydenow For now we won't advertise this feature for public properties, but it will only be used for private properties that hold JSX template functions, therefore there should be no change with respect to the CEM. In the future, if we decide this is more universally useful (f.e. to be able to pass a custom filter function as a combo box property or something similar), we should update the CEM/documentation.

This change is a preparation for the rework of *component features*. 

It will make it possible to have **JSX templates as component properties** (of type `Function` as templates are functions) so that whenever the function property changes (a template is assigned or re-assigned), the component will invalidate and re-render with the new template from the property.

Example:

```ts
@property({ type: Function })
myFeatureTemplate?: JsxTemplate;
```

and in the template

```tsx
<div>
  Hello
  { this.myFeatureTemplate?.call(this) }
</div>
```

When `myFeatureTemplate` is set (assigned a JSX template) at a later stage:

```ts
someComponent.myFeatureTemplate = someJSX;
```

the component will invalidate and render the additional template.