### PR TITLE
fix(ui5-list-item): change highlight state color variables

### DIFF
--- a/packages/main/src/themes/ListItem.css
+++ b/packages/main/src/themes/ListItem.css
@@ -194,19 +194,19 @@
 }
 
 :host([highlight="Negative"]) .ui5-li-highlight {
-	background: var(--sapNegativeTextColor);
+	background: var(--sapErrorBorderColor);
 }
 
 :host([highlight="Critical"]) .ui5-li-highlight {
-	background: var(--sapCriticalTextColor);
+	background: var(--sapWarningBorderColor);
 }
 
 :host([highlight="Positive"]) .ui5-li-highlight {
-	background: var(--sapPositiveTextColor);
+	background: var(--sapSuccessBorderColor);
 }
 
 :host([highlight="Information"]) .ui5-li-highlight {
-	background: var(--sapInformativeTextColor);
+	background: var(--sapInformationBorderColor);
 }
 
 /* wrapping */


### PR DESCRIPTION
Change highlight background colors to use border color variables instead of text color variables to align with the design spec.

- Negative: `sapNegativeTextColor` → `sapErrorBorderColor`
- Critical: `sapCriticalTextColor` → `sapWarningBorderColor `
- Positive: `sapPositiveTextColor` → `sapSuccessBorderColor`
- Information: `sapInformativeTextColor` → `sapInformationBorderColor`