### PR TITLE
fix(ui5-multi-input): prevent form submission on enter

### DIFF
--- a/packages/main/cypress/specs/MultiInput.cy.tsx
+++ b/packages/main/cypress/specs/MultiInput.cy.tsx
@@ -544,6 +544,217 @@ describe("MultiInput tokens", () => {
 			.should("have.attr", "value", "Bulgaria");
 	});
 });
+
+describe("MultiInput Form Submission Prevention", () => {
+	it("should prevent form submission when Enter is pressed with a value", () => {
+		cy.mount(
+			<form>
+				<MultiInput id="mi-form-prevent" onChange={cy.stub().as("change")} />
+			</form>
+		);
+
+		cy.get("form")
+			.then($form => {
+				cy.spy($form[0], "requestSubmit").as("formSubmit");
+			});
+
+		cy.get("#mi-form-prevent")
+			.shadow()
+			.find("input")
+			.as("innerInput");
+
+		cy.get("@innerInput")
+			.realClick()
+			.should("be.focused");
+
+		cy.get("@innerInput")
+			.realType("test value");
+
+		cy.get("@innerInput")
+			.realPress("Enter");
+
+		// Form submission should be prevented when there's a value
+		cy.get("@formSubmit").should("not.have.been.called");
+		cy.get("@change").should("have.been.calledOnce");
+	});
+
+	it("should allow form submission when Enter is pressed without a value in single input form", () => {
+		cy.mount(
+			<form>
+				<MultiInput id="mi-form-allow" onChange={cy.stub().as("change")} />
+			</form>
+		);
+
+		cy.get("form")
+			.then($form => {
+				cy.spy($form[0], "requestSubmit").as("formSubmit");
+			});
+
+		cy.get("#mi-form-allow")
+			.shadow()
+			.find("input")
+			.as("innerInput");
+
+		cy.get("@innerInput")
+			.realClick()
+			.should("be.focused");
+
+		// Press Enter without typing anything
+		cy.get("@innerInput")
+			.realPress("Enter");
+
+		// Form submission should be allowed when there's no value and it's a single input
+		cy.get("@formSubmit").should("have.been.calledOnce");
+		cy.get("@change").should("not.have.been.called");
+	});
+
+	it("should prevent form submission when there are multiple inputs in form", () => {
+		cy.mount(
+			<form>
+				<MultiInput id="mi-form-multi1" />
+				<MultiInput id="mi-form-multi2" />
+			</form>
+		);
+
+		cy.get("form")
+			.then($form => {
+				cy.spy($form[0], "requestSubmit").as("formSubmit");
+			});
+
+		cy.get("#mi-form-multi1")
+			.shadow()
+			.find("input")
+			.as("firstInput");
+
+		cy.get("@firstInput")
+			.realClick()
+			.should("be.focused");
+
+		// Press Enter without typing anything
+		cy.get("@firstInput")
+			.realPress("Enter");
+
+		// Form submission should be prevented when there are multiple inputs
+		cy.get("@formSubmit").should("not.have.been.called");
+	});
+
+	it("should create token on Enter keypress and prevent form submission", () => {
+		cy.mount(
+			<form>
+				<MultiInput id="mi-token-creation" onChange={cy.stub().as("change")} />
+			</form>
+		);
+
+		cy.get("form")
+			.then($form => {
+				cy.spy($form[0], "requestSubmit").as("formSubmit");
+			});
+
+		cy.get("#mi-token-creation")
+			.as("multiInput")
+			.then($multiInput => {
+				$multiInput[0].addEventListener("ui5-change", (event) => {
+					const target = event.target as HTMLInputElement;
+					if (target.value.trim()) {
+						const token = createTokenFromText(target.value);
+						target.appendChild(token);
+						target.value = "";
+					}
+				});
+			});
+
+		cy.get("@multiInput")
+			.shadow()
+			.find("input")
+			.as("innerInput");
+
+		cy.get("@innerInput")
+			.realClick()
+			.should("be.focused");
+
+		cy.get("@innerInput")
+			.realType("new token");
+
+		cy.get("@innerInput")
+			.realPress("Enter");
+
+		// Token should be created
+		cy.get("@multiInput")
+			.find("[ui5-token]")
+			.should("have.length", 1)
+			.and("have.attr", "text", "new token");
+
+		// Input should be cleared
+		cy.get("@multiInput")
+			.should("have.attr", "value", "");
+
+		// Form submission should be prevented
+		cy.get("@formSubmit").should("not.have.been.called");
+		cy.get("@change").should("have.been.calledOnce");
+	});
+
+	it("should work correctly with suggestions and prevent form submission", () => {
+		cy.mount(
+			<form>
+				<MultiInput id="mi-suggestions" showSuggestions onChange={cy.stub().as("change")}>
+					<SuggestionItem text="Suggestion 1"></SuggestionItem>
+					<SuggestionItem text="Suggestion 2"></SuggestionItem>
+				</MultiInput>
+			</form>
+		);
+
+		cy.get("form")
+			.then($form => {
+				cy.spy($form[0], "requestSubmit").as("formSubmit");
+			});
+
+		cy.get("#mi-suggestions")
+			.as("multiInput")
+			.then($multiInput => {
+				$multiInput[0].addEventListener("ui5-change", (event) => {
+					const target = event.target as HTMLInputElement;
+					if (target.value.trim()) {
+						const token = createTokenFromText(target.value);
+						target.appendChild(token);
+						target.value = "";
+					}
+				});
+			});
+
+		cy.get("@multiInput")
+			.shadow()
+			.find("input")
+			.as("innerInput");
+
+		cy.get("@innerInput")
+			.realClick()
+			.should("be.focused");
+
+		// Type to trigger suggestions
+		cy.get("@innerInput")
+			.realType("Sugg");
+
+		// Suggestions should be open
+		cy.get("@multiInput")
+			.shadow()
+			.find("[ui5-responsive-popover]")
+			.should("have.attr", "open");
+
+		// Press Enter to select suggestion and create token
+		cy.get("@innerInput")
+			.realPress("Enter");
+
+		// Token should be created with the autocompleted value
+		cy.get("@multiInput")
+			.find("[ui5-token]")
+			.should("have.length", 1);
+
+		// Form submission should be prevented
+		cy.get("@formSubmit").should("not.have.been.called");
+		cy.get("@change").should("have.been.calledOnce");
+	});
+});
+
 describe("MultiInput Truncated Token", () => {
 	beforeEach(() => {
 		cy.mount(

--- a/packages/main/src/MultiInput.ts
+++ b/packages/main/src/MultiInput.ts
@@ -13,6 +13,8 @@ import {
 	isHome,
 	isEnd,
 	isDown,
+	isEnter,
+
 } from "@ui5/webcomponents-base/dist/Keys.js";
 import type { ITabbable } from "@ui5/webcomponents-base/dist/delegate/ItemNavigation.js";
 import { getScopedVarName } from "@ui5/webcomponents-base/dist/CustomElementsScope.js";
@@ -226,6 +228,10 @@ class MultiInput extends Input implements IFormInputElement {
 		if (isHomeInBeginning) {
 			this._skipOpenSuggestions = true; // Prevent input focus when navigating through the tokens
 			return this._focusFirstToken(e);
+		}
+
+		if (isEnter(e)) {
+			e.preventDefault();
 		}
 
 		if (isLeft(e)) {


### PR DESCRIPTION
the native behavior of `input `HTML element is that when there is only one input field in a form, if ENTER key is pressed the form gets submitted, this is not the desired behavior of the MultiInput web component as on ENTER it should create a token.

fixes: #12167
