### PR TITLE
feat(ui5-table-row): add semantic click event on TableRow

### DIFF
--- a/packages/main/cypress/specs/Table.cy.tsx
+++ b/packages/main/cypress/specs/Table.cy.tsx
@@ -1004,18 +1004,27 @@ describe("Table - Interactive Rows", () => {
 		cy.get("#row1").invoke("on", "click", cy.stub().as("row1ClickSpy"));
 		cy.get("#row2").invoke("on", "click", cy.stub().as("row2ClickSpy"));
 
-		// Non-interactive row should not fire click
+		// Non-interactive row should not fire custom click
 		cy.get("#row1").realClick();
-		cy.get("@row1ClickSpy").should("not.have.been.called");
+		cy.get("@row1ClickSpy").then(stub => {
+			const customClicks = (stub as unknown as Cypress.Agent<sinon.SinonStub>).getCalls().filter(call => call.args[0].originalEvent instanceof CustomEvent);
+			expect(customClicks).to.have.length(0);
+		});
 
-		// Interactive row fires click on mouse click
+		// Interactive row does not fire custom click on mouse click (native click bubbles normally)
 		cy.get("#row2").realClick();
-		cy.get("@row2ClickSpy").should("have.been.calledOnce");
-		cy.get("@row2ClickSpy").invoke("getCall", 0).its("args.0").should("have.property", "detail");
+		cy.get("@row2ClickSpy").then(stub => {
+			const customClicks = (stub as unknown as Cypress.Agent<sinon.SinonStub>).getCalls().filter(call => call.args[0].originalEvent instanceof CustomEvent);
+			expect(customClicks).to.have.length(0);
+		});
 
-		// Interactive row fires click on Enter key
+		// Interactive row fires custom click on Enter key
 		cy.get("#row2").realPress("Enter");
-		cy.get("@row2ClickSpy").should("have.been.calledTwice");
+		cy.get("@row2ClickSpy").then(stub => {
+			const customClicks = (stub as unknown as Cypress.Agent<sinon.SinonStub>).getCalls().filter(call => call.args[0].originalEvent instanceof CustomEvent);
+			expect(customClicks).to.have.length(1);
+			expect(customClicks[0].args[0].originalEvent).to.have.property("detail");
+		});
 	});
 });
 

--- a/packages/main/cypress/specs/Table.cy.tsx
+++ b/packages/main/cypress/specs/Table.cy.tsx
@@ -982,6 +982,41 @@ describe("Table - Interactive Rows", () => {
 		cy.get("@buttonClickHandler").should("have.been.calledThrice");
 		cy.get("@rowClickHandler").should("have.been.calledThrice");
 	});
+
+	it("fires click event on the row element", () => {
+		cy.mount(
+			<Table id="table1">
+				<TableHeaderRow slot="headerRow">
+					<TableHeaderCell>ColumnA</TableHeaderCell>
+					<TableHeaderCell>ColumnB</TableHeaderCell>
+				</TableHeaderRow>
+				<TableRow id="row1" rowKey="1">
+					<TableCell><Label>Cell A</Label></TableCell>
+					<TableCell><Label>Cell B</Label></TableCell>
+				</TableRow>
+				<TableRow id="row2" rowKey="2" interactive={true}>
+					<TableCell><Label>Cell A</Label></TableCell>
+					<TableCell><Label>Cell B</Label></TableCell>
+				</TableRow>
+			</Table>
+		);
+
+		cy.get("#row1").invoke("on", "click", cy.stub().as("row1ClickSpy"));
+		cy.get("#row2").invoke("on", "click", cy.stub().as("row2ClickSpy"));
+
+		// Non-interactive row should not fire click
+		cy.get("#row1").realClick();
+		cy.get("@row1ClickSpy").should("not.have.been.called");
+
+		// Interactive row fires click on mouse click
+		cy.get("#row2").realClick();
+		cy.get("@row2ClickSpy").should("have.been.calledOnce");
+		cy.get("@row2ClickSpy").invoke("getCall", 0).its("args.0").should("have.property", "detail");
+
+		// Interactive row fires click on Enter key
+		cy.get("#row2").realPress("Enter");
+		cy.get("@row2ClickSpy").should("have.been.calledTwice");
+	});
 });
 
 describe("Table - HeaderCell", () => {

--- a/packages/main/src/TableRow.ts
+++ b/packages/main/src/TableRow.ts
@@ -1,4 +1,6 @@
-import { customElement, slotStrict as slot, property } from "@ui5/webcomponents-base/dist/decorators.js";
+import {
+	customElement, slotStrict as slot, property, eventStrict,
+} from "@ui5/webcomponents-base/dist/decorators.js";
 import { isEnter } from "@ui5/webcomponents-base/dist/Keys.js";
 import getActiveElement from "@ui5/webcomponents-base/dist/util/getActiveElement.js";
 import query from "@ui5/webcomponents-base/dist/decorators/query.js";
@@ -31,12 +33,33 @@ import {
  * @since 2.0.0
  * @public
  */
+/**
+ * Fired when the row is activated by the user via click or Enter key.
+ *
+ * **Note:** This event is not fired when the row has `behavior="RowOnly"` selection.
+ * In that case, use the selection component's `change` event instead.
+ *
+ * @public
+ * @since 2.9.0
+ */
+@eventStrict("click", {
+	bubbles: true,
+})
 @customElement({
 	tag: "ui5-table-row",
 	styles: [TableRowBase.styles, TableRowCss],
 	template: TableRowTemplate,
 })
 class TableRow extends TableRowBase<TableCell> {
+	eventDetails!: TableRowBase["eventDetails"] & {
+		click: void
+	}
+
+	constructor() {
+		super();
+		this.addEventListener("click", this._interceptClick);
+	}
+
 	/**
 	 * Defines the cells of the component.
 	 *
@@ -124,6 +147,14 @@ class TableRow extends TableRowBase<TableCell> {
 	@query("#actions-cell")
 	_actionsCell?: TableCell;
 
+	_interceptClick = (e: Event) => {
+		if (e instanceof CustomEvent) {
+			return;
+		}
+		e.stopImmediatePropagation();
+		this._table?._onEvent(e);
+	};
+
 	onBeforeRendering() {
 		super.onBeforeRendering();
 		this.ariaRowIndex = (this.role === "row") ? `${this._rowIndex + 2}` : null;
@@ -160,15 +191,24 @@ class TableRow extends TableRowBase<TableCell> {
 
 		if (eventOrigin === this && this._isInteractive && isEnter(e)) {
 			this._setActive("keyup");
-			this._onclick();
+			this._handleClick();
 		}
 	}
 
-	_onclick() {
+	_onclick(e: Event) {
+		if (e instanceof CustomEvent) {
+			return;
+		}
+
+		this._handleClick();
+	}
+
+	_handleClick() {
 		if (this === getActiveElement()) {
 			if (this._isSelectable && !this._hasSelector) {
 				this._onSelectionChange();
 			} else 	if (this.interactive || this._isNavigable) {
+				this.fireDecoratorEvent("click");
 				this._table?._onRowClick(this);
 			}
 		}

--- a/packages/main/src/TableRow.ts
+++ b/packages/main/src/TableRow.ts
@@ -55,11 +55,6 @@ class TableRow extends TableRowBase<TableCell> {
 		click: void
 	}
 
-	constructor() {
-		super();
-		this.addEventListener("click", this._interceptClick);
-	}
-
 	/**
 	 * Defines the cells of the component.
 	 *
@@ -147,14 +142,6 @@ class TableRow extends TableRowBase<TableCell> {
 	@query("#actions-cell")
 	_actionsCell?: TableCell;
 
-	_interceptClick = (e: Event) => {
-		if (e instanceof CustomEvent) {
-			return;
-		}
-		e.stopImmediatePropagation();
-		this._table?._onEvent(e);
-	};
-
 	onBeforeRendering() {
 		super.onBeforeRendering();
 		this.ariaRowIndex = (this.role === "row") ? `${this._rowIndex + 2}` : null;
@@ -191,7 +178,7 @@ class TableRow extends TableRowBase<TableCell> {
 
 		if (eventOrigin === this && this._isInteractive && isEnter(e)) {
 			this._setActive("keyup");
-			this._handleClick();
+			this._handleClick(true);
 		}
 	}
 
@@ -199,16 +186,17 @@ class TableRow extends TableRowBase<TableCell> {
 		if (e instanceof CustomEvent) {
 			return;
 		}
-
-		this._handleClick();
+		this._handleClick(false);
 	}
 
-	_handleClick() {
+	_handleClick(fireClick = false) {
 		if (this === getActiveElement()) {
 			if (this._isSelectable && !this._hasSelector) {
 				this._onSelectionChange();
 			} else 	if (this.interactive || this._isNavigable) {
-				this.fireDecoratorEvent("click");
+				if (fireClick) {
+					this.fireDecoratorEvent("click");
+				}
 				this._table?._onRowClick(this);
 			}
 		}

--- a/packages/main/src/TableRow.ts
+++ b/packages/main/src/TableRow.ts
@@ -33,6 +33,11 @@ import {
  * @since 2.0.0
  * @public
  */
+@customElement({
+	tag: "ui5-table-row",
+	styles: [TableRowBase.styles, TableRowCss],
+	template: TableRowTemplate,
+})
 /**
  * Fired when the row is activated by the user via click or Enter key.
  *
@@ -44,11 +49,6 @@ import {
  */
 @eventStrict("click", {
 	bubbles: true,
-})
-@customElement({
-	tag: "ui5-table-row",
-	styles: [TableRowBase.styles, TableRowCss],
-	template: TableRowTemplate,
 })
 class TableRow extends TableRowBase<TableCell> {
 	eventDetails!: TableRowBase["eventDetails"] & {

--- a/packages/main/src/TableRowBase.ts
+++ b/packages/main/src/TableRowBase.ts
@@ -26,6 +26,10 @@ import {
 	styles: TableRowBaseCss,
 })
 abstract class TableRowBase<TCell extends TableCellBase = TableCellBase> extends UI5Element {
+	eventDetails!: {
+		click: void
+	}
+
 	cells!: Array<TCell>;
 
 	@property({ type: Number, noAttribute: true })

--- a/packages/website/docs/_components_pages/main/Table/Table.mdx
+++ b/packages/website/docs/_components_pages/main/Table/Table.mdx
@@ -9,6 +9,7 @@ import StickyHeader from "../../../_samples/main/Table/StickyHeader/StickyHeader
 import StickyHeaderContainer from "../../../_samples/main/Table/StickyHeaderContainer/StickyHeaderContainer.md";
 import NoDataSlot from "../../../_samples/main/Table/NoDataSlot/NoDataSlot.md";
 import Interactive from "../../../_samples/main/Table/Interactive/Interactive.md";
+import RowClick from "../../../_samples/main/Table/RowClick/RowClick.md";
 import DragAndDrop from "../../../_samples/main/Table/DragAndDrop/DragAndDrop.md";
 
 <%COMPONENT_OVERVIEW%>
@@ -56,6 +57,13 @@ Create an interactive table by marking `ui5-table-row` components as `interactiv
 will fire the `row-click` event.
 
 <Interactive />
+
+### Row Click Event
+
+The `click` event is fired directly on `ui5-table-row` when an interactive row is activated via mouse click or keyboard Enter.
+This allows attaching click handlers directly on row elements, which is particularly useful for framework wrappers like React.
+
+<RowClick />
 
 ### Drag and Drop
 

--- a/packages/website/docs/_components_pages/main/Table/TableRow.mdx
+++ b/packages/website/docs/_components_pages/main/Table/TableRow.mdx
@@ -3,6 +3,7 @@ slug: ../../TableRow
 ---
 
 import Interactive from "../../../_samples/main/Table/Interactive/Interactive.md";
+import RowClick from "../../../_samples/main/Table/RowClick/RowClick.md";
 import DragAndDrop from "../../../_samples/main/Table/DragAndDrop/DragAndDrop.md";
 
 <%COMPONENT_OVERVIEW%>
@@ -15,6 +16,13 @@ Create an interactive table by marking `ui5-table-row` components as `interactiv
 will fire the `row-click` event.
 
 <Interactive />
+
+## Row Click Event
+
+The `click` event is fired directly on `ui5-table-row` when an interactive row is activated via mouse click or keyboard Enter.
+This allows attaching click handlers directly on row elements, which is particularly useful for framework wrappers like React.
+
+<RowClick />
 
 ## Movable Rows
 

--- a/packages/website/docs/_samples/main/Table/RowClick/RowClick.md
+++ b/packages/website/docs/_samples/main/Table/RowClick/RowClick.md
@@ -1,0 +1,5 @@
+import html from '!!raw-loader!./sample.html';
+import js from '!!raw-loader!./main.js';
+import react from '!!raw-loader!./sample.tsx';
+
+<Editor html={html} js={js} react={react} />

--- a/packages/website/docs/_samples/main/Table/RowClick/main.js
+++ b/packages/website/docs/_samples/main/Table/RowClick/main.js
@@ -1,0 +1,17 @@
+import "@ui5/webcomponents/dist/Table.js";
+import "@ui5/webcomponents/dist/TableHeaderRow.js";
+import "@ui5/webcomponents/dist/TableHeaderCell.js";
+import "@ui5/webcomponents/dist/Label.js";
+import "@ui5/webcomponents/dist/Toast.js";
+
+const toast = document.getElementById("message");
+
+document.getElementById("row-a").addEventListener("click", () => {
+	toast.textContent = "Row A clicked!";
+	toast.open = true;
+});
+
+document.getElementById("row-b").addEventListener("click", () => {
+	toast.textContent = "Row B clicked!";
+	toast.open = true;
+});

--- a/packages/website/docs/_samples/main/Table/RowClick/sample.html
+++ b/packages/website/docs/_samples/main/Table/RowClick/sample.html
@@ -1,0 +1,38 @@
+<!-- playground-fold -->
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sample</title>
+</head>
+
+<body style="background-color: var(--sapBackgroundColor)">
+<!-- playground-fold-end -->
+	<ui5-toast id="message"></ui5-toast>
+	<ui5-table id="table">
+<!-- playground-fold -->
+		<ui5-table-header-row slot="headerRow">
+			<ui5-table-header-cell width="300px">Product</ui5-table-header-cell>
+			<ui5-table-header-cell width="200px">Supplier</ui5-table-header-cell>
+			<ui5-table-header-cell width="100px">Price</ui5-table-header-cell>
+		</ui5-table-header-row>
+<!-- playground-fold-end -->
+		<ui5-table-row id="row-a" row-key="a" interactive>
+			<ui5-table-cell><ui5-label>Notebook Basic 15</ui5-label></ui5-table-cell>
+			<ui5-table-cell><ui5-label>Very Best Screens</ui5-label></ui5-table-cell>
+			<ui5-table-cell><ui5-label><b>956</b> EUR</ui5-label></ui5-table-cell>
+		</ui5-table-row>
+		<ui5-table-row id="row-b" row-key="b" interactive>
+			<ui5-table-cell><ui5-label>Notebook Basic 17</ui5-label></ui5-table-cell>
+			<ui5-table-cell><ui5-label>Smartcards</ui5-label></ui5-table-cell>
+			<ui5-table-cell><ui5-label><b>1249</b> EUR</ui5-label></ui5-table-cell>
+		</ui5-table-row>
+	</ui5-table>
+<!-- playground-fold -->
+    <script type="module" src="main.js"></script>
+</body>
+
+</html>
+<!-- playground-fold-end -->

--- a/packages/website/docs/_samples/main/Table/RowClick/sample.tsx
+++ b/packages/website/docs/_samples/main/Table/RowClick/sample.tsx
@@ -1,0 +1,71 @@
+import { useRef } from "react";
+import createReactComponent from "@ui5/webcomponents-base/dist/createReactComponent.js";
+import LabelClass from "@ui5/webcomponents/dist/Label.js";
+import TableClass from "@ui5/webcomponents/dist/Table.js";
+import TableCellClass from "@ui5/webcomponents/dist/TableCell.js";
+import TableHeaderCellClass from "@ui5/webcomponents/dist/TableHeaderCell.js";
+import TableHeaderRowClass from "@ui5/webcomponents/dist/TableHeaderRow.js";
+import TableRowClass from "@ui5/webcomponents/dist/TableRow.js";
+import ToastClass from "@ui5/webcomponents/dist/Toast.js";
+
+const Label = createReactComponent(LabelClass);
+const Table = createReactComponent(TableClass);
+const TableCell = createReactComponent(TableCellClass);
+const TableHeaderCell = createReactComponent(TableHeaderCellClass);
+const TableHeaderRow = createReactComponent(TableHeaderRowClass);
+const TableRow = createReactComponent(TableRowClass);
+const Toast = createReactComponent(ToastClass);
+
+function App() {
+  const toastRef = useRef(null);
+
+  const showToast = (message: string) => {
+    if (toastRef.current) {
+      toastRef.current!.textContent = message;
+      toastRef.current!.open = true;
+    }
+  };
+
+  return (
+    <>
+      <Toast ref={toastRef} id="message" />
+      <Table id="table">
+        {/* playground-fold */}
+        <TableHeaderRow slot="headerRow">
+          <TableHeaderCell width="300px">Product</TableHeaderCell>
+          <TableHeaderCell width="200px">Supplier</TableHeaderCell>
+          <TableHeaderCell width="100px">Price</TableHeaderCell>
+        </TableHeaderRow>
+        {/* playground-fold-end */}
+        <TableRow rowKey="a" interactive={true} onClick={() => showToast("Row A clicked!")}>
+          <TableCell>
+            <Label>Notebook Basic 15</Label>
+          </TableCell>
+          <TableCell>
+            <Label>Very Best Screens</Label>
+          </TableCell>
+          <TableCell>
+            <Label>
+              <b>956</b> EUR
+            </Label>
+          </TableCell>
+        </TableRow>
+        <TableRow rowKey="b" interactive={true} onClick={() => showToast("Row B clicked!")}>
+          <TableCell>
+            <Label>Notebook Basic 17</Label>
+          </TableCell>
+          <TableCell>
+            <Label>Smartcards</Label>
+          </TableCell>
+          <TableCell>
+            <Label>
+              <b>1249</b> EUR
+            </Label>
+          </TableCell>
+        </TableRow>
+      </Table>
+    </>
+  );
+}
+
+export default App;


### PR DESCRIPTION
## Summary

- `ui5-table-row` now fires its own custom `click` event when an interactive row is activated via mouse click or Enter key
- The native DOM click is intercepted in the constructor (like `Button`) and replaced with a `CustomEvent` that unifies mouse and keyboard activation
- The existing Table-level `row-click` event is preserved for backward compatibility
- Follows the established semantic click pattern used by `Button`, `Link`, `Icon`, `CardHeader`, and other components

This enables React consumers using `createReactComponent` to attach `onClick` handlers directly on `<TableRow>`:

```tsx
<TableRow interactive={true} onClick={() => handleRowClick()}>
```

### Implementation details

- `@eventStrict("click", { bubbles: true })` declared on `TableRow`
- `eventDetails.click` declared on `TableRowBase` to maintain JSX type compatibility across the hierarchy (same pattern as `SideNavigationItemBase`)
- Native click suppressed via `stopImmediatePropagation` in a constructor-registered listener, then forwarded to the Table's event router so `TableNavigation` and other extensions still work
- `_handleClick()` fires `fireDecoratorEvent("click")` followed by `_table._onRowClick()` for backward compat

## Test plan

- [x] New test: "fires click event on the row element" — verifies non-interactive rows don't fire, interactive rows fire CustomEvent on click and Enter
- [x] Existing `row-click` test still passes
- [x] Selection tests (`TableSelections.cy.tsx`) all pass — RowOnly behavior unaffected
- [x] TypeScript compiles cleanly
- [x] New RowClick sample renders correctly on the documentation website