### PR TITLE
fix(ui5-user-settings): correct usage with scoping

### DIFF
--- a/packages/base/src/UI5Element.ts
+++ b/packages/base/src/UI5Element.ts
@@ -1404,14 +1404,18 @@ abstract class UI5Element extends HTMLElement {
 /**
  * Always use duck-typing to cover all runtimes on the page.
  */
-const instanceOfUI5Element = (object: any): object is UI5Element => {
+export const instanceOfUI5Element = (object: any): object is UI5Element => {
 	return "isUI5Element" in object;
 };
 
-export default UI5Element;
-export {
-	instanceOfUI5Element,
+/**
+ * Checks whether the object is a UI5Element with the given tag before scoping
+ */
+export const hasTag = (object: any, tag: Lowercase<string>): boolean => {
+	return instanceOfUI5Element(object) && (object.constructor as typeof UI5Element).getMetadata().getPureTag() === tag;
 };
+
+export default UI5Element;
 export type {
 	ChangeInfo,
 	InvalidationInfo,

--- a/packages/base/src/index.ts
+++ b/packages/base/src/index.ts
@@ -105,6 +105,7 @@ import { addCustomCSS, attachThemeLoaded, detachThemeLoaded } from "./Theming.js
 // UI5Element.ts
 import UI5Element from "./UI5Element.js";
 
+export { hasTag, instanceOfUI5Element } from "./UI5Element.js";
 export default UI5Element;
 export {
 	// drag and drop

--- a/packages/fiori/src/UserSettingsAppearanceView.ts
+++ b/packages/fiori/src/UserSettingsAppearanceView.ts
@@ -10,6 +10,7 @@ import {
 	customElement, slot, eventStrict as event,
 } from "@ui5/webcomponents-base/dist/decorators.js";
 import jsxRenderer from "@ui5/webcomponents-base/dist/renderer/JsxRenderer.js";
+import { hasTag } from "@ui5/webcomponents-base/dist/UI5Element.js";
 
 type UserSettingsAppearanceViewItemSelectEventDetail = {
 	item: UserSettingsAppearanceViewItem;
@@ -77,13 +78,13 @@ class UserSettingsAppearanceView extends UserSettingsView {
 		const allItems: Array<UserSettingsAppearanceViewItem> = [];
 
 		this.items.forEach(item => {
-			if (item.tagName === "UI5-USER-SETTINGS-APPEARANCE-VIEW-GROUP") {
+			if (hasTag(item, "ui5-user-settings-appearance-view-group")) {
 				const group = item as UserSettingsAppearanceViewGroup;
 				const groupItems = Array.from(group.children).filter(
-					child => child.tagName === "UI5-USER-SETTINGS-APPEARANCE-VIEW-ITEM",
+					child => hasTag(child, "ui5-user-settings-appearance-view-item"),
 				) as Array<UserSettingsAppearanceViewItem>;
 				allItems.push(...groupItems);
-			} else if (item.tagName === "UI5-USER-SETTINGS-APPEARANCE-VIEW-ITEM") {
+			} else if (hasTag(item, "ui5-user-settings-appearance-view-item")) {
 				allItems.push(item as UserSettingsAppearanceViewItem);
 			}
 		});
@@ -93,7 +94,7 @@ class UserSettingsAppearanceView extends UserSettingsView {
 
 	_handleItemClick = (e: CustomEvent<ListItemClickEventDetail>) => {
 		const listItem = e.detail.item as ListItemBase & { associatedSettingItem?: UserSettingsAppearanceViewItem };
-		if (listItem.tagName === "UI5-USER-SETTINGS-APPEARANCE-VIEW-ITEM") {
+		if (hasTag(listItem, "ui5-user-settings-appearance-view-item")) {
 			const item = listItem as UserSettingsAppearanceViewItem;
 			const eventPrevented = !this.fireDecoratorEvent("selection-change", {
 				item,


### PR DESCRIPTION
comparing strings to `.tagName` won't work when tags are scoped. This change introduces a new helper `hasTag` that checks the pureTag from the component definition.

```ts
import { hasTag } from "@ui5/webcomponents-base";
if (hasTag(element, "ui5-button")) {
  // to something
}
```