### PR TITLE
docs(website): use local sandbox URL for playground-elements

### DIFF
--- a/packages/website/src/components/Editor/index.js
+++ b/packages/website/src/components/Editor/index.js
@@ -44,9 +44,6 @@ const getProjectFromPool = () => {
     return projectPool.pop();
   } else {
     const plProject = document.createElement("playground-project");
-    if (process.env.NODE_ENV === "development") {
-      plProject.sandboxBaseUrl = window.location.origin + "/";
-    }
     return plProject;
   }
 }
@@ -391,6 +388,9 @@ export default function Editor({ html, js, css, mainFile = "main.js", canShare =
 
   useEffect(() => {
     projectRef.current = getProjectFromPool();
+    // Always use local static resources instead of unpkg.com CDN
+    // This avoids issues with webpack's import.meta.url handling
+    projectRef.current.sandboxBaseUrl = new URL(baseUrl, window.location.origin).href;
 
     const activeExample = getActiveExampleContent();
     let _html = activeExample.html || html;


### PR DESCRIPTION
## Summary

Always set `sandboxBaseUrl` to the current origin instead of only in development mode. This makes playground-elements load its resources from local static files instead of unpkg.com CDN.

## Problem

Webpack 5.105.0 (#13040) changed how it handles `import.meta.url` properties - they are now determined at runtime instead of being statically analyzed at compile time. This broke playground-elements which uses dynamic imports with `import.meta.url` to load resources from unpkg.com:

```
Uncaught (in promise) Error: Cannot find module 'https://unpkg.com/playground-elements@0.18.1/'
```

## Solution

Since we already have playground-elements static resources copied to `website/static/`, we can set `sandboxBaseUrl` to use the current origin for all environments (not just development). This way playground-elements never tries to resolve URLs from unpkg.com.

## Benefits

- Fixes the runtime error without reverting webpack
- Faster loading - resources served from same origin
- No CORS issues
- Works offline
- Future-proof against webpack changes