### PR TITLE
fix(ui5-view-settings-dialog): remove focus on first item on filter options

### DIFF
--- a/packages/fiori/cypress/specs/ViewSettingsDialog.cy.tsx
+++ b/packages/fiori/cypress/specs/ViewSettingsDialog.cy.tsx
@@ -452,43 +452,6 @@ describe("ViewSettingsDialog Tests", () => {
 			.invoke("prop", "open", false);
 	});
 
-	it("should focus first item in filter options", () => {
-		cy.mount(
-			<ViewSettingsDialog id="vsdFilter">
-				<FilterItem slot="filterItems" text="Filter 1">
-					<FilterItemOption id="focusedItem" slot="values" text="Some filter 1"></FilterItemOption>
-					<FilterItemOption slot="values" text="Some filter 2"></FilterItemOption>
-					<FilterItemOption slot="values" text="Some filter 3"></FilterItemOption>
-				</FilterItem>
-				<FilterItem slot="filterItems" text="Filter 2">
-					<FilterItemOption slot="values" text="Some filter 4"></FilterItemOption>
-					<FilterItemOption slot="values" text="Some filter 5"></FilterItemOption>
-					<FilterItemOption slot="values" text="Some filter 6"></FilterItemOption>
-				</FilterItem>
-			</ViewSettingsDialog>
-		);
-
-		cy.get("#vsdFilter")
-			.as("vsd");
-
-		cy.get("@vsd")
-			.invoke("prop", "open", true);
-
-		cy.get("@vsd")
-			.shadow()
-			.find("[ui5-li]")
-			.first()
-			.shadow()
-			.find("span[part=title]")
-			.realClick();
-
-		cy.get("@vsd")
-			.shadow()
-			.find("[ui5-li]")
-			.first()
-			.should("be.focused");
-	});
-
 	it("should show a split button with all loaded VSD options", () => {
 		cy.mount(
 			<ViewSettingsDialog id="vsd">

--- a/packages/fiori/src/ViewSettingsDialog.ts
+++ b/packages/fiori/src/ViewSettingsDialog.ts
@@ -14,9 +14,8 @@ import type List from "@ui5/webcomponents/dist/List.js";
 import type { ListItemClickEventDetail, ListSelectionChangeEventDetail } from "@ui5/webcomponents/dist/List.js";
 import announce from "@ui5/webcomponents-base/dist/util/InvisibleMessage.js";
 import InvisibleMessageMode from "@ui5/webcomponents-base/dist/types/InvisibleMessageMode.js";
-import { renderFinished } from "@ui5/webcomponents-base/dist/Render.js";
-
 import ViewSettingsDialogMode from "./types/ViewSettingsDialogMode.js";
+
 import "@ui5/webcomponents-icons/dist/sort.js";
 import "@ui5/webcomponents-icons/dist/filter.js";
 import "@ui5/webcomponents-icons/dist/group-2.js";
@@ -328,14 +327,6 @@ class ViewSettingsDialog extends UI5Element {
 
 		if (this.shouldBuildGroup) {
 			this._currentMode = ViewSettingsDialogMode.Group;
-		}
-	}
-
-	onAfterRendering() {
-		if (this.isModeFilter) {
-			renderFinished().then(() => {
-				this._list?.focusFirstItem();
-			});
 		}
 	}
 


### PR DESCRIPTION
Currently on each render of the view settings dialog filter options the first item is focused, this breaks user interactions and other items cannot be focused.
