### PR TITLE
fix(ui5-date-picker): open picker on correct view based on valueFormat/formatPattern

### DIFF
--- a/packages/main/src/DateComponentBase.ts
+++ b/packages/main/src/DateComponentBase.ts
@@ -155,7 +155,7 @@ class DateComponentBase extends UI5Element {
 	}
 
 	get _formatPattern() {
-		return this.formatPattern || "medium"; // get from config
+		return this.formatPattern || this.valueFormat || "medium"; // get from config
 	}
 
 	get _isPattern() {


### PR DESCRIPTION
Previously we had a bug, where if we provide for example `yyyy-MM` as a value for the `valueFormat` property, in our `ui5-date-picker` component, the picker opened on the **day view**, instead of the **month view** as it was expected.

The reason behind this is that we had a fallback to `"medium"` format without checking if a `valueFormat` was provided.
So in short if a `formatPattern` property was missing (which is expected, as it is deprecated), we were using `"medium"` as a format. Therefore by default, we were opening to **day view**, as it is expected for the `"medium"` format.

Now, we correctly check the formats, and the `ui5-date-picker` is opening on the correct view.

## Before and After

### Before

### After