### PR TITLE
docs: remove duplicate default slot appearance

### DIFF
--- a/packages/main/src/Link.ts
+++ b/packages/main/src/Link.ts
@@ -71,7 +71,6 @@ type LinkAccessibilityAttributes = Pick<AccessibilityAttributes, "expanded" | "h
  * @public
  * @csspart icon - Used to style the provided icon within the link
  * @csspart endIcon - Used to style the provided endIcon within the link
- * @slot {Array<Node>} default - Defines the text of the component.
  *
  * **Note:** Although this slot accepts HTML Elements, it is strongly recommended that you only use text in order to preserve the intended design.
  */


### PR DESCRIPTION
Recently named field has been added for the default slot resulting in double appearance in the docs

<img width="837" height="549" alt="Screenshot 2026-01-07 at 15 00 36" src="https://github.com/user-attachments/assets/2f7f1ac3-d1d2-4fb7-8b4e-a97276ff9249" />
