### PR TITLE
[RFC] feat(ui5-li): add semantic click event to ListItemBase

### DIFF
--- a/packages/fiori/src/Search.ts
+++ b/packages/fiori/src/Search.ts
@@ -44,6 +44,7 @@ interface ISearchSuggestionItem extends UI5Element {
 	selected: boolean;
 	text: string;
 	items?: ISearchSuggestionItem[];
+	eventDetails: { click?: object };
 }
 
 type SearchEventDetails = {

--- a/packages/fiori/src/SearchItemShowMore.ts
+++ b/packages/fiori/src/SearchItemShowMore.ts
@@ -2,6 +2,7 @@ import customElement from "@ui5/webcomponents-base/dist/decorators/customElement
 import property from "@ui5/webcomponents-base/dist/decorators/property.js";
 import event from "@ui5/webcomponents-base/dist/decorators/event-strict.js";
 import ListItemBase from "@ui5/webcomponents/dist/ListItemBase.js";
+import type { ListItemBaseClickEventDetail } from "@ui5/webcomponents/dist/ListItemBase.js";
 import jsxRenderer from "@ui5/webcomponents-base/dist/renderer/JsxRenderer.js";
 import i18n from "@ui5/webcomponents-base/dist/decorators/i18n.js";
 import type I18nBundle from "@ui5/webcomponents-base/dist/i18nBundle.js";
@@ -11,7 +12,7 @@ import SearchItemShowMoreCss from "./generated/themes/SearchItemShowMore.css.js"
 import { SEARCH_ITEM_SHOW_MORE_COUNT, SEARCH_ITEM_SHOW_MORE_NO_COUNT } from "./generated/i18n/i18n-defaults.js";
 import { isEnter, isSpace } from "@ui5/webcomponents-base/dist/Keys.js";
 
-type ShowMoreItemClickEventDetail = {
+type ShowMoreItemClickEventDetail = ListItemBaseClickEventDetail & {
 	fromKeyboard: boolean;
 }
 
@@ -100,7 +101,7 @@ If a number is provided, it displays "Show more (N)", where N is that number.
 
 	_onclick(e: MouseEvent | KeyboardEvent, fromKeyboard = false) {
 		e.stopImmediatePropagation();
-		this.fireDecoratorEvent("click", { fromKeyboard });
+		this.fireDecoratorEvent("click", { item: this, originalEvent: e, fromKeyboard });
 	}
 
 	_onkeydown(e: KeyboardEvent) {

--- a/packages/main/cypress/specs/List.cy.tsx
+++ b/packages/main/cypress/specs/List.cy.tsx
@@ -2797,3 +2797,101 @@ describe("List sticky header", () => {
 			});
 	});
 });
+
+describe("ListItemBase semantic click event", () => {
+	it("fires click event on list item when clicked", () => {
+		cy.mount(
+			<List>
+				<ListItemStandard id="item1">Item 1</ListItemStandard>
+				<ListItemStandard id="item2">Item 2</ListItemStandard>
+			</List>
+		);
+
+		cy.get("#item1").then(($item) => {
+			$item[0].addEventListener("click", cy.stub().as("clickStub"));
+		});
+
+		cy.get("#item1").realClick();
+
+		cy.get("@clickStub").should("have.been.calledOnce");
+		cy.get("@clickStub").should((stub: any) => {
+			const event = stub.firstCall.args[0];
+			expect(event).to.be.instanceOf(CustomEvent);
+			expect(event.detail.item).to.exist;
+			expect(event.detail.originalEvent).to.be.instanceOf(MouseEvent);
+		});
+	});
+
+	it("fires click event on list item when activated with Enter key", () => {
+		cy.mount(
+			<List>
+				<ListItemStandard id="item1">Item 1</ListItemStandard>
+			</List>
+		);
+
+		cy.get("#item1").then(($item) => {
+			$item[0].addEventListener("click", cy.stub().as("clickStub"));
+		});
+
+		cy.get("#item1").realClick();
+		cy.realPress("Enter");
+
+		cy.get("@clickStub")
+			.should("have.been.calledTwice");
+	});
+
+	it("fires click event on list item when activated with Space key", () => {
+		cy.mount(
+			<List>
+				<ListItemStandard id="item1">Item 1</ListItemStandard>
+			</List>
+		);
+
+		cy.get("#item1").then(($item) => {
+			$item[0].addEventListener("click", cy.stub().as("clickStub"));
+		});
+
+		cy.get("#item1").realClick();
+		cy.realPress("Space");
+
+		cy.get("@clickStub")
+			.should("have.been.calledTwice");
+	});
+
+	it("does not fire click event on disabled list item", () => {
+		cy.mount(
+			<List>
+				<ListItemStandard id="item1" disabled>Item 1</ListItemStandard>
+			</List>
+		);
+
+		cy.get("#item1").then(($item) => {
+			$item[0].addEventListener("click", cy.stub().as("clickStub"));
+		});
+
+		cy.get("#item1").realClick({ position: "center" });
+
+		cy.get("@clickStub").should("not.have.been.called");
+	});
+
+	it("fires both click and item-click events", () => {
+		cy.mount(
+			<List>
+				<ListItemStandard id="item1">Item 1</ListItemStandard>
+			</List>
+		);
+
+		cy.get("#item1").then(($item) => {
+			$item[0].addEventListener("click", cy.stub().as("itemClickStub"));
+		});
+
+		cy.get("[ui5-list]").then(($list) => {
+			$list[0].addEventListener("ui5-item-click", cy.stub().as("listItemClickStub"));
+		});
+
+		cy.get("#item1").realClick();
+
+		cy.get("@itemClickStub").should("have.been.calledOnce");
+		cy.get("@listItemClickStub").should("have.been.calledOnce");
+	});
+});

--- a/packages/main/cypress/specs/Menu.cy.tsx
+++ b/packages/main/cypress/specs/Menu.cy.tsx
@@ -1414,3 +1414,91 @@ describe("Menu - Submenu Focus Behavior", () => {
 			.should("be.focused");
 	});
 });
+
+describe("MenuItem semantic click event", () => {
+	it("fires click event on menu item when clicked", () => {
+		cy.mount(
+			<>
+				<Button id="btnOpen">Open Menu</Button>
+				<Menu opener="btnOpen">
+					<MenuItem id="item1" text="New File"></MenuItem>
+					<MenuItem id="item2" text="New Folder"></MenuItem>
+				</Menu>
+			</>
+		);
+
+		cy.get("[ui5-menu]")
+			.ui5MenuOpen({ opener: "btnOpen" });
+
+		cy.get("#item1").then(($item) => {
+			$item[0].addEventListener("click", cy.stub().as("clickStub"));
+		});
+
+		cy.get("#item1").realClick();
+
+		cy.get("@clickStub").should("have.been.calledOnce");
+		cy.get("@clickStub").should((stub: any) => {
+			const event = stub.firstCall.args[0];
+			expect(event).to.be.instanceOf(CustomEvent);
+			expect(event.detail.item).to.exist;
+			expect(event.detail.originalEvent).to.be.instanceOf(MouseEvent);
+		});
+	});
+
+	it("fires click event on menu item when activated with Enter", () => {
+		cy.mount(
+			<>
+				<Button id="btnOpen">Open Menu</Button>
+				<Menu opener="btnOpen">
+					<MenuItem id="item1" text="New File"></MenuItem>
+				</Menu>
+			</>
+		);
+
+		cy.get("[ui5-menu]")
+			.ui5MenuOpen({ opener: "btnOpen" });
+
+		cy.get("[ui5-menu]")
+			.ui5MenuOpened();
+
+		cy.get("#item1").then(($item) => {
+			$item[0].addEventListener("click", cy.stub().as("clickStub"));
+		});
+
+		cy.get("[ui5-menu-item]")
+			.ui5MenuItemPress("Enter");
+
+		cy.get("@clickStub").should("have.been.calledOnce");
+	});
+
+	it("fires both click on MenuItem and item-click on Menu", () => {
+		cy.mount(
+			<>
+				<Button id="btnOpen">Open Menu</Button>
+				<Menu id="menu" opener="btnOpen">
+					<MenuItem id="item1" text="New File"></MenuItem>
+				</Menu>
+			</>
+		);
+
+		cy.get("[ui5-menu]")
+			.ui5MenuOpen({ opener: "btnOpen" });
+
+		cy.get("[ui5-menu]")
+			.ui5MenuOpened();
+
+		cy.get("#item1").then(($item) => {
+			$item[0].addEventListener("click", cy.stub().as("itemClickStub"));
+		});
+
+		cy.get("#menu").then(($menu) => {
+			$menu[0].addEventListener("ui5-item-click", cy.stub().as("menuItemClickStub"));
+		});
+
+		cy.get("[ui5-menu-item]")
+			.ui5MenuItemClick();
+
+		cy.get("@itemClickStub").should("have.been.calledOnce");
+		cy.get("@menuItemClickStub").should("have.been.calledOnce");
+	});
+});

--- a/packages/main/cypress/specs/Tree.cy.tsx
+++ b/packages/main/cypress/specs/Tree.cy.tsx
@@ -780,3 +780,103 @@ describe("Tree drag and drop tests", () => {
 		});
 	});
 });
+
+describe("TreeItem semantic click event", () => {
+	it("fires click event on tree item when clicked", () => {
+		cy.mount(
+			<Tree>
+				<TreeItem id="item1" text="Tree 1"></TreeItem>
+				<TreeItem text="Tree 2"></TreeItem>
+			</Tree>
+		);
+
+		cy.get("#item1").then(($item) => {
+			$item[0].addEventListener("click", cy.stub().as("clickStub"));
+		});
+
+		cy.get("#item1").realClick();
+
+		cy.get("@clickStub").should("have.been.calledOnce");
+		cy.get("@clickStub").should((stub: any) => {
+			const event = stub.firstCall.args[0];
+			expect(event).to.be.instanceOf(CustomEvent);
+			expect(event.detail.item).to.exist;
+			expect(event.detail.originalEvent).to.be.instanceOf(MouseEvent);
+		});
+	});
+
+	it("fires click event on tree item when activated with Enter", () => {
+		cy.mount(
+			<Tree>
+				<TreeItem id="item1" text="Tree 1"></TreeItem>
+				<TreeItem text="Tree 2"></TreeItem>
+			</Tree>
+		);
+
+		cy.get("#item1").then(($item) => {
+			$item[0].addEventListener("click", cy.stub().as("clickStub"));
+		});
+
+		cy.get("#item1").realClick();
+		cy.realPress("Enter");
+
+		cy.get("@clickStub").should("have.been.calledTwice");
+	});
+
+	it("fires click event on tree item when activated with Space", () => {
+		cy.mount(
+			<Tree>
+				<TreeItem id="item1" text="Tree 1"></TreeItem>
+				<TreeItem text="Tree 2"></TreeItem>
+			</Tree>
+		);
+
+		cy.get("#item1").then(($item) => {
+			$item[0].addEventListener("click", cy.stub().as("clickStub"));
+		});
+
+		cy.get("#item1").realClick();
+		cy.realPress("Space");
+
+		cy.get("@clickStub").should("have.been.calledTwice");
+	});
+
+	it("does not fire click event on disabled tree item", () => {
+		cy.mount(
+			<Tree>
+				<TreeItem id="item1" text="Tree 1" disabled></TreeItem>
+				<TreeItem text="Tree 2"></TreeItem>
+			</Tree>
+		);
+
+		cy.get("#item1").then(($item) => {
+			$item[0].addEventListener("click", cy.stub().as("clickStub"));
+		});
+
+		cy.get("#item1").realClick({ force: true });
+
+		cy.get("@clickStub").should("not.have.been.called");
+	});
+
+	it("fires both click on TreeItem and item-click on Tree", () => {
+		cy.mount(
+			<Tree id="tree">
+				<TreeItem id="item1" text="Tree 1"></TreeItem>
+				<TreeItem text="Tree 2"></TreeItem>
+			</Tree>
+		);
+
+		cy.get("#item1").then(($item) => {
+			$item[0].addEventListener("click", cy.stub().as("itemClickStub"));
+		});
+
+		cy.get("#tree").then(($tree) => {
+			$tree[0].addEventListener("ui5-item-click", cy.stub().as("treeItemClickStub"));
+		});
+
+		cy.get("#item1").realClick();
+
+		cy.get("@itemClickStub").should("have.been.calledOnce");
+		cy.get("@treeItemClickStub").should("have.been.calledOnce");
+	});
+});

--- a/packages/main/src/ComboBox.ts
+++ b/packages/main/src/ComboBox.ts
@@ -106,7 +106,8 @@ interface IComboBoxItem extends UI5Element {
 	selected?: boolean,
 	additionalText?: string,
 	_isVisible?: boolean,
-	items?: Array<IComboBoxItem>
+	items?: Array<IComboBoxItem>,
+	eventDetails: { click?: object },
 }
 
 type ValueStateAnnouncement = Record<Exclude<ValueState, ValueState.None>, string>;

--- a/packages/main/src/Input.ts
+++ b/packages/main/src/Input.ts
@@ -110,6 +110,7 @@ interface IInputSuggestionItem extends UI5Element {
 	focused: boolean;
 	additionalText?: string;
 	items?: IInputSuggestionItem[];
+	eventDetails: { click?: object };
 }
 
 interface IInputSuggestionItemSelectable extends IInputSuggestionItem {

--- a/packages/main/src/ListItemBase.ts
+++ b/packages/main/src/ListItemBase.ts
@@ -25,6 +25,11 @@ type ListItemBasePressEventDetail = {
 	key?: string,
 }
 
+type ListItemBaseClickEventDetail = {
+	item: ListItemBase,
+	originalEvent: Event,
+}
+
 /**
  * @class
  * A class to serve as a foundation
@@ -37,6 +42,9 @@ type ListItemBasePressEventDetail = {
 @customElement({
 	renderer: jsxRenderer,
 	styles: [styles, draggableElementStyles],
+})
+@event("click", {
+	bubbles: true,
 })
 @event("request-tabindex-change", {
 	bubbles: true,
@@ -56,6 +64,7 @@ type ListItemBasePressEventDetail = {
 })
 class ListItemBase extends UI5Element implements ITabbable {
 	eventDetails!: {
+		"click": ListItemBaseClickEventDetail,
 		"request-tabindex-change": FocusEvent,
 		"_press": ListItemBasePressEventDetail,
 		"_focused": FocusEvent,
@@ -168,6 +177,7 @@ class ListItemBase extends UI5Element implements ITabbable {
 		if (this.getFocusDomRef()!.matches(":has(:focus-within)") || this._isDisabledInteractiveContentClicked(e)) {
 			return;
 		}
+		e.stopPropagation();
 		this.fireItemPress(e);
 	}
 
@@ -233,6 +243,7 @@ class ListItemBase extends UI5Element implements ITabbable {
 		if (isEnter(e as KeyboardEvent)) {
 			e.preventDefault();
 		}
+		this.fireDecoratorEvent("click", { item: this, originalEvent: e });
 		this.fireDecoratorEvent("_press", { item: this, selected: this.selected, key: (e as KeyboardEvent).key });
 	}
 
@@ -313,4 +324,5 @@ export default ListItemBase;
 
 export type {
 	ListItemBasePressEventDetail,
+	ListItemBaseClickEventDetail,
 };

--- a/packages/main/src/ListItemGroup.ts
+++ b/packages/main/src/ListItemGroup.ts
@@ -83,6 +83,7 @@ type ListItemGroupMoveEventDetail = {
 
 class ListItemGroup extends UI5Element {
 	eventDetails!: {
+		"click"?: object,
 		"move-over": ListItemGroupMoveEventDetail,
 		"move": ListItemGroupMoveEventDetail,
 	}

--- a/packages/main/src/Menu.ts
+++ b/packages/main/src/Menu.ts
@@ -60,6 +60,7 @@ interface IMenuItem extends UI5Element {
 	isMenuItem?: boolean;
 	isSeparator?: boolean;
 	isGroup?: boolean;
+	eventDetails: { click?: object };
 }
 
 type MenuItemClickEventDetail = {

--- a/packages/main/src/MultiComboBox.ts
+++ b/packages/main/src/MultiComboBox.ts
@@ -128,6 +128,7 @@ interface IMultiComboBoxItem extends UI5Element {
 	isGroupItem?: boolean,
 	_isVisible?: boolean,
 	items?: Array<IMultiComboBoxItem>,
+	eventDetails: { click?: object },
 }
 
 type ValueStateAnnouncement = Record<Exclude<ValueState, ValueState.None>, string>;


### PR DESCRIPTION
## Summary

- Adds a public `click` CustomEvent to `ListItemBase`, enabling framework consumers (React, Angular, Vue) to attach `onClick` handlers directly on list items (`<ListItemStandard onClick={...}>`) instead of relying on the parent container's `item-click` event
- Event detail includes `item` (the ListItemBase instance) and `originalEvent` (the underlying mouse/keyboard event), matching the Button's semantic click pattern
- Native click from shadow DOM `<li>` is stopped via `stopPropagation()` to prevent duplicate events reaching consumers
- All components extending ListItemBase inherit this behavior: ListItemStandard, MenuItem, TreeItem, NotificationListItem, UploadCollectionItem, etc.

Resolves #13304

## Changes

**`packages/main/src/ListItemBase.ts`**
- Added `@event("click", { bubbles: true })` decorator
- Added `ListItemBaseClickEventDetail` type with `item` and `originalEvent`
- `fireItemPress()` now fires `fireDecoratorEvent("click", { item, originalEvent })` alongside existing `_press`
- `_onclick()` calls `e.stopPropagation()` before `fireItemPress()` to suppress native click from shadow DOM

## Test plan

- [x] `List.cy.tsx` — 5 new tests (click, Enter, Space, disabled, backward compat with item-click)
- [x] `Menu.cy.tsx` — 3 new tests (click, Enter, backward compat with item-click)
- [x] `Tree.cy.tsx` — 5 new tests (click, Enter, Space, disabled, backward compat with item-click)
- [x] Tests listen for `"click"` (not `"ui5-click"`) and assert `calledOnce` to verify no duplicate native+semantic events
- [x] All existing tests pass (92 List, 41 Menu, 26 Tree)
- [x] Lint passes