### PR TITLE
fix(ui5-list): correct checkbox/radio alignment when description is present

### DIFF
--- a/packages/main/src/themes/ListItem.css
+++ b/packages/main/src/themes/ListItem.css
@@ -148,12 +148,10 @@
 
 :host([description]) .ui5-li-singlesel-radiobtn {
 	align-self: flex-start;
-	margin-top: var(--_ui5_list_item_selection_btn_margin_top);
 }
 
 :host([description]) .ui5-li-multisel-cb {
 	align-self: flex-start;
-	margin-top: var(--_ui5_list_item_selection_btn_margin_top);
 }
 
 :host([_selection-mode="SingleStart"]) .ui5-li-root {


### PR DESCRIPTION
Problem: 
- Checkbox/radio buttons were misaligned in list items with descriptions

Solution:
- Removed unnecessary top margin while preserving top alignment

Fixes: [#11126](https://github.com/SAP/ui5-webcomponents/issues/11126)