### PR TITLE
fix(f6navigation): backward navigation in N level nesting

### DIFF
--- a/packages/base/src/features/F6Navigation.ts
+++ b/packages/base/src/features/F6Navigation.ts
@@ -100,10 +100,20 @@ class F6Navigation {
 				//     </ui5-list>
 				// </ui5-flexible-column-layout>
 				// Here for both FCL & List the firstFoccusableElement is the same (the ui5-li)
-				const firstFocusable = await this.groupElementToFocus(this.groups[currentIndex - 1]);
-				const shouldSkipParent = firstFocusable === await this.groupElementToFocus(this.groups[currentIndex]);
+				const currentGroupFocusable = await this.groupElementToFocus(this.groups[currentIndex]);
+				let distanceToNextGroup = 1;
 
-				currentIndex = shouldSkipParent ? currentIndex - 2 : currentIndex - 1;
+				for (let distanceIndex = 1; distanceIndex < this.groups.length; distanceIndex++) {
+					const firstFocusable = await this.groupElementToFocus(this.groups[currentIndex - distanceIndex]);
+
+					if (firstFocusable === currentGroupFocusable) {
+						distanceToNextGroup++;
+					} else {
+						break;
+					}
+				}
+
+				currentIndex -= distanceToNextGroup;
 
 				if (currentIndex < 0) {
 					currentIndex = this.groups.length - 1;

--- a/packages/main/cypress/specs/F6.cy.tsx
+++ b/packages/main/cypress/specs/F6.cy.tsx
@@ -256,7 +256,9 @@ describe("F6 navigation", () => {
 					</div>
 					<div class="section" data-sap-ui-fastnavgroup="true">
 						<div class="section" data-sap-ui-fastnavgroup="true">
-							<Button id="first">First focusable</Button>
+							<div class="section" data-sap-ui-fastnavgroup="true">
+								<Button id="first">First focusable</Button>
+							</div>
 						</div>
 					</div>
 					<div class="section">
@@ -264,14 +266,20 @@ describe("F6 navigation", () => {
 					</div>
 					<div class="section" data-sap-ui-fastnavgroup="true">
 						<div class="section" data-sap-ui-fastnavgroup="true">
-							<Button id="second">First focusable</Button>
+							<div class="section" data-sap-ui-fastnavgroup="true">
+								<div class="section" data-sap-ui-fastnavgroup="true">
+									<div class="section" data-sap-ui-fastnavgroup="true">
+										<Button id="second">Second focusable</Button>
+									</div>
+								</div>
+							</div>
 						</div>
 					</div>
 					<div class="section">
 						<Button>Something focusable</Button>
 					</div>
 					<div class="section" data-sap-ui-fastnavgroup="true">
-						<Button id="third">Second focusable</Button>
+						<Button id="third">Third focusable</Button>
 					</div>
 					<div class="section">
 						<Button>After Element</Button>
@@ -670,7 +678,9 @@ describe("F6 navigation", () => {
 					</div>
 					<div class="section" data-sap-ui-fastnavgroup="true">
 						<div class="section" data-sap-ui-fastnavgroup="true">
-							<Button id="first">First focusable</Button>
+							<div class="section" data-sap-ui-fastnavgroup="true">
+								<Button id="first">First focusable</Button>
+							</div>
 						</div>
 					</div>
 					<div class="section">
@@ -678,14 +688,20 @@ describe("F6 navigation", () => {
 					</div>
 					<div class="section" data-sap-ui-fastnavgroup="true">
 						<div class="section" data-sap-ui-fastnavgroup="true">
-							<Button id="second">First focusable</Button>
+							<div class="section" data-sap-ui-fastnavgroup="true">
+								<div class="section" data-sap-ui-fastnavgroup="true">
+									<div class="section" data-sap-ui-fastnavgroup="true">
+										<Button id="second">Second focusable</Button>
+									</div>
+								</div>
+							</div>
 						</div>
 					</div>
 					<div class="section">
 						<Button>Something focusable</Button>
 					</div>
 					<div class="section" data-sap-ui-fastnavgroup="true">
-						<Button id="third">Second focusable</Button>
+						<Button id="third">Third focusable</Button>
 					</div>
 					<div class="section">
 						<Button>After Element</Button>

--- a/packages/main/test/pages/F6Test9.html
+++ b/packages/main/test/pages/F6Test9.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<meta charset="utf-8">
+
+	<title>Avatar</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+	<meta charset="utf-8">
+
+
+	<script src="%VITE_BUNDLE_PATH%" type="module"></script>
+	<link rel="stylesheet" type="text/css" href="./styles/F6Test.css">
+</head>
+
+<body>
+	<div class="section">
+		<ui5-button id="before">Before element</ui5-button>
+	</div>
+	<div class="section" data-sap-ui-fastnavgroup="true">
+		<div class="section" data-sap-ui-fastnavgroup="true">
+			<div class="section" data-sap-ui-fastnavgroup="true">
+				<ui5-button id="first">First focusable</ui5-utton>
+			</div>
+		</div>
+	</div>
+	<div class="section">
+		<ui5-button>Something focusable</ui5-utton>
+	</div>
+	<div class="section" data-sap-ui-fastnavgroup="true">
+		<div class="section" data-sap-ui-fastnavgroup="true">
+			<div class="section" data-sap-ui-fastnavgroup="true">
+				<div class="section" data-sap-ui-fastnavgroup="true">
+					<div class="section" data-sap-ui-fastnavgroup="true">
+						<ui5-button id="second">Second focusable</ui5-utton>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+	<div class="section">
+		<ui5-button>Something focusable</ui5-utton>
+	</div>
+	<div class="section" data-sap-ui-fastnavgroup="true">
+		<ui5-button id="third">Third focusable</ui5-utton>
+	</div>
+	<div class="section">
+		<ui5-button>After Element</ui5-utton>
+	</div>
+</body>
+
+</html>


### PR DESCRIPTION
Previously, only the first parent was checked when determining the next focusable group during backward navigation. With this PR, all parent groups are traversed until a different element is found.

Fixes: https://github.com/UI5/webcomponents/issues/12268