### PR TITLE
chore: remove npx from wc-dev

### DIFF
--- a/packages/tools/bin/dev.js
+++ b/packages/tools/bin/dev.js
@@ -14,4 +14,4 @@ if (command === "watch") {
 	command = ["test", ...process.argv.slice(3)].join(" ");
 }
 
-child_process.execSync(`npx ui5nps "${command}"`, {stdio: 'inherit'});
+child_process.execSync(`ui5nps "${command}"`, {stdio: 'inherit'});


### PR DESCRIPTION
Remove the usage of `npx`. When the `ui5nps` bin is not found, `npx` attempts to fetch it from the npm registry, which leads to an error. If running the scripts still results in a missing `ui5nps` bin, the dependencies need to be reinstalled. This can be done by removing `node_modules` and installing everything again, since Yarn does not automatically re-link new binaries unless the installation is refreshed.