### PR TITLE
docs: fix assets paths of test pages

### DIFF
--- a/packages/tools/components-package/nps.js
+++ b/packages/tools/components-package/nps.js
@@ -4,9 +4,9 @@ const LIB = path.join(__dirname, `../lib/`);
 let websiteBaseUrl = "/";
 
 if (process.env.DEPLOY) {
-	websiteBaseUrl = "/ui5-webcomponents/";
+	websiteBaseUrl = "/webcomponents/";
 } else if (process.env.DEPLOY_NIGHTLY) {
-	websiteBaseUrl = "/ui5-webcomponents/nightly/";
+	websiteBaseUrl = "/webcomponents/nightly/";
 }
 
 const cypressEnvVariables = (options, predefinedVars) => {


### PR DESCRIPTION
The test pages like don't open after migrating from SAP to UI5 org
https://ui5.github.io/webcomponents/nightly/packages/main/test/pages/Select.html

because of the renaming of the project name from ui5-webcomponents to webcomponents.