### PR TITLE
poc(ui5-shellbar): apply old spacings to shellbar's branding

### DIFF
--- a/packages/fiori/src/ShellBar.ts
+++ b/packages/fiori/src/ShellBar.ts
@@ -1446,14 +1446,23 @@ class ShellBar extends UI5Element {
 	}
 
 	get showStartSeparator(): boolean {
+		if (this.isSBreakPoint) {
+			return false;
+		}
 		return this.startContentInfoSorted.some(item => !item.classes.includes("ui5-shellbar-hidden-button"));
 	}
 
 	get showEndSeparator(): boolean {
+		if (this.isSBreakPoint) {
+			return false;
+		}
 		return this.endContentInfoSorted.some(item => !item.classes.includes("ui5-shellbar-hidden-button"));
 	}
 
 	shouldIncludeSeparator(itemInfo: IShellBarContentItem | undefined, contentInfo: IShellBarContentItem[]) {
+		if (this.isSBreakPoint) {
+			return false;
+		}
 		// once the last item from the start/end content was hidden, the
 		// separator is "packed" with it in order to account for any next measurements
 		if (!itemInfo) {

--- a/packages/fiori/src/themes/NavigationLayout.css
+++ b/packages/fiori/src/themes/NavigationLayout.css
@@ -60,5 +60,5 @@
 }
 
 :host([has-side-navigation]) ::slotted([ui5-shellbar][slot="header"]) {
-	padding-inline: 0.875rem 1rem;
+	padding-inline: 0.875rem;
 }

--- a/packages/fiori/src/themes/ShellBar.css
+++ b/packages/fiori/src/themes/ShellBar.css
@@ -300,6 +300,10 @@ slot[name="profile"] {
 	border-radius: var(--_ui5_shellbar_image_button_border_radius);
 }
 
+:host([breakpoint-size="S"]) .ui5-shellbar-image-button {
+	margin-inline-start: 6px;
+}
+
 .ui5-shellbar-overflow-container-left {
 	padding: 0;
 	justify-content: flex-start;
@@ -307,7 +311,7 @@ slot[name="profile"] {
 	flex-shrink: 0;
 }
 
-.ui5-shellbar-overflow-container-left > :nth-child(n) {
+.ui5-shellbar-overflow-container-left > :nth-child(n):not(.ui5-shellbar-logo) {
 	margin-inline-end: 0.5rem;
 }
 

--- a/packages/fiori/src/themes/ShellBarBranding.css
+++ b/packages/fiori/src/themes/ShellBarBranding.css
@@ -10,18 +10,17 @@
 	overflow: hidden;
 	display: flex;
 	align-items: center;
-
 	box-sizing: border-box;
 	cursor: pointer;
 	background: var(--sapButton_Lite_Background);
 	border: 1px solid var(--sapButton_Lite_BorderColor);
 	color: var(--sapShell_TextColor);
-	margin-inline-end: .25rem;
 }
 
 :host(:not([_is-sbreak-point])) .ui5-shellbar-branding-root {
 	padding-block: 0.25rem;
 	padding-inline: 0.25rem 0.5rem;
+	margin-inline-end: .25rem;
 }
 
 .ui5-shellbar-branding-root:focus {

--- a/packages/fiori/src/themes/ShellBarBranding.css
+++ b/packages/fiori/src/themes/ShellBarBranding.css
@@ -10,16 +10,18 @@
 	overflow: hidden;
 	display: flex;
 	align-items: center;
-	padding-block: 0.25rem;
-	padding-inline: 0.25rem 0.5rem;
+
 	box-sizing: border-box;
 	cursor: pointer;
 	background: var(--sapButton_Lite_Background);
 	border: 1px solid var(--sapButton_Lite_BorderColor);
 	color: var(--sapShell_TextColor);
-	/* fix cutting of the focus outline */
-	margin-inline-start: 0.125rem;
-	margin-inline-end: .5rem;
+	margin-inline-end: .25rem;
+}
+
+:host(:not([_is-sbreak-point])) .ui5-shellbar-branding-root {
+	padding-block: 0.25rem;
+	padding-inline: 0.25rem 0.5rem;
 }
 
 .ui5-shellbar-branding-root:focus {
@@ -67,6 +69,9 @@
 
 ::slotted([slot="logo"]) {
 	max-height: 2rem;
+}
+
+:host(:not([_is-sbreak-point])) ::slotted([slot="logo"]) {
 	padding-inline: 0.25rem;
 }
 

--- a/packages/fiori/test/pages/ShellBar_evolution.html
+++ b/packages/fiori/test/pages/ShellBar_evolution.html
@@ -22,194 +22,62 @@
 
 <ui5-navigation-layout mode="Collapsed">
 
-	<ui5-menu id="menuSubsDynamic" opener="btnOpenBasicDynamic">
-		<ui5-menu-item text="New File" icon="add-document"></ui5-menu-item>
-		<ui5-menu-item text="New Folder" icon="add-folder" disabled></ui5-menu-item>
-		<ui5-menu-item text="Open" icon="open-folder" starts-section>
-			<ui5-menu-item text="Open Locally" icon="open-folder">
-				<ui5-menu-item text="Open from C"></ui5-menu-item>
-				<ui5-menu-item text="Open from D"></ui5-menu-item>
-				<ui5-menu-item text="Open from E"></ui5-menu-item>
-			</ui5-menu-item>
-			<ui5-menu-item text="Open from Cloud"></ui5-menu-item>
-		</ui5-menu-item>
-		<ui5-menu-item text="Save" icon="save">
-			<ui5-menu-item text="Save Locally" icon="save">
-				<ui5-menu-item text="Save on C" icon="save"></ui5-menu-item>
-				<ui5-menu-item text="Save on D" icon="save"></ui5-menu-item>
-				<ui5-menu-item text="Save on E" icon="save"></ui5-menu-item>
-			</ui5-menu-item>
-			<ui5-menu-item text="Save on Cloud" icon="upload-to-cloud"></ui5-menu-item>
-		</ui5-menu-item>
-		<ui5-menu-item text="Close"></ui5-menu-item>
-		<ui5-menu-item text="Preferences" icon="action-settings" starts-section></ui5-menu-item>
-		<ui5-menu-item text="Exit" icon="journey-arrive"></ui5-menu-item>
-	</ui5-menu>
+			<ui5-shellbar slot="header" show-notifications>
+			<ui5-shellbar-branding slot="branding">
+				S/4HANA Cloud
+				<img src="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg" slot="logo" />
+			</ui5-shellbar-branding>
 
-	<ui5-shellbar
-		id="shellbarDynamicContent"
-		slot="header"
-		show-notifications
-		>
-		<ui5-shellbar-branding slot="branding">
-			S/4HANA Cloud
-			<img src="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg" slot="logo"/>
-		</ui5-shellbar-branding>
+			<ui5-button icon="menu2" slot="startButton"></ui5-button>
+			<ui5-button icon="nav-back" slot="startButton"></ui5-button>
 
-		<ui5-button icon="menu2" slot="startButton"></ui5-button>
-		<ui5-button icon="nav-back" slot="startButton"></ui5-button>
+			<ui5-button icon="slim-arrow-down" slot="content" data-hide-order="9"></ui5-button>
 
-		<ui5-tag design="Set2" color-scheme="10" slot="content">EMEA</ui5-tag>
-		<ui5-button id="btnOpenBasicDynamic" end-icon="slim-arrow-down" slot="content" data-hide-order="9">Deliveries overdue for billing neeed more text because of a bug</ui5-button>
+			<ui5-shellbar-spacer slot="content"></ui5-shellbar-spacer>
 
-		<ui5-shellbar-spacer slot="content"></ui5-shellbar-spacer>
+			<div slot="content" style="display: flex; align-items: center;">
+				<ui5-label>New Version</ui5-label>
+				<ui5-switch checked></ui5-switch>
+			</div>
 
-		<div slot="content" style="display: flex; align-items: center;">
-			<ui5-label>New Version</ui5-label>
-			<ui5-switch checked></ui5-switch>
-		</div>
+			<ui5-input placeholder="Instructions" slot="searchField" show-suggestions value-state="Information">
+				<div slot="valueStateMessage">Instructions</div>
+			</ui5-input>
 
-		<ui5-input placeholder="Instructions" slot="searchField" show-suggestions value-state="Information">
-			<div slot="valueStateMessage">Instructions</div>
-		</ui5-input>
+			<ui5-toggle-button icon="sap-icon://da" slot="assistant" text="Assitant"
+				title="Assitant"></ui5-toggle-button>
+			<ui5-avatar slot="profile" initials="JM"></ui5-avatar>
+			</ui5-avatar>
+		</ui5-shellbar>
 
-		<ui5-toggle-button id="assistantDynamic" icon="sap-icon://da" slot="assistant" text="Assitant" title="Assitant"></ui5-toggle-button>
-		<ui5-avatar slot="profile" initials="JM"></ui5-avatar>
-		</ui5-avatar>
-	</ui5-shellbar>
+		<ui5-shellbar slot="header" show-notifications primary-title="S/4HANA Cloud">
+			<!-- <ui5-shellbar-branding slot="branding"> -->
+			<!-- S/4HANA Cloud -->
+			<img src="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg" slot="logo" />
+			<!-- </ui5-shellbar-branding> -->
 
-	<ui5-menu id="menuSubs" opener="btnOpenBasic" data-hide-order="10">
-		<ui5-menu-item text="New File" icon="add-document"></ui5-menu-item>
-		<ui5-menu-item text="New Folder" icon="add-folder" disabled></ui5-menu-item>
-		<ui5-menu-item text="Open" icon="open-folder" starts-section>
-			<ui5-menu-item text="Open Locally" icon="open-folder">
-				<ui5-menu-item text="Open from C"></ui5-menu-item>
-				<ui5-menu-item text="Open from D"></ui5-menu-item>
-				<ui5-menu-item text="Open from E"></ui5-menu-item>
-			</ui5-menu-item>
-			<ui5-menu-item text="Open from Cloud"></ui5-menu-item>
-		</ui5-menu-item>
-		<ui5-menu-item text="Save" icon="save">
-			<ui5-menu-item text="Save Locally" icon="save">
-				<ui5-menu-item text="Save on C" icon="save"></ui5-menu-item>
-				<ui5-menu-item text="Save on D" icon="save"></ui5-menu-item>
-				<ui5-menu-item text="Save on E" icon="save"></ui5-menu-item>
-			</ui5-menu-item>
-			<ui5-menu-item text="Save on Cloud" icon="upload-to-cloud"></ui5-menu-item>
-		</ui5-menu-item>
-		<ui5-menu-item text="Close"></ui5-menu-item>
-		<ui5-menu-item text="Preferences" icon="action-settings" starts-section></ui5-menu-item>
-		<ui5-menu-item text="Exit" icon="journey-arrive"></ui5-menu-item>
-	</ui5-menu>
+			<ui5-button icon="menu2" slot="startButton"></ui5-button>
+			<ui5-button icon="nav-back" slot="startButton"></ui5-button>
 
-	<ui5-shellbar
-		id="shellbar"
-		class="shellbar-example"
-		data-ui5-static-stable="shellbarWithLogoClickStatic"
-		show-notifications
-		notifications-count="777"
-		show-product-switch
-		show-search-field
-		slot="header"
-	>
-		<ui5-shellbar-branding slot="branding">
-			SAP Labs Bulgaria
-			<img src="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg" slot="logo"/>
-		</ui5-shellbar-branding>
+			<ui5-button icon="slim-arrow-down" slot="content" data-hide-order="9"></ui5-button>
 
-		<ui5-button icon="menu2" slot="startButton" id="btnOpenStart"></ui5-button>
-		<ui5-button id="btnOpenBasic" end-icon="slim-arrow-down" slot="content" data-hide-order="10">PR10</ui5-button>
+			<ui5-shellbar-spacer slot="content"></ui5-shellbar-spacer>
 
-		<ui5-tag color-scheme="7" slot="content" data-hide-order="4">PR 4</ui5-tag>
-		<ui5-text slot="content" data-hide-order="3">PR3</ui5-text>
+			<div slot="content" style="display: flex; align-items: center;">
+				<ui5-label>New Version</ui5-label>
+				<ui5-switch checked></ui5-switch>
+			</div>
 
-		<ui5-switch design="Textual" text-on="PR0" text-off="PR0" slot="content"></ui5-switch>
+			<ui5-input placeholder="Instructions" slot="searchField" show-suggestions value-state="Information">
+				<div slot="valueStateMessage">Instructions</div>
+			</ui5-input>
 
-		<ui5-shellbar-spacer slot="content"></ui5-shellbar-spacer>
+			<ui5-toggle-button icon="sap-icon://da" slot="assistant" text="Assitant"
+				title="Assitant"></ui5-toggle-button>
+			<ui5-avatar slot="profile" initials="JM"></ui5-avatar>
+			</ui5-avatar>
+		</ui5-shellbar>
 
-		<ui5-toggle-button  slot="content" text="PR2" data-hide-order="2">PR2</ui5-toggle-button>
-
-		<ui5-toggle-button  slot="content" text="PR1" data-hide-order="1">PR1</ui5-toggle-button>
-
-		<ui5-toggle-button  slot="content" text="PR6" data-hide-order="6">PR6</ui5-toggle-button>
-
-		<ui5-toggle-button  slot="content" text="PR7" data-hide-order="7">PR7</ui5-toggle-button>
-
-		<ui5-toggle-button  slot="content" text="PR8" data-hide-order="8">PR8</ui5-toggle-button>
-
-		<ui5-toggle-button  slot="content" text="PR9" data-hide-order="9">PR9</ui5-toggle-button>
-
-		<ui5-shellbar-search slot="searchField">
-			<ui5-search-item text="List Item" icon="history" ></ui5-search-item>
-			<ui5-search-item text="List Item" icon="history" ></ui5-search-item>
-			<ui5-search-item text="List Item" icon="history" ></ui5-search-item>
-			<ui5-search-item text="List Item" icon="history" ></ui5-search-item>
-			<ui5-search-item text="List Item" icon="globe" ></ui5-search-item>
-			<ui5-search-item text="List Item" icon="globe" ></ui5-search-item>
-			<ui5-search-item text="List Item" icon="globe" ></ui5-search-item>
-
-			<ui5-search-scope text="All" slot="scopes"></ui5-search-scope>
-			<ui5-search-scope text="Apps" selected slot="scopes"></ui5-search-scope>
-			<ui5-search-scope text="Products" slot="scopes"></ui5-search-scope>
-		</ui5-shellbar-search>
-
-		<ui5-avatar slot="profile" icon="customer"></ui5-avatar>
-		<ui5-shellbar-item icon="activities" text="Button4"></ui5-shellbar-item>
-		<ui5-shellbar-item icon="feedback" text="Button5"></ui5-shellbar-item>
-		<ui5-shellbar-item count="12" icon="action-settings" text="Button8"></ui5-shellbar-item>
-		<ui5-shellbar-item icon="sys-help" text="Button9"></ui5-shellbar-item>
-		<ui5-toggle-button id="assistant" icon="sap-icon://da" slot="assistant" text="Assitant" title="Assitant"></ui5-toggle-button>
-
-	</ui5-shellbar>
-	<ui5-shellbar
-		id="shellbar_hide_search"
-		class="shellbar-example"
-		data-ui5-static-stable="shellbarWithLogoClickStatic"
-		show-notifications
-		notifications-count="777"
-		show-product-switch
-		slot="header"
-	>
-		<ui5-shellbar-branding slot="branding">
-			SAP Labs Bulgaria
-			<img src="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg" slot="logo"/>
-		</ui5-shellbar-branding>
-
-		<ui5-button icon="menu2" slot="startButton" id="btnOpenStart"></ui5-button>
-		<ui5-button id="btnOpenBasic" end-icon="slim-arrow-down" slot="content" data-hide-order="10">PR10</ui5-button>
-
-		<ui5-tag color-scheme="7" slot="content" data-hide-order="4">PR 4</ui5-tag>
-		<ui5-text slot="content" data-hide-order="3">PR3</ui5-text>
-
-		<ui5-switch design="Textual" text-on="PR0" text-off="PR0" slot="content"></ui5-switch>
-
-		<ui5-shellbar-spacer slot="content"></ui5-shellbar-spacer>
-
-		<ui5-toggle-button  slot="content" text="PR2" data-hide-order="2">PR2</ui5-toggle-button>
-
-		<ui5-toggle-button  slot="content" text="PR1" data-hide-order="1">PR1</ui5-toggle-button>
-
-		<ui5-toggle-button  slot="content" text="PR6" data-hide-order="6">PR6</ui5-toggle-button>
-
-		<ui5-toggle-button  slot="content" text="PR7" data-hide-order="7">PR7</ui5-toggle-button>
-
-		<ui5-toggle-button  slot="content" text="PR8" data-hide-order="8">PR8</ui5-toggle-button>
-
-		<ui5-toggle-button  slot="content" text="PR9" data-hide-order="9">PR9</ui5-toggle-button>
-
-		<div style="width: 100%; display: flex;" slot="searchField" id="customSearch">
-			<input id="customSearchInput" style="width: 100%" type="text">
-			<button id="customSearchClose">x</button>
-		</div>
-
-		<ui5-avatar slot="profile" icon="customer"></ui5-avatar>
-		<ui5-shellbar-item icon="activities" text="Button4"></ui5-shellbar-item>
-		<ui5-shellbar-item icon="feedback" text="Button5" id="feedbackBtn"></ui5-shellbar-item>
-		<ui5-shellbar-item count="12" icon="action-settings" text="Button8"></ui5-shellbar-item>
-		<ui5-shellbar-item icon="sys-help" text="Button9"></ui5-shellbar-item>
-		<ui5-toggle-button id="assistant_no_search" icon="sap-icon://da" slot="assistant" text="Assitant" title="Assitant"></ui5-toggle-button>
-
-	</ui5-shellbar>
 	<ui5-side-navigation slot="sideContent">
 		<ui5-side-navigation-item text="Home" icon="home"></ui5-side-navigation-item>
 		<ui5-side-navigation-item text="People" expanded icon="group">
@@ -233,93 +101,7 @@
 </ui5-navigation-layout>
 
 	<div class="content"></div>
-	<script>
-		const btnOpenBasic = document.getElementById("btnOpenBasic");
-		const btnOpenStart = document.getElementById("btnOpenStart");
 
-		const menuBasic = document.getElementById("menuSubs");
-		const sidenav = document.querySelector("ui5-side-navigation");
-
-		const feedbackBtn = document.getElementById("feedbackBtn");
-
-		const feedbackButtonAcc = {
-			hasPopup: "dialog",
-			expanded: true
-		}
-		feedbackBtn.accessibilityAttributes = feedbackButtonAcc;
-
-		btnOpenBasic.addEventListener("click", function(event) {
-			menuBasic.open = !menuBasic.open;
-		});
-		btnOpenStart.addEventListener("click", () => {
-			sidenav.toggleAttribute("collapsed");
-		});
-
-		assistant.addEventListener("click", event => {
-			const toggleButton = event.target;
-			toggleButton.icon = toggleButton.pressed ? "sap-icon://da-2" : "sap-icon://da";
-		});
-
-		shellbar.addEventListener("content-item-visibility-change", (e) => {
-			console.log(e.detail.items);
-		})
-
-		const menuSubsDynamic = document.getElementById("menuSubsDynamic");
-		const btnOpenBasicDynamic = document.getElementById("btnOpenBasicDynamic");
-
-		btnOpenBasicDynamic.addEventListener("click", () => {
-			menuSubsDynamic.open = true;
-		});
-
-		const shellbarDynamicContent = document.getElementById("shellbarDynamicContent");
-		const arrowButtonOnly = document.createElement("ui5-button");
-		arrowButtonOnly.id = "arrowButtonOnly";
-		arrowButtonOnly.endIcon = "slim-arrow-down";
-		arrowButtonOnly.slot = "content";
-		arrowButtonOnly.setAttribute("data-hide-order", "10");
-		arrowButtonOnly.addEventListener("click", () => {
-			menuSubsDynamic.open = true;
-		});
-
-		function displayMenuOpener(compact) {
-			if (compact) {
-				menuSubsDynamic.setAttribute("opener", "arrowButtonOnly");
-				shellbarDynamicContent.insertBefore(arrowButtonOnly, shellbarDynamicContent.querySelector("ui5-tag"));
-			} else {
-				menuSubsDynamic.setAttribute("opener", "btnOpenBasicDynamic");
-				arrowButtonOnly.remove();
-			}
-		}
-
-		shellbarDynamicContent.addEventListener("content-item-visibility-change", (event) => {
-			const hiddenItems = event.detail.items;
-			displayMenuOpener(hiddenItems.indexOf(btnOpenBasicDynamic) > -1);
-		});
-
-		["focus", "blur", "input"].forEach((event) => {
-			customSearchInput.addEventListener(event, () => {
-				shellbar_hide_search.disableSearchCollapse =
-					customSearchInput.value || customSearchInput === document.activeElement;
-			});
-		});
-
-		shellbar_hide_search.addEventListener('ui5-search-field-toggle', async (e) => {
-			shellbar_hide_search.hideSearchButton = e.detail.expanded;
-		});
-
-		shellbar_hide_search.addEventListener('ui5-search-button-click', async (e) => {
-			shellbar_hide_search.addEventListener('ui5-search-field-toggle', async (e) => {
-				customSearchInput.focus();
-			}, { once: true });
-		});
-
-		customSearchClose.addEventListener('click', async () => {
-			shellbar_hide_search.showSearchField = false;
-			shellbar_hide_search.hideSearchButton = false;
-			const searchButton = await shellbar_hide_search.getSearchButtonDomRef()
-			searchButton.focus();
-		});
-	</script>
 
 </body>
 </html>

--- a/packages/fiori/test/pages/ShellBar_evolution.html
+++ b/packages/fiori/test/pages/ShellBar_evolution.html
@@ -79,9 +79,9 @@
 			</ui5-avatar>
 		</ui5-shellbar>
 
-		<h4>ShellBar in 320px with container padding-inline of 0.5rem </h4>
+		<h4>ShellBar in 320px with container padding-inline of 0.875rem </h4>
 		<div style="width: 320px; border: 1px solid red; margin: 1rem;">
-			<ui5-shellbar style="padding-inline: 0.5rem" slot="header" show-notifications>
+			<ui5-shellbar style="padding-inline: 0.875rem" slot="header" show-notifications>
 				<ui5-shellbar-branding slot="branding">
 					S/4HANA Cloud
 					<img src="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg" slot="logo" />

--- a/packages/fiori/test/pages/ShellBar_evolution.html
+++ b/packages/fiori/test/pages/ShellBar_evolution.html
@@ -81,11 +81,11 @@
 
 		<h4>ShellBar in 320px with container padding-inline of 0.5rem </h4>
 		<div style="width: 320px; border: 1px solid red; margin: 1rem; box-sizing: border-box;">
-			<ui5-shellbar style="padding-inline: 0.5rem" slot="header" show-notifications primary-title="S/4HANA Cloud">
-				<!-- <ui5-shellbar-branding slot="branding"> -->
-				<!-- S/4HANA Cloud -->
-				<img src="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg" slot="logo" />
-				<!-- </ui5-shellbar-branding> -->
+			<ui5-shellbar style="padding-inline: 0.5rem" slot="header" show-notifications>
+				<ui5-shellbar-branding slot="branding">
+					S/4HANA Cloud
+					<img src="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg" slot="logo" />
+				</ui5-shellbar-branding>
 
 				<ui5-button icon="menu2" slot="startButton"></ui5-button>
 				<ui5-button icon="nav-back" slot="startButton"></ui5-button>
@@ -112,11 +112,11 @@
 
 		<h4>ShellBar in 320px with container padding-inline of 0.875rem 1rem</h4>
 		<div style="width: 320px; border: 1px solid red; margin: 1rem; box-sizing: border-box;">
-			<ui5-shellbar style="padding-inline: 0.875rem 1rem" slot="header" show-notifications primary-title="S/4HANA Cloud">
-				<!-- <ui5-shellbar-branding slot="branding"> -->
-				<!-- S/4HANA Cloud -->
-				<img src="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg" slot="logo" />
-				<!-- </ui5-shellbar-branding> -->
+			<ui5-shellbar style="padding-inline: 0.875rem 1rem" slot="header" show-notifications>
+				<ui5-shellbar-branding slot="branding">
+					S/4HANA Cloud
+					<img src="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg" slot="logo" />
+				</ui5-shellbar-branding>
 
 				<ui5-button icon="menu2" slot="startButton"></ui5-button>
 				<ui5-button icon="nav-back" slot="startButton"></ui5-button>

--- a/packages/fiori/test/pages/ShellBar_evolution.html
+++ b/packages/fiori/test/pages/ShellBar_evolution.html
@@ -1,9 +1,10 @@
 <!DOCTYPE html>
 <html>
+
 <head>
 	<meta charset="utf-8">
 	<title>Shell Bar</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 
 	<script data-ui5-config type="application/json">
 		{
@@ -20,9 +21,9 @@
 
 <body class="shellbar1auto">
 
-<ui5-navigation-layout mode="Collapsed">
+	<ui5-navigation-layout mode="Collapsed">
 
-			<ui5-shellbar slot="header" show-notifications>
+		<ui5-shellbar slot="header" show-notifications>
 			<ui5-shellbar-branding slot="branding">
 				S/4HANA Cloud
 				<img src="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg" slot="logo" />
@@ -78,30 +79,94 @@
 			</ui5-avatar>
 		</ui5-shellbar>
 
-	<ui5-side-navigation slot="sideContent">
-		<ui5-side-navigation-item text="Home" icon="home"></ui5-side-navigation-item>
-		<ui5-side-navigation-item text="People" expanded icon="group">
-			<ui5-side-navigation-sub-item text="From My Team"></ui5-side-navigation-sub-item>
-			<ui5-side-navigation-sub-item text="From Other Team"></ui5-side-navigation-sub-item>
-		</ui5-side-navigation-item>
-		<ui5-side-navigation-item text="Locations" icon="locate-me" selected></ui5-side-navigation-item>
-		<ui5-side-navigation-item text="Events" icon="calendar">
-			<ui5-side-navigation-sub-item text="Local"></ui5-side-navigation-sub-item>
-			<ui5-side-navigation-sub-item text="Others"></ui5-side-navigation-sub-item>
-			<ui5-side-navigation-sub-item text="External Link" href="https://sap.com" target="_blank">
-			</ui5-side-navigation-sub-item>
-		</ui5-side-navigation-item>
-		<ui5-side-navigation-item slot="fixedItems" text="Useful Links" icon="chain-link">
-			<ui5-side-navigation-sub-item text="External Link" href="https://sap.com" target="_blank">
-			</ui5-side-navigation-sub-item>
-		</ui5-side-navigation-item>
-		<ui5-side-navigation-item slot="fixedItems" text="History" icon="history">
-		</ui5-side-navigation-item>
-	</ui5-side-navigation>
-</ui5-navigation-layout>
+		<h4>ShellBar in 320px with container padding-inline of 0.5rem </h4>
+		<div style="width: 320px; border: 1px solid red; margin: 1rem; box-sizing: border-box;">
+			<ui5-shellbar style="padding-inline: 0.5rem" slot="header" show-notifications primary-title="S/4HANA Cloud">
+				<!-- <ui5-shellbar-branding slot="branding"> -->
+				<!-- S/4HANA Cloud -->
+				<img src="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg" slot="logo" />
+				<!-- </ui5-shellbar-branding> -->
+
+				<ui5-button icon="menu2" slot="startButton"></ui5-button>
+				<ui5-button icon="nav-back" slot="startButton"></ui5-button>
+
+				<ui5-button icon="slim-arrow-down" slot="content" data-hide-order="9"></ui5-button>
+
+				<ui5-shellbar-spacer slot="content"></ui5-shellbar-spacer>
+
+				<div slot="content" style="display: flex; align-items: center;">
+					<ui5-label>New Version</ui5-label>
+					<ui5-switch checked></ui5-switch>
+				</div>
+
+				<ui5-input placeholder="Instructions" slot="searchField" show-suggestions value-state="Information">
+					<div slot="valueStateMessage">Instructions</div>
+				</ui5-input>
+
+				<ui5-toggle-button icon="sap-icon://da" slot="assistant" text="Assitant"
+					title="Assitant"></ui5-toggle-button>
+				<ui5-avatar slot="profile" initials="JM"></ui5-avatar>
+				</ui5-avatar>
+			</ui5-shellbar>
+		</div>
+
+		<h4>ShellBar in 320px with container padding-inline of 0.875rem 1rem</h4>
+		<div style="width: 320px; border: 1px solid red; margin: 1rem; box-sizing: border-box;">
+			<ui5-shellbar style="padding-inline: 0.875rem 1rem" slot="header" show-notifications primary-title="S/4HANA Cloud">
+				<!-- <ui5-shellbar-branding slot="branding"> -->
+				<!-- S/4HANA Cloud -->
+				<img src="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg" slot="logo" />
+				<!-- </ui5-shellbar-branding> -->
+
+				<ui5-button icon="menu2" slot="startButton"></ui5-button>
+				<ui5-button icon="nav-back" slot="startButton"></ui5-button>
+
+				<ui5-button icon="slim-arrow-down" slot="content" data-hide-order="9"></ui5-button>
+
+				<ui5-shellbar-spacer slot="content"></ui5-shellbar-spacer>
+
+				<div slot="content" style="display: flex; align-items: center;">
+					<ui5-label>New Version</ui5-label>
+					<ui5-switch checked></ui5-switch>
+				</div>
+
+				<ui5-input placeholder="Instructions" slot="searchField" show-suggestions value-state="Information">
+					<div slot="valueStateMessage">Instructions</div>
+				</ui5-input>
+
+				<ui5-toggle-button icon="sap-icon://da" slot="assistant" text="Assitant"
+					title="Assitant"></ui5-toggle-button>
+				<ui5-avatar slot="profile" initials="JM"></ui5-avatar>
+				</ui5-avatar>
+			</ui5-shellbar>
+		</div>
+
+		<ui5-side-navigation slot="sideContent">
+			<ui5-side-navigation-item text="Home" icon="home"></ui5-side-navigation-item>
+			<ui5-side-navigation-item text="People" expanded icon="group">
+				<ui5-side-navigation-sub-item text="From My Team"></ui5-side-navigation-sub-item>
+				<ui5-side-navigation-sub-item text="From Other Team"></ui5-side-navigation-sub-item>
+			</ui5-side-navigation-item>
+			<ui5-side-navigation-item text="Locations" icon="locate-me" selected></ui5-side-navigation-item>
+			<ui5-side-navigation-item text="Events" icon="calendar">
+				<ui5-side-navigation-sub-item text="Local"></ui5-side-navigation-sub-item>
+				<ui5-side-navigation-sub-item text="Others"></ui5-side-navigation-sub-item>
+				<ui5-side-navigation-sub-item text="External Link" href="https://sap.com" target="_blank">
+				</ui5-side-navigation-sub-item>
+			</ui5-side-navigation-item>
+			<ui5-side-navigation-item slot="fixedItems" text="Useful Links" icon="chain-link">
+				<ui5-side-navigation-sub-item text="External Link" href="https://sap.com" target="_blank">
+				</ui5-side-navigation-sub-item>
+			</ui5-side-navigation-item>
+			<ui5-side-navigation-item slot="fixedItems" text="History" icon="history">
+			</ui5-side-navigation-item>
+		</ui5-side-navigation>
+	</ui5-navigation-layout>
 
 	<div class="content"></div>
 
 
+
 </body>
+
 </html>

--- a/packages/fiori/test/pages/ShellBar_evolution.html
+++ b/packages/fiori/test/pages/ShellBar_evolution.html
@@ -80,7 +80,7 @@
 		</ui5-shellbar>
 
 		<h4>ShellBar in 320px with container padding-inline of 0.5rem </h4>
-		<div style="width: 320px; border: 1px solid red; margin: 1rem; box-sizing: border-box;">
+		<div style="width: 320px; border: 1px solid red; margin: 1rem;">
 			<ui5-shellbar style="padding-inline: 0.5rem" slot="header" show-notifications>
 				<ui5-shellbar-branding slot="branding">
 					S/4HANA Cloud
@@ -111,7 +111,7 @@
 		</div>
 
 		<h4>ShellBar in 320px with container padding-inline of 0.875rem 1rem</h4>
-		<div style="width: 320px; border: 1px solid red; margin: 1rem; box-sizing: border-box;">
+		<div style="width: 320px; border: 1px solid red; margin: 1rem;">
 			<ui5-shellbar style="padding-inline: 0.875rem 1rem" slot="header" show-notifications>
 				<ui5-shellbar-branding slot="branding">
 					S/4HANA Cloud


### PR DESCRIPTION
- reduced container space on right from **1rem** to **0.875rem** 
- reduced left margin on profile avatar from **8px** to **6px**
- removed separators on S breakpoint
- removed margin right from logo as we removed the separator
- removed padding space around logo on S breakpoint


https://pr-12568--ui5-webcomponents-preview.netlify.app/packages/fiori/test/pages/shellbar_evolution