### PR TITLE
fix(ui5-shellbar): remove pointer events restriction

### DIFF
--- a/packages/fiori/src/themes/ShellBar.css
+++ b/packages/fiori/src/themes/ShellBar.css
@@ -485,7 +485,6 @@ slot[name="profile"] {
 
 ::slotted([slot="logo"]) {
 	max-height: 2rem;
-	pointer-events: none;
 }
 
 .ui5-shellbar-co-pilot-placeholder {

--- a/packages/fiori/src/themes/ShellBarBranding.css
+++ b/packages/fiori/src/themes/ShellBarBranding.css
@@ -67,6 +67,5 @@
 ::slotted([slot="logo"]) {
 	max-height: 2rem;
 	max-width: 3.75rem;
-	pointer-events: none;
 	padding-inline: 0.25rem;
 }


### PR DESCRIPTION
In order to show title on the image slotted for logo in Shellbar branding, pointer-events: none is removed from the logo.

Internal reference: DINC0628202