### PR TITLE
fix(ui5-bar): allow overwrite of container-type

### DIFF
--- a/packages/main/src/themes/Bar.css
+++ b/packages/main/src/themes/Bar.css
@@ -4,10 +4,11 @@
 	width: 100%;
 	box-shadow: var(--sapContent_HeaderShadow);
 	display: block;
+	container-type: inline-size;
 }
 
 .ui5-bar-root {
-	container-type: size;
+	container-type: inherit;
 	display: flex;
 	align-items: center;
 	justify-content: space-between;


### PR DESCRIPTION
Previously the `ui5-bar` web component was strictly said to be a query container as its root element had `container-type: size` CSS property.
However this makes it ignore its children width requirements and sometimes they might get clipped, which is not always the desired behaviour.

Because of the above explained behaviour from now on we allow the app developers to overwrite that behaviour by setting the `container-type: inherit` on root level.
We also change the default query container behaviour from
```diff
- container-type: size
+ container-type: inline-size
```
as `size` observes both, `height` and `width` of a container, which is not necessary for our case.

Now the container type of the `ui5-bar` could be easily overwritten as simple as:

e.g
```css
[ui5-bar] {
	container-type: unset;
}
```

Closes: #10012 