### PR TITLE
fix(ui5-table-growing): invalidate table onActivate

### DIFF
--- a/packages/main/src/TableGrowing.ts
+++ b/packages/main/src/TableGrowing.ts
@@ -144,10 +144,13 @@ class TableGrowing extends UI5Element implements ITableGrowing {
 	onTableActivate(table: Table): void {
 		this._table = table;
 		this._shouldFocusRow = false;
-		this._invalidateTable();
 	}
 
 	onTableAfterRendering(): void {
+		if (this.type === TableGrowingMode.Scroll && !this._table) {
+			this._invalidateTable();
+		}
+
 		// Focus the first row after growing, when the growing button is used
 		if (this._shouldFocusRow) {
 			this._shouldFocusRow = false;

--- a/packages/main/src/TableGrowing.ts
+++ b/packages/main/src/TableGrowing.ts
@@ -144,6 +144,7 @@ class TableGrowing extends UI5Element implements ITableGrowing {
 	onTableActivate(table: Table): void {
 		this._table = table;
 		this._shouldFocusRow = false;
+		this._invalidateTable();
 	}
 
 	onTableAfterRendering(): void {


### PR DESCRIPTION
With PR #10949, invalidation is fixed. This uncovers an issue in TableGrowing (type: Scroll), where the growing button is not rendered.
This is due to the fact, that during initial rendering the table tries to figure out whether the table exceeds the scrollport, but this is not possible yet, as the feature is not active yet.

Forcing an invalidation of growing activation solves this issue.