### PR TITLE
feat(ui5-li): customIcon slot added

### DIFF
--- a/packages/main/cypress/specs/List.cy.tsx
+++ b/packages/main/cypress/specs/List.cy.tsx
@@ -1,5 +1,8 @@
 import List from "../../src/List.js";
 import ListItemStandard from "../../src/ListItemStandard.js";
+import Icon from "../../src/Icon.js";
+
+import bell from "@ui5/webcomponents-icons/dist/bell.js";
 
 describe("List Tests", () => {
 	it("tests 'loadMore' event fired upon infinite scroll", () => {
@@ -149,5 +152,26 @@ describe("List Tests", () => {
 			.shadow()
 			.find("[id$='growing-btn']")
 			.should("be.focused");
+	});
+
+	it("Tests customIcon slot", () => {
+		cy.mount(
+			<List>
+				<ListItemStandard id="custom-icon-slot-li">
+					<Icon name={bell} slot="customIcon" id="custom-icon"></Icon>Color Set 1 - color-scheme 1
+				</ListItemStandard>
+			</List>
+		);
+
+		cy.get("#custom-icon-slot-li")
+			.shadow()
+			.find("slot[name='customIcon']")
+			.should("exist")
+			.then($slot => {
+				const slotElement = $slot[0] as HTMLSlotElement;
+				const assignedNodes = slotElement.assignedNodes();
+				expect(assignedNodes.length).to.be.greaterThan(0);
+				cy.wrap(assignedNodes[0]).should("have.attr", "id", "custom-icon");
+			});
 	});
 });

--- a/packages/main/src/ListItem.ts
+++ b/packages/main/src/ListItem.ts
@@ -20,6 +20,7 @@ import ListItemBase from "./ListItemBase.js";
 import type RadioButton from "./RadioButton.js";
 import type CheckBox from "./CheckBox.js";
 import type { IButton } from "./Button.js";
+import type { IIcon } from "./Icon.js";
 import {
 	DELETE,
 	ARIA_LABEL_LIST_ITEM_CHECKBOX,
@@ -200,6 +201,14 @@ abstract class ListItem extends ListItemBase {
 	*/
 	@slot()
 	deleteButton!: Array<IButton>;
+
+	/**
+	 * Defines the icon to be displayed in the component.
+	 * @public
+	 * @since 2.8.2
+	 */
+	@slot()
+	customIcon!: Array<IIcon>;
 
 	deactivateByKey: (e: KeyboardEvent) => void;
 	deactivate: () => void;
@@ -458,6 +467,10 @@ abstract class ListItem extends ListItemBase {
 
 	get hasDeleteButtonSlot() {
 		return !!this.deleteButton.length;
+	}
+
+	get hasCustomIconSlot() {
+		return !!this.customIcon.length;
 	}
 
 	get _accessibleNameRef(): string {

--- a/packages/main/src/ListItem.ts
+++ b/packages/main/src/ListItem.ts
@@ -205,7 +205,7 @@ abstract class ListItem extends ListItemBase {
 	/**
 	 * Defines the icon to be displayed in the component.
 	 * @public
-	 * @since 2.8.2
+	 * @since 2.9.0
 	 */
 	@slot()
 	customIcon!: Array<IIcon>;

--- a/packages/main/src/ListItemTemplate.tsx
+++ b/packages/main/src/ListItemTemplate.tsx
@@ -86,6 +86,10 @@ export default function ListItemTemplate(this: ListItem, hooks?: Partial<ListIte
 			</div>
 		)}
 
+		{this.hasCustomIconSlot &&
+			<slot name="customIcon"></slot>
+		}
+
 		{this.typeNavigation && (
 			<Icon name={slimArrowRightIcon} />
 		)}

--- a/packages/main/test/pages/List.html
+++ b/packages/main/test/pages/List.html
@@ -188,6 +188,20 @@
 	</ui5-list>
 
 	<br/><br/>
+
+	<ui5-list header-text="API: customIcon slot">
+		<ui5-li>Item 1
+			<ui5-icon slot="customIcon" name="accept" mode="Interactive" accessible-name="Custom icon accept label"></ui5-icon>
+		</ui5-li>
+		<ui5-li>Item 2
+			<ui5-icon slot="customIcon" name="bell" mode="Image" accessible-name="Custom icon bell label"></ui5-icon>
+		</ui5-li>
+		<ui5-li>Item 3
+			<ui5-icon slot="customIcon" name="bookmark" accessible-name="Custom icon bookmark label"></ui5-icon>
+		</ui5-li>
+	</ui5-list>
+
+	<br/><br/>
 	<hr />
 	<br/><br/>
 


### PR DESCRIPTION
This feature enables semantic icons to be used with the `ui5-tree-item` and `ui5-li` components.

Fixes: https://github.com/SAP/ui5-webcomponents/issues/7481
