### PR TITLE
feat(ui5-step-input): Euler`s constant support

### DIFF
--- a/packages/main/cypress/specs/StepInput.cy.tsx
+++ b/packages/main/cypress/specs/StepInput.cy.tsx
@@ -816,6 +816,74 @@ describe("StepInput property propagation", () => {
     });
 });
 
+describe("Number expressions", () => {
+	it("should work properly with number expressions which contains Euler`s constant", () => {
+		 cy.mount(
+			<StepInput value={5}></StepInput>
+		);
+
+		cy.get("[ui5-step-input]")
+			.as("stepInput");
+
+		cy.get<StepInput>("@stepInput")
+			.ui5StepInputAttachHandler("ui5-change", "change");
+
+		cy.get<StepInput>("@stepInput")
+			.ui5StepInputTypeNumber("1e3");
+
+		cy.get("@change")
+			.should("have.been.calledOnce");
+
+		cy.get<StepInput>("@stepInput")
+			.should("have.prop", "value", 1000);
+	});
+
+	it("should work properly with number expressions which contains Euler`s constant and decimals", () => {
+		cy.mount(
+			<StepInput value={5} valuePrecision={2}></StepInput>
+		);
+
+		cy.get("[ui5-step-input]")
+			.as("stepInput");
+
+		cy.get<StepInput>("@stepInput")
+			.ui5StepInputAttachHandler("ui5-change", "change");
+
+		cy.get<StepInput>("@stepInput")
+			.ui5StepInputTypeNumber("1.5e3");
+
+		cy.get("@change")
+			.should("have.been.calledOnce");
+
+		cy.get<StepInput>("@stepInput")
+			.should("have.prop", "value", 1500);
+
+		cy.get<StepInput>("@stepInput")
+			.should("have.prop", "valueState", "None");
+	});
+
+	it("should set value to 0 when the number expression is infinity", () => {
+		cy.mount(
+			<StepInput value={5}></StepInput>
+		);
+
+		cy.get("[ui5-step-input]")
+			.as("stepInput");
+
+		cy.get<StepInput>("@stepInput")
+			.ui5StepInputAttachHandler("ui5-change", "change");
+
+		cy.get<StepInput>("@stepInput")
+			.ui5StepInputTypeNumber("1e9999");
+
+		cy.get("@change")
+			.should("have.been.calledOnce");
+
+		cy.get<StepInput>("@stepInput")
+			.should("have.prop", "value", 0);
+	});
+});
+
 describe("Validation inside form", () => {
 	it("has correct validity for patternMissmatch", () => {
 		cy.mount(
@@ -835,7 +903,7 @@ describe("Validation inside form", () => {
 			.as("stepInput");
 
 		cy.get<StepInput>("@stepInput")
-			.ui5StepInputTypeNumber(2.34);
+			.ui5StepInputTypeNumber("2.34");
 
 		cy.get("#submitBtn")
 			.realClick();
@@ -855,7 +923,7 @@ describe("Validation inside form", () => {
 			.should("exist", "StepInput without formatted value should have :invalid CSS class");
 
 		cy.get<StepInput>("@stepInput")
-			.ui5StepInputTypeNumber(2.345);
+			.ui5StepInputTypeNumber("2.345");
 
 		cy.get("@stepInput")
 			.ui5AssertValidityState({
@@ -886,7 +954,7 @@ describe("Validation inside form", () => {
 			.as("stepInput");
 
 		cy.get<StepInput>("@stepInput")
-			.ui5StepInputTypeNumber(2);
+			.ui5StepInputTypeNumber("2");
 
 		cy.get("#submitBtn")
 			.realClick();
@@ -906,7 +974,7 @@ describe("Validation inside form", () => {
 			.should("exist", "StepInput with value lower than min should have :invalid CSS class");
 
 		cy.get<StepInput>("@stepInput")
-			.ui5StepInputTypeNumber(4);
+			.ui5StepInputTypeNumber("4");
 
 		cy.get("@stepInput")
 			.ui5AssertValidityState({
@@ -938,7 +1006,7 @@ describe("Validation inside form", () => {
 			.as("stepInput");
 
 		cy.get<StepInput>("@stepInput")
-			.ui5StepInputTypeNumber(4);
+			.ui5StepInputTypeNumber("4");
 
 		cy.get("#submitBtn")
 			.realClick();
@@ -958,7 +1026,7 @@ describe("Validation inside form", () => {
 			.should("exist", "StepInput without value lower than min should have :invalid CSS class");
 
 		cy.get<StepInput>("@stepInput")
-			.ui5StepInputTypeNumber(2);
+			.ui5StepInputTypeNumber("2");
 
 		cy.get("@stepInput")
 			.ui5AssertValidityState({

--- a/packages/main/cypress/specs/StepInput.cy.tsx
+++ b/packages/main/cypress/specs/StepInput.cy.tsx
@@ -816,7 +816,7 @@ describe("StepInput property propagation", () => {
     });
 });
 
-describe("Number expressions", () => {
+describe("Number expressions with constants", () => {
 	it("should work properly with number expressions which contains Euler`s constant", () => {
 		 cy.mount(
 			<StepInput value={5}></StepInput>
@@ -862,9 +862,9 @@ describe("Number expressions", () => {
 			.should("have.prop", "valueState", "None");
 	});
 
-	it("should set value to 0 when the number expression is infinity", () => {
+	it("should set default value when value is out of bounds", () => {
 		cy.mount(
-			<StepInput value={5}></StepInput>
+			<StepInput value={5} max={20}></StepInput>
 		);
 
 		cy.get("[ui5-step-input]")
@@ -881,6 +881,9 @@ describe("Number expressions", () => {
 
 		cy.get<StepInput>("@stepInput")
 			.should("have.prop", "value", 0);
+		
+		cy.get<StepInput>("@stepInput")
+			.should("have.prop", "valueState", "None");
 	});
 });
 

--- a/packages/main/cypress/specs/StepInput.cy.tsx
+++ b/packages/main/cypress/specs/StepInput.cy.tsx
@@ -885,6 +885,33 @@ describe("Number expressions with constants", () => {
 		cy.get<StepInput>("@stepInput")
 			.should("have.prop", "valueState", "None");
 	});
+
+	it("should not format value when formatted value is too bid", () => {
+		cy.mount(
+			<StepInput value={5}></StepInput>
+		);
+
+		cy.get("[ui5-step-input]")
+			.as("stepInput");
+
+		cy.get<StepInput>("@stepInput")
+			.ui5StepInputAttachHandler("ui5-change", "change");
+
+		cy.get<StepInput>("@stepInput")
+			.ui5StepInputTypeNumber("1e100");
+
+		cy.get("@change")
+			.should("have.been.calledOnce");
+
+		cy.get<StepInput>("@stepInput")
+			.should("have.prop", "value", 1e100);
+		
+		cy.get<StepInput>("@stepInput")
+			.should("have.prop", "valueState", "None");
+		
+		cy.get<StepInput>("@stepInput")
+			.ui5StepInputCheckInnerInputProperty("value", "1e+100");
+	});
 });
 
 describe("Validation inside form", () => {

--- a/packages/main/cypress/support/commands/StepInput.commands.ts
+++ b/packages/main/cypress/support/commands/StepInput.commands.ts
@@ -68,7 +68,7 @@ Cypress.Commands.add("ui5StepInputCheckInnerInputProperty", { prevSubject: true 
         });
 });
 
-Cypress.Commands.add("ui5StepInputTypeNumber", { prevSubject: true }, (subject, value: number) => {
+Cypress.Commands.add("ui5StepInputTypeNumber", { prevSubject: true }, (subject, value: string) => {
 	cy.wrap(subject)
 		 .as("stepInput")
 		.should("be.visible");
@@ -79,7 +79,7 @@ Cypress.Commands.add("ui5StepInputTypeNumber", { prevSubject: true }, (subject, 
 		.shadow()
 		.find("input")
 		.clear()
-		.realType(value.toString())
+		.realType(value)
 		.realPress("Enter");
 });
 
@@ -120,7 +120,7 @@ declare global {
 			ui5StepInputAttachHandler(eventName: string, stubName: string): Chainable<void>
 			ui5StepInputGetInnerInput(): Chainable<JQuery<HTMLElement>>
 			ui5StepInputCheckInnerInputProperty(propName: string, expectedValue: any, shouldBePropagated?: boolean): Chainable<void>
-			ui5StepInputTypeNumber(value: number): Chainable<void>
+			ui5StepInputTypeNumber(value: string): Chainable<void>
 			ui5StepInputScrollToChangeValue(expectedValue: number, decreaseValue: boolean): Chainable<void>
 		}
 	}

--- a/packages/main/src/StepInput.ts
+++ b/packages/main/src/StepInput.ts
@@ -614,10 +614,6 @@ class StepInput extends UI5Element implements IFormInputElement {
  	 * @private
  	*/
 	_parseNumber(formattedValue: string): number {
-		if (this._isScientificNotation(formattedValue)) {
-			return Number(formattedValue);
-		}
-
 		return this.formatter.parse(formattedValue) as number;
 	}
 

--- a/packages/main/src/StepInput.ts
+++ b/packages/main/src/StepInput.ts
@@ -54,6 +54,7 @@ const INITIAL_WAIT_TIMEOUT = 500; // milliseconds
 const ACCELERATION = 0.8;
 const MIN_WAIT_TIMEOUT = 50; // milliseconds
 const INITIAL_SPEED = 120; // milliseconds
+const MAX_FORMATTED_LENGTH = 25;
 
 type StepInputValueStateChangeEventDetail = {
 	valueState: `${ValueState}`,
@@ -577,6 +578,10 @@ class StepInput extends UI5Element implements IFormInputElement {
 	 * @param fireChangeEvent if `true`, fires `change` event when the value is changed
 	 */
 	_modifyValue(modifier: number, fireChangeEvent = false) {
+		if (this._isScientificNotation(this.value.toString())) {
+			this.value = this._defaultValue;
+		}
+
 		let value;
 		value = this.value + modifier;
 		if (this.min !== undefined && value < this.min) {
@@ -606,6 +611,9 @@ class StepInput extends UI5Element implements IFormInputElement {
  	 * @private
  	 */
 	_formatNumber(value: number): string {
+		if (this._isScientificNotation(value.toString()) || value.toString().length > MAX_FORMATTED_LENGTH) {
+			return parseFloat(value.toString()).toExponential(this.valuePrecision);
+		}
 		return this.formatter.format(value);
 	}
 

--- a/packages/main/src/StepInput.ts
+++ b/packages/main/src/StepInput.ts
@@ -534,8 +534,13 @@ class StepInput extends UI5Element implements IFormInputElement {
 	}
 
 	_updateValueState() {
-		const isWithinRange = (this.min === undefined || this._parseNumber(this.input.value) >= this.min)
-							  && (this.max === undefined || this._parseNumber(this.input.value) <= this.max);
+		let parsedValue = this._parseNumber(this.input.value);
+		if (this._isInfinity(parsedValue) && this._isScientificNotation(this.input.value)) {
+			parsedValue = this._defaultValue;
+		}
+
+		const isWithinRange = (this.min === undefined || parsedValue >= this.min)
+							  && (this.max === undefined || parsedValue <= this.max);
 		const isValueWithCorrectPrecision = this._isValueWithCorrectPrecision;
 		const previousValueState = this.valueState;
 		const isValid = isWithinRange && isValueWithCorrectPrecision;
@@ -648,24 +653,32 @@ class StepInput extends UI5Element implements IFormInputElement {
 		return decimalPartLength === this.valuePrecision;
 	}
 
+	_isInfinity(value: number) {
+		return Math.abs(value) === Infinity;
+	}
+
 	_onInputChange() {
 		this._setDefaultInputValueIfNeeded();
 		const updatedValue = this._removeGroupSeparators(this.input.value);
 		let inputValue = this._parseNumber(updatedValue);
-		const isInfinity = Math.abs(inputValue) === Infinity;
+		const isInfinity = this._isInfinity(inputValue);
 		if (isInfinity) {
-			inputValue = 0;
+			inputValue = this._defaultValue;
 		}
 
 		if (this._isValueChanged(inputValue) || isInfinity) {
-			this._updateValueAndValidate(Number.isNaN(inputValue) ? this.min || 0 : inputValue);
+			this._updateValueAndValidate(Number.isNaN(inputValue) ? this._defaultValue : inputValue);
 			this.innerInput.value = this.input.value;
 		}
 	}
 
+	get _defaultValue() {
+		return this.min !== undefined ? this.min : 0;
+	}
+
 	_setDefaultInputValueIfNeeded() {
 		if (this.input.value === "") {
-			const defaultValue = this._formatNumber(this.min || 0);
+			const defaultValue = this._formatNumber(this._defaultValue);
 			this.input.value = defaultValue;
 			this.innerInput.value = defaultValue; // we need to update inner input value as well, to avoid empty input scenario
 		}

--- a/packages/main/src/StepInput.ts
+++ b/packages/main/src/StepInput.ts
@@ -609,6 +609,10 @@ class StepInput extends UI5Element implements IFormInputElement {
  	 * @private
  	*/
 	_parseNumber(formattedValue: string): number {
+		if (this._isScientificNotation(formattedValue)) {
+			return Number(formattedValue);
+		}
+
 		return this.formatter.parse(formattedValue) as number;
 	}
 
@@ -627,6 +631,10 @@ class StepInput extends UI5Element implements IFormInputElement {
 	}
 
 	get _isValueWithCorrectPrecision() {
+		if (this._isScientificNotation(this.input?.value)) {
+			return true;
+		}
+
 		const delimiter = this.delimiter;
 		// check if the value will be displayed with correct precision
 		// _displayValue has special formatting logic
@@ -643,8 +651,13 @@ class StepInput extends UI5Element implements IFormInputElement {
 	_onInputChange() {
 		this._setDefaultInputValueIfNeeded();
 		const updatedValue = this._removeGroupSeparators(this.input.value);
-		const inputValue = this._parseNumber(updatedValue);
-		if (this._isValueChanged(inputValue)) {
+		let inputValue = this._parseNumber(updatedValue);
+		const isInfinity = Math.abs(inputValue) === Infinity;
+		if (isInfinity) {
+			inputValue = 0;
+		}
+
+		if (this._isValueChanged(inputValue) || isInfinity) {
 			this._updateValueAndValidate(Number.isNaN(inputValue) ? this.min || 0 : inputValue);
 			this.innerInput.value = this.input.value;
 		}
@@ -763,7 +776,18 @@ class StepInput extends UI5Element implements IFormInputElement {
 		return value.replaceAll(groupSeparator, "");
 	}
 
+	_isScientificNotation(value: string) {
+		const sEscapedDecimalSep = this.delimiter.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+		const oScientificNotationRegex = new RegExp(`^[+-]?\\d+(${sEscapedDecimalSep}\\d*)?[eE]([+-]?\\d+)?$`);
+
+		return oScientificNotationRegex.test(value);
+	}
+
 	_isInputValueValid(typedValue: string, parsedValue: number) {
+		if (this._isScientificNotation(typedValue)) {
+			return true;
+		}
+
 		return !Number.isNaN(parsedValue) && !/, {2,}/.test(typedValue);
 	}
 


### PR DESCRIPTION
This PR enhances the StepInput component to properly handle scientific notation (exponential notation using Euler's constant e), allowing users to input values like 1e3, 1.5e3, etc.

Background:
Previously, the StepInput component couldn't correctly parse and handle numbers written in scientific notation format (e.g., 1e3 for 1000, 1.5e-2 for 0.015). This is a common notation used in scientific and engineering applications, and the component now supports it to improve usability in these contexts.
