### PR TITLE
docs(ui5-tokenizer): updated documentation of popoverMinWidth

### DIFF
--- a/packages/main/src/Tokenizer.ts
+++ b/packages/main/src/Tokenizer.ts
@@ -306,7 +306,7 @@ class Tokenizer extends UI5Element implements IFormInputElement {
 
 	/**
 	 * Prevents tokens to be part of the tab chain.
-	 * **Note:** Used inside MultiInput and MultiComboBox components.
+	 * **Note:** Used inside MultiInput, MultiComboBox and FileUploader components.
 	 * @default false
 	 * @private
 	 */


### PR DESCRIPTION
Update the documentation to allow the usage of the popoverMinWidth property in the FileUploader component. 

FIXES: #11856