### PR TITLE
fix(framework): explicitly allow setting sap-ui-themeRoot

### DIFF
--- a/docs/2-advanced/01-configuration.md
+++ b/docs/2-advanced/01-configuration.md
@@ -283,6 +283,13 @@ Example:
 </script>
 ```
 
+*Note:* For security reasons, setting the `themeRoot` parameter via URL must be explicitly allowed by calling:
+
+```
+import { allowThemeRootUrl } from "@ui5/webcomponents-base/dist/config/ThemeRoot.js";
+allowThemeRootUrl(true);
+```
+
 ## Configuration Script
 <a name="script"></a>
 

--- a/packages/base/cypress/specs/ConfigurationURL.cy.tsx
+++ b/packages/base/cypress/specs/ConfigurationURL.cy.tsx
@@ -1,6 +1,7 @@
 import { internals } from "../../src/Location.js";
 import TestGeneric from "../../test/test-elements/Generic.js";
 import { resetConfiguration } from "../../src/InitialConfiguration.js";
+import { allowThemeRootUrl } from "../../src/config/ThemeRoot.js";
 import { getLanguage } from "../../src/config/Language.js";
 import { getCalendarType } from "../../src/config/CalendarType.js";
 import { getTheme } from "../../src/config/Theme.js";
@@ -14,6 +15,10 @@ describe("Some settings can be set via SAP UI URL params", () => {
 
 		cy.stub(internals, "search", () => {
 			return searchParams;
+		});
+
+		cy.then(() => {
+			return allowThemeRootUrl(true);
 		});
 
 		cy.then(() => {

--- a/packages/base/src/InitialConfiguration.ts
+++ b/packages/base/src/InitialConfiguration.ts
@@ -8,6 +8,7 @@ import AnimationMode from "./types/AnimationMode.js";
 import type CalendarType from "./types/CalendarType.js";
 import { resetConfiguration as resetConfigurationFn } from "./config/ConfigurationReset.js";
 import { getLocationSearch } from "./Location.js";
+import { themeRootUrlAllowed } from "./config/ThemeRoot.js";
 
 let initialized = false;
 
@@ -56,6 +57,10 @@ const getTheme = () => {
 
 const getThemeRoot = () => {
 	initConfiguration();
+	if (!themeRootUrlAllowed() && initialConfig.themeRoot) {
+		console.warn("Setting sap-ui-themeRoot via URL must be explicitly allowed by calling allowThemeRootUrl(true); The provided sap-ui-themeRoot was ignored."); // eslint-disable-line
+		initialConfig.themeRoot = undefined;
+	}
 	return initialConfig.themeRoot;
 };
 

--- a/packages/base/src/config/ThemeRoot.ts
+++ b/packages/base/src/config/ThemeRoot.ts
@@ -4,6 +4,7 @@ import { getThemeRoot as getConfiguredThemeRoot } from "../InitialConfiguration.
 import { getTheme } from "./Theme.js";
 import { attachConfigurationReset } from "./ConfigurationReset.js";
 
+let urlAllowed = false;
 let currThemeRoot: string | undefined;
 
 attachConfigurationReset(() => {
@@ -70,8 +71,18 @@ const attachCustomThemeStylesToHead = async (theme: string): Promise<void> => {
 	await createLinkInHead(formatThemeLink(theme), { "sap-ui-webcomponents-theme": theme });
 };
 
+const allowThemeRootUrl = (enable: boolean) => {
+	urlAllowed = enable;
+};
+
+const themeRootUrlAllowed = () => {
+	return urlAllowed;
+};
+
 export {
 	getThemeRoot,
 	setThemeRoot,
 	attachCustomThemeStylesToHead,
+	allowThemeRootUrl,
+	themeRootUrlAllowed,
 };

--- a/packages/cypress-internal/src/commands.ts
+++ b/packages/cypress-internal/src/commands.ts
@@ -1,10 +1,12 @@
 import { mount } from '@ui5/cypress-ct-ui5-webc';
+// @ts-ignore
 import { renderFinished } from '@ui5/webcomponents-base/dist/Render.js';
 import "cypress-real-events";
 import '@cypress/code-coverage/support';
 import "./acc_report/support.js";
 import "./helpers.js";
 
+// @ts-ignore
 Cypress.Commands.add('waitRenderFinished', () => {
 	return cy.wrap(renderFinished(), { log: false });
 });

--- a/packages/main/src/bundle.common.bootstrap.ts
+++ b/packages/main/src/bundle.common.bootstrap.ts
@@ -61,7 +61,7 @@ import { sanitizeHTML, URLListValidator } from "@ui5/webcomponents-base/dist/uti
 
 import { getAnimationMode, setAnimationMode } from "@ui5/webcomponents-base/dist/config/AnimationMode.js";
 import { getTheme, setTheme, isLegacyThemeFamily } from "@ui5/webcomponents-base/dist/config/Theme.js";
-import { getThemeRoot, setThemeRoot } from "@ui5/webcomponents-base/dist/config/ThemeRoot.js";
+import { getThemeRoot, setThemeRoot, allowThemeRootUrl } from "@ui5/webcomponents-base/dist/config/ThemeRoot.js";
 import { getTimezone, setTimezone } from "@ui5/webcomponents-base/dist/config/Timezone.js";
 import { getLanguage, setLanguage } from "@ui5/webcomponents-base/dist/config/Language.js";
 import getEffectiveIconCollection from "@ui5/webcomponents-base/dist/asset-registries/util/getIconCollectionByTheme.js";
@@ -79,6 +79,8 @@ import getElementSelection from "@ui5/webcomponents-base/dist/util/SelectionAssi
 import * as defaultTexts from "./generated/i18n/i18n-defaults.js";
 
 setRuntimeAlias("UI5 Web Components Playground");
+
+allowThemeRootUrl(true);
 
 // @ts-ignore
 window.sanitizeHTML = sanitizeHTML;


### PR DESCRIPTION
This change requires developers to explicitly opt-in for allowing `data-sap-themeRoot` to be configured by URL. Other methods (configuration script, calling `setThemeRoot` directly) are not affected. 

BREAK ING CHANGE:

For security reasons, setting the `themeRoot` parameter via URL must be explicitly allowed by calling:

```
import { allowThemeRootUrl } from "@ui5/webcomponents-base/dist/config/ThemeRoot.js";
allowThemeRootUrl(true);
```

Unless this method is called with `true`, setting `data-sap-themeRoot` in the URL has no effect and will produce a console warning.