### PR TITLE
fix(website): fix CLDR crash for regional locales and rename React samples

### DIFF
--- a/packages/website/docs/_samples/ai/Button/ButtonMenu/sample.tsx
+++ b/packages/website/docs/_samples/ai/Button/ButtonMenu/sample.tsx
@@ -16,7 +16,7 @@ const Menu = createReactComponent(MenuClass);
 const MenuItem = createReactComponent(MenuItemClass);
 const MenuSeparator = createReactComponent(MenuSeparatorClass);
 
-function App() {
+export const Example = () => {
   const [buttonState, setButtonState] = useState("generate");
   const [menuOpen, setMenuOpen] = useState(false);
   const buttonRef = useRef(null);
@@ -132,5 +132,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/ai/Button/ButtonSplitMenu/sample.tsx
+++ b/packages/website/docs/_samples/ai/Button/ButtonSplitMenu/sample.tsx
@@ -13,7 +13,7 @@ const AIButtonState = createReactComponent(AIButtonStateClass);
 const Menu = createReactComponent(MenuClass);
 const MenuItem = createReactComponent(MenuItemClass);
 
-function App() {
+export const Example = () => {
   const [buttonState, setButtonState] = useState("generate");
   const [menuOpen, setMenuOpen] = useState(false);
   const buttonRef = useRef(null);
@@ -142,5 +142,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/ai/Button/IconOnlyButton/sample.tsx
+++ b/packages/website/docs/_samples/ai/Button/IconOnlyButton/sample.tsx
@@ -16,7 +16,7 @@ const Menu = createReactComponent(MenuClass);
 const MenuItem = createReactComponent(MenuItemClass);
 const MenuSeparator = createReactComponent(MenuSeparatorClass);
 
-function App() {
+export const Example = () => {
   const [buttonState, setButtonState] = useState("generate");
   const [menuOpen, setMenuOpen] = useState(false);
   const buttonRef = useRef(null);
@@ -114,5 +114,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/ai/Input/Basic/sample.tsx
+++ b/packages/website/docs/_samples/ai/Input/Basic/sample.tsx
@@ -128,7 +128,7 @@ interface VersionEntry {
   timestamp: string;
 }
 
-function App() {
+export const Example = () => {
   const inputRef = useRef<any>(null);
   const [inputValue, setInputValue] = useState("");
   const [loading, setLoading] = useState(false);
@@ -423,5 +423,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/ai/PromptInput/Basic/sample.tsx
+++ b/packages/website/docs/_samples/ai/PromptInput/Basic/sample.tsx
@@ -22,7 +22,7 @@ const countries = [
   "Bolivia",
 ];
 
-function App() {
+export const Example = () => {
   const [valueState, setValueState] = useState<`${ValueState}`>("None");
   const [suggestions, setSuggestions] = useState<string[]>([]);
 
@@ -63,5 +63,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/ai/TextArea/Basic/sample.tsx
+++ b/packages/website/docs/_samples/ai/TextArea/Basic/sample.tsx
@@ -18,7 +18,7 @@ interface VersionEntry {
   timestamp: string;
 }
 
-function App() {
+export const Example = () => {
   const textareaRef = useRef<any>(null);
   const menuRef = useRef<any>(null);
   const [textValue, setTextValue] = useState(
@@ -214,5 +214,3 @@ function App() {
     </AITextArea>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/ai/TextArea/Extended/sample.tsx
+++ b/packages/website/docs/_samples/ai/TextArea/Extended/sample.tsx
@@ -126,7 +126,7 @@ interface VersionEntry {
   timestamp: string;
 }
 
-function App() {
+export const Example = () => {
   const textareaRef = useRef<any>(null);
   const [textValue, setTextValue] = useState(
     "Innovation managers operate with both creativity and business acumen, driving initiatives that cultivate an innovation-friendly culture.",
@@ -447,5 +447,3 @@ function App() {
     </div>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/compat/Table/ActiveRows/sample.tsx
+++ b/packages/website/docs/_samples/compat/Table/ActiveRows/sample.tsx
@@ -11,7 +11,7 @@ const CompatTableColumn = createReactComponent(TableColumnClass);
 const CompatTableCell = createReactComponent(CompatTableCellClass);
 const Text = createReactComponent(TextClass);
 
-function App() {
+export const Example = () => {
   return (
     <CompatTable>
       <CompatTableColumn slot="columns">
@@ -76,5 +76,3 @@ function App() {
     </CompatTable>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/compat/Table/Basic/sample.tsx
+++ b/packages/website/docs/_samples/compat/Table/Basic/sample.tsx
@@ -11,7 +11,7 @@ const TableColumn = createReactComponent(TableColumnClass);
 const CompatTableCell = createReactComponent(CompatTableCellClass);
 const Text = createReactComponent(TextClass);
 
-function App() {
+export const Example = () => {
   return (
     <CompatTable>
       <TableColumn slot="columns">
@@ -98,5 +98,3 @@ function App() {
     </CompatTable>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/compat/Table/Grouping/sample.tsx
+++ b/packages/website/docs/_samples/compat/Table/Grouping/sample.tsx
@@ -15,7 +15,7 @@ const TableGroupRow = createReactComponent(TableGroupRowClass);
 const Text = createReactComponent(TextClass);
 const Label = createReactComponent(LabelClass);
 
-function App() {
+export const Example = () => {
   return (
     <CompatTable>
       <CompatTableColumn slot="columns">
@@ -85,5 +85,3 @@ function App() {
     </CompatTable>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/compat/Table/GrowingOnButtonPress/sample.tsx
+++ b/packages/website/docs/_samples/compat/Table/GrowingOnButtonPress/sample.tsx
@@ -137,7 +137,7 @@ const products = [
 
 const ROWS_PER_LOAD = 2;
 
-function App() {
+export const Example = () => {
   const [visibleCount, setVisibleCount] = useState(2);
   const [busy, setBusy] = useState(false);
 
@@ -228,5 +228,3 @@ function App() {
     </CompatTable>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/compat/Table/GrowingOnScroll/sample.tsx
+++ b/packages/website/docs/_samples/compat/Table/GrowingOnScroll/sample.tsx
@@ -137,7 +137,7 @@ const products = [
 
 const ROWS_PER_LOAD = 2;
 
-function App() {
+export const Example = () => {
   const [visibleCount, setVisibleCount] = useState(2);
   const [busy, setBusy] = useState(false);
 
@@ -209,5 +209,3 @@ function App() {
     </div>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/compat/Table/MultipleSelection/sample.tsx
+++ b/packages/website/docs/_samples/compat/Table/MultipleSelection/sample.tsx
@@ -11,7 +11,7 @@ const CompatTableColumn = createReactComponent(TableColumnClass);
 const CompatTableCell = createReactComponent(CompatTableCellClass);
 const Text = createReactComponent(TextClass);
 
-function App() {
+export const Example = () => {
   return (
     <CompatTable mode="MultiSelect">
       <CompatTableColumn slot="columns" popinDisplay="Inline">
@@ -116,5 +116,3 @@ function App() {
     </CompatTable>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/compat/Table/NoData/sample.tsx
+++ b/packages/website/docs/_samples/compat/Table/NoData/sample.tsx
@@ -7,7 +7,7 @@ const CompatTable = createReactComponent(CompatTableClass);
 const CompatTableColumn = createReactComponent(TableColumnClass);
 const Text = createReactComponent(TextClass);
 
-function App() {
+export const Example = () => {
   return (
     <CompatTable noDataText="No data found">
       <CompatTableColumn slot="columns">
@@ -28,5 +28,3 @@ function App() {
     </CompatTable>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/compat/Table/Popin/sample.tsx
+++ b/packages/website/docs/_samples/compat/Table/Popin/sample.tsx
@@ -11,7 +11,7 @@ const CompatTableColumn = createReactComponent(TableColumnClass);
 const CompatTableCell = createReactComponent(CompatTableCellClass);
 const Text = createReactComponent(TextClass);
 
-function App() {
+export const Example = () => {
   return (
     <CompatTable>
       <CompatTableColumn slot="columns" popinDisplay="Inline">
@@ -116,5 +116,3 @@ function App() {
     </CompatTable>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/compat/Table/SingleSelection/sample.tsx
+++ b/packages/website/docs/_samples/compat/Table/SingleSelection/sample.tsx
@@ -11,7 +11,7 @@ const CompatTableColumn = createReactComponent(TableColumnClass);
 const CompatTableCell = createReactComponent(CompatTableCellClass);
 const Text = createReactComponent(TextClass);
 
-function App() {
+export const Example = () => {
   return (
     <CompatTable mode="SingleSelect">
       <CompatTableColumn slot="columns" popinDisplay="Inline">
@@ -116,5 +116,3 @@ function App() {
     </CompatTable>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/compat/Table/StickyHeader/sample.tsx
+++ b/packages/website/docs/_samples/compat/Table/StickyHeader/sample.tsx
@@ -11,7 +11,7 @@ const CompatTableColumn = createReactComponent(TableColumnClass);
 const CompatTableCell = createReactComponent(CompatTableCellClass);
 const Text = createReactComponent(TextClass);
 
-function App() {
+export const Example = () => {
   return (
     <div style={{ height: "150px", overflow: "scroll" }}>
       <CompatTable stickyColumnHeader>
@@ -154,5 +154,3 @@ function App() {
     </div>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/BardcodeScannerDialog/Basic/sample.tsx
+++ b/packages/website/docs/_samples/fiori/BardcodeScannerDialog/Basic/sample.tsx
@@ -10,7 +10,7 @@ const BarcodeScannerDialog = createReactComponent(BarcodeScannerDialogClass);
 const Button = createReactComponent(ButtonClass);
 const Label = createReactComponent(LabelClass);
 
-function App() {
+export const Example = () => {
   const [open, setOpen] = useState(false);
   const [scanResult, setScanResult] = useState("");
   const [scanError, setScanError] = useState("");
@@ -54,5 +54,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/DynamicPage/Basic/sample.tsx
+++ b/packages/website/docs/_samples/fiori/DynamicPage/Basic/sample.tsx
@@ -35,7 +35,7 @@ const Title = createReactComponent(TitleClass);
 const Toolbar = createReactComponent(ToolbarClass);
 const ToolbarButton = createReactComponent(ToolbarButtonClass);
 
-function App() {
+export const Example = () => {
   const [showFooter, setShowFooter] = useState(true);
 
   const handleEditButtonClick = () => {
@@ -914,5 +914,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/DynamicSideContent/Basic/sample.tsx
+++ b/packages/website/docs/_samples/fiori/DynamicSideContent/Basic/sample.tsx
@@ -5,7 +5,7 @@ import TitleClass from "@ui5/webcomponents/dist/Title.js";
 const DynamicSideContent = createReactComponent(DynamicSideContentClass);
 const Title = createReactComponent(TitleClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <style>{`
@@ -57,5 +57,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/DynamicSideContent/EqualSplit/sample.tsx
+++ b/packages/website/docs/_samples/fiori/DynamicSideContent/EqualSplit/sample.tsx
@@ -5,7 +5,7 @@ import TitleClass from "@ui5/webcomponents/dist/Title.js";
 const DynamicSideContent = createReactComponent(DynamicSideContentClass);
 const Title = createReactComponent(TitleClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <style>{`
@@ -60,5 +60,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/DynamicSideContent/SideContentPosition/sample.tsx
+++ b/packages/website/docs/_samples/fiori/DynamicSideContent/SideContentPosition/sample.tsx
@@ -5,7 +5,7 @@ import TitleClass from "@ui5/webcomponents/dist/Title.js";
 const DynamicSideContent = createReactComponent(DynamicSideContentClass);
 const Title = createReactComponent(TitleClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <style>{`
@@ -60,5 +60,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/FlexibleColumnLayout/Basic/sample.tsx
+++ b/packages/website/docs/_samples/fiori/FlexibleColumnLayout/Basic/sample.tsx
@@ -89,7 +89,7 @@ function getRandomInt(max: number) {
   return Math.floor(Math.random() * Math.floor(max));
 }
 
-function App() {
+export const Example = () => {
   const [layout, setLayout] = useState<`${FCLLayout}`>("OneColumn");
   const [col2Title, setCol2Title] = useState("");
   const [col3Title, setCol3Title] = useState("");
@@ -611,5 +611,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/FlexibleColumnLayout/LayoutsConfiguration/sample.tsx
+++ b/packages/website/docs/_samples/fiori/FlexibleColumnLayout/LayoutsConfiguration/sample.tsx
@@ -146,7 +146,7 @@ const layoutsConfiguration = {
   },
 };
 
-function App() {
+export const Example = () => {
   const fclRef = useRef(null);
   const selectLayoutRef = useRef(null);
 
@@ -455,5 +455,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/IllustratedMessage/Basic/sample.tsx
+++ b/packages/website/docs/_samples/fiori/IllustratedMessage/Basic/sample.tsx
@@ -5,7 +5,7 @@ import ButtonClass from "@ui5/webcomponents/dist/Button.js";
 const IllustratedMessage = createReactComponent(IllustratedMessageClass);
 const Button = createReactComponent(ButtonClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <IllustratedMessage name="UnableToUpload">
@@ -15,5 +15,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/IllustratedMessage/CustomTitle/sample.tsx
+++ b/packages/website/docs/_samples/fiori/IllustratedMessage/CustomTitle/sample.tsx
@@ -9,7 +9,7 @@ const Button = createReactComponent(ButtonClass);
 const Link = createReactComponent(LinkClass);
 const Title = createReactComponent(TitleClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <IllustratedMessage name="UnableToUpload">
@@ -25,5 +25,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/IllustratedMessage/WithDialog/sample.tsx
+++ b/packages/website/docs/_samples/fiori/IllustratedMessage/WithDialog/sample.tsx
@@ -10,7 +10,7 @@ const Bar = createReactComponent(BarClass);
 const Button = createReactComponent(ButtonClass);
 const Dialog = createReactComponent(DialogClass);
 
-function App() {
+export const Example = () => {
   const [dialogOpen, setDialogOpen] = useState(false);
 
   return (
@@ -39,5 +39,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/MediaGallery/Basic/sample.tsx
+++ b/packages/website/docs/_samples/fiori/MediaGallery/Basic/sample.tsx
@@ -5,7 +5,7 @@ import MediaGalleryItemClass from "@ui5/webcomponents-fiori/dist/MediaGalleryIte
 const MediaGallery = createReactComponent(MediaGalleryClass);
 const MediaGalleryItem = createReactComponent(MediaGalleryItemClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <style>{`
@@ -42,5 +42,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/MediaGallery/Horizontal/sample.tsx
+++ b/packages/website/docs/_samples/fiori/MediaGallery/Horizontal/sample.tsx
@@ -5,7 +5,7 @@ import MediaGalleryItemClass from "@ui5/webcomponents-fiori/dist/MediaGalleryIte
 const MediaGallery = createReactComponent(MediaGalleryClass);
 const MediaGalleryItem = createReactComponent(MediaGalleryItemClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <style>{`
@@ -46,5 +46,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/MediaGallery/Interactive/sample.tsx
+++ b/packages/website/docs/_samples/fiori/MediaGallery/Interactive/sample.tsx
@@ -16,7 +16,7 @@ const Dialog = createReactComponent(DialogClass);
 const Label = createReactComponent(LabelClass);
 const Title = createReactComponent(TitleClass);
 
-function App() {
+export const Example = () => {
   const mediaGalleryDialogRef = useRef(null);
 
   const handleCloseDialogButtonClick = () => {
@@ -150,5 +150,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/MediaGallery/ThumbnailCustom/sample.tsx
+++ b/packages/website/docs/_samples/fiori/MediaGallery/ThumbnailCustom/sample.tsx
@@ -5,7 +5,7 @@ import MediaGalleryItemClass from "@ui5/webcomponents-fiori/dist/MediaGalleryIte
 const MediaGallery = createReactComponent(MediaGalleryClass);
 const MediaGalleryItem = createReactComponent(MediaGalleryItemClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <style>{`
@@ -32,5 +32,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/MediaGallery/Vertical/sample.tsx
+++ b/packages/website/docs/_samples/fiori/MediaGallery/Vertical/sample.tsx
@@ -5,7 +5,7 @@ import MediaGalleryItemClass from "@ui5/webcomponents-fiori/dist/MediaGalleryIte
 const MediaGallery = createReactComponent(MediaGalleryClass);
 const MediaGalleryItem = createReactComponent(MediaGalleryItemClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <style>{`
@@ -42,5 +42,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/MediaGallery/VideoContent/sample.tsx
+++ b/packages/website/docs/_samples/fiori/MediaGallery/VideoContent/sample.tsx
@@ -5,7 +5,7 @@ import MediaGalleryItemClass from "@ui5/webcomponents-fiori/dist/MediaGalleryIte
 const MediaGallery = createReactComponent(MediaGalleryClass);
 const MediaGalleryItem = createReactComponent(MediaGalleryItemClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <style>{`
@@ -38,5 +38,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/MediaGallery/WithDisabledItem/sample.tsx
+++ b/packages/website/docs/_samples/fiori/MediaGallery/WithDisabledItem/sample.tsx
@@ -5,7 +5,7 @@ import MediaGalleryItemClass from "@ui5/webcomponents-fiori/dist/MediaGalleryIte
 const MediaGallery = createReactComponent(MediaGalleryClass);
 const MediaGalleryItem = createReactComponent(MediaGalleryItemClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <style>{`
@@ -42,5 +42,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/MediaGallery/WithSelectedItem/sample.tsx
+++ b/packages/website/docs/_samples/fiori/MediaGallery/WithSelectedItem/sample.tsx
@@ -5,7 +5,7 @@ import MediaGalleryItemClass from "@ui5/webcomponents-fiori/dist/MediaGalleryIte
 const MediaGallery = createReactComponent(MediaGalleryClass);
 const MediaGalleryItem = createReactComponent(MediaGalleryItemClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <style>{`
@@ -30,5 +30,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/NavigationLayout/Basic/sample.tsx
+++ b/packages/website/docs/_samples/fiori/NavigationLayout/Basic/sample.tsx
@@ -67,7 +67,7 @@ const contentPages = [
   { id: "subitem6", title: "Sub Item 6" },
 ];
 
-function App() {
+export const Example = () => {
   const navLayoutRef = useRef(null);
   const [activePage, setActivePage] = useState("home");
 
@@ -224,5 +224,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/NotificationList/Basic/sample.tsx
+++ b/packages/website/docs/_samples/fiori/NotificationList/Basic/sample.tsx
@@ -15,7 +15,7 @@ const Menu = createReactComponent(MenuClass);
 const MenuItem = createReactComponent(MenuItemClass);
 const Toast = createReactComponent(ToastClass);
 
-function App() {
+export const Example = () => {
   const toastRef = useRef(null);
 
   const handleNotificationListItemClose = (
@@ -101,5 +101,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/NotificationList/GroupItems/sample.tsx
+++ b/packages/website/docs/_samples/fiori/NotificationList/GroupItems/sample.tsx
@@ -19,7 +19,7 @@ const Avatar = createReactComponent(AvatarClass);
 const Menu = createReactComponent(MenuClass);
 const MenuItem = createReactComponent(MenuItemClass);
 
-function App() {
+export const Example = () => {
   const handleNotificationListItemClose = (
     e: UI5CustomEvent<NotificationListClass, "item-close">,
   ) => {
@@ -154,5 +154,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/NotificationList/InShellBar/sample.tsx
+++ b/packages/website/docs/_samples/fiori/NotificationList/InShellBar/sample.tsx
@@ -42,7 +42,7 @@ const Popover = createReactComponent(PopoverClass);
 const Text = createReactComponent(TextClass);
 const Title = createReactComponent(TitleClass);
 
-function App() {
+export const Example = () => {
   const clearAllDialogRef = useRef(null);
   const notificationsListGroupGrowingRef = useRef(null);
   const popoverRef = useRef(null);
@@ -525,5 +525,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/Page/Basic/sample.tsx
+++ b/packages/website/docs/_samples/fiori/Page/Basic/sample.tsx
@@ -11,7 +11,7 @@ const Bar = createReactComponent(BarClass);
 const Button = createReactComponent(ButtonClass);
 const Label = createReactComponent(LabelClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Page style={{ height: "500px" }} background-design="Solid">
@@ -83,5 +83,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/Page/FixedFooter/sample.tsx
+++ b/packages/website/docs/_samples/fiori/Page/FixedFooter/sample.tsx
@@ -11,7 +11,7 @@ const Bar = createReactComponent(BarClass);
 const Button = createReactComponent(ButtonClass);
 const Label = createReactComponent(LabelClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Page style={{ height: "500px" }} background-design="Transparent">
@@ -132,5 +132,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/ProductSwitch/Basic/sample.tsx
+++ b/packages/website/docs/_samples/fiori/ProductSwitch/Basic/sample.tsx
@@ -9,7 +9,7 @@ import "@ui5/webcomponents-icons/dist/flight.js";
 const ProductSwitch = createReactComponent(ProductSwitchClass);
 const ProductSwitchItem = createReactComponent(ProductSwitchItemClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <ProductSwitch>
@@ -37,5 +37,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/ProductSwitch/WithImageSlot/sample.tsx
+++ b/packages/website/docs/_samples/fiori/ProductSwitch/WithImageSlot/sample.tsx
@@ -11,7 +11,7 @@ const ProductSwitch = createReactComponent(ProductSwitchClass);
 const ProductSwitchItem = createReactComponent(ProductSwitchItemClass);
 const Avatar = createReactComponent(AvatarClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <ProductSwitch>
@@ -53,5 +53,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/ProductSwitch/WithShellBar/sample.tsx
+++ b/packages/website/docs/_samples/fiori/ProductSwitch/WithShellBar/sample.tsx
@@ -31,7 +31,7 @@ const ShellBarBranding = createReactComponent(ShellBarBrandingClass);
 const Popover = createReactComponent(PopoverClass);
 const ToggleButton = createReactComponent(ToggleButtonClass);
 
-function App() {
+export const Example = () => {
   const popoverRef = useRef(null);
   const [assistantIcon, setAssistantIcon] = useState("da");
 
@@ -131,5 +131,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/Search/Actions/sample.tsx
+++ b/packages/website/docs/_samples/fiori/Search/Actions/sample.tsx
@@ -9,7 +9,7 @@ const Search = createReactComponent(SearchClass);
 const SearchItem = createReactComponent(SearchItemClass);
 const Button = createReactComponent(ButtonClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Search id="actions-search" showClearIcon={true}>
@@ -34,5 +34,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/Search/Advanced/sample.tsx
+++ b/packages/website/docs/_samples/fiori/Search/Advanced/sample.tsx
@@ -19,7 +19,7 @@ const data = [
   { name: "Tomato", category: "Vegetable" },
 ];
 
-function App() {
+export const Example = () => {
   const [items, setItems] = useState(data);
 
   const handleFilteringInput = (e: UI5CustomEvent<SearchClass, "input">) => {
@@ -62,5 +62,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/Search/AdvancedFilter/sample.tsx
+++ b/packages/website/docs/_samples/fiori/Search/AdvancedFilter/sample.tsx
@@ -9,7 +9,7 @@ const Search = createReactComponent(SearchClass);
 const Button = createReactComponent(ButtonClass);
 const Toast = createReactComponent(ToastClass);
 
-function App() {
+export const Example = () => {
   const [toastOpen, setToastOpen] = useState(false);
 
   return (
@@ -33,5 +33,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/Search/Basic/sample.tsx
+++ b/packages/website/docs/_samples/fiori/Search/Basic/sample.tsx
@@ -18,7 +18,7 @@ const scopeData = [
   { name: "Tablet", scope: "products" },
 ];
 
-function App() {
+export const Example = () => {
   const [currentScope, setCurrentScope] = useState("");
 
   const filteredItems = currentScope
@@ -51,5 +51,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/Search/Byline/sample.tsx
+++ b/packages/website/docs/_samples/fiori/Search/Byline/sample.tsx
@@ -10,7 +10,7 @@ const SearchItem = createReactComponent(SearchItemClass);
 const SearchItemGroup = createReactComponent(SearchItemGroupClass);
 const Avatar = createReactComponent(AvatarClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Search showClearIcon={true} placeholder="Type D to search ...">
@@ -48,5 +48,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/Search/Loading/sample.tsx
+++ b/packages/website/docs/_samples/fiori/Search/Loading/sample.tsx
@@ -8,7 +8,7 @@ const SearchField = createReactComponent(SearchFieldClass);
 const Label = createReactComponent(LabelClass);
 const Text = createReactComponent(TextClass);
 
-function App() {
+export const Example = () => {
   const [resultText, setResultText] = useState(
     "Enter a search term and press Enter or click the search icon",
   );
@@ -48,5 +48,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/Search/ShowMore/sample.tsx
+++ b/packages/website/docs/_samples/fiori/Search/ShowMore/sample.tsx
@@ -27,7 +27,7 @@ const allItems = [
 
 const visibleCount = 3;
 
-function App() {
+export const Example = () => {
   const [expanded, setExpanded] = useState(false);
   const [group1Items, setGroup1Items] = useState(allItems);
 
@@ -83,5 +83,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/ShellBar/Advanced/sample.tsx
+++ b/packages/website/docs/_samples/fiori/ShellBar/Advanced/sample.tsx
@@ -30,7 +30,7 @@ const Tag = createReactComponent(TagClass);
 const Text = createReactComponent(TextClass);
 const ToggleButton = createReactComponent(ToggleButtonClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <ShellBar
@@ -73,5 +73,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/ShellBar/Basic/sample.tsx
+++ b/packages/website/docs/_samples/fiori/ShellBar/Basic/sample.tsx
@@ -19,7 +19,7 @@ const Avatar = createReactComponent(AvatarClass);
 const Button = createReactComponent(ButtonClass);
 const ToggleButton = createReactComponent(ToggleButtonClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <ShellBar notificationsCount="72" showNotifications={true}>
@@ -43,5 +43,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/ShellBar/EmbeddedBackNavigation/sample.tsx
+++ b/packages/website/docs/_samples/fiori/ShellBar/EmbeddedBackNavigation/sample.tsx
@@ -21,7 +21,7 @@ const Avatar = createReactComponent(AvatarClass);
 const Button = createReactComponent(ButtonClass);
 const ToggleButton = createReactComponent(ToggleButtonClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <ShellBar notificationsCount="72" showNotifications={true}>
@@ -46,5 +46,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/ShellBar/MultipleNonProductiveInstances/sample.tsx
+++ b/packages/website/docs/_samples/fiori/ShellBar/MultipleNonProductiveInstances/sample.tsx
@@ -23,7 +23,7 @@ const Tag = createReactComponent(TagClass);
 const Text = createReactComponent(TextClass);
 const ToggleButton = createReactComponent(ToggleButtonClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <ShellBar
@@ -84,5 +84,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/ShellBar/MultipleProductiveInstances/sample.tsx
+++ b/packages/website/docs/_samples/fiori/ShellBar/MultipleProductiveInstances/sample.tsx
@@ -19,7 +19,7 @@ const Button = createReactComponent(ButtonClass);
 const Tag = createReactComponent(TagClass);
 const ToggleButton = createReactComponent(ToggleButtonClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <ShellBar
@@ -75,5 +75,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/ShellBar/Overflow/sample.tsx
+++ b/packages/website/docs/_samples/fiori/ShellBar/Overflow/sample.tsx
@@ -29,7 +29,7 @@ const ShellBar = createReactComponent(ShellBarClass);
 const ShellBarBranding = createReactComponent(ShellBarBrandingClass);
 const ShellBarItem = createReactComponent(ShellBarItemClass);
 
-function App() {
+export const Example = () => {
   const [containerWidth, setContainerWidth] = useState(100);
   const [hiddenItems, setHiddenItems] = useState<any[]>([]);
   const [popoverOpen, setPopoverOpen] = useState(false);
@@ -122,5 +122,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/ShellBar/TrialExample/sample.tsx
+++ b/packages/website/docs/_samples/fiori/ShellBar/TrialExample/sample.tsx
@@ -21,7 +21,7 @@ const Tag = createReactComponent(TagClass);
 const Text = createReactComponent(TextClass);
 const ToggleButton = createReactComponent(ToggleButtonClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <ShellBar
@@ -51,5 +51,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/SideNavigation/Basic/sample.tsx
+++ b/packages/website/docs/_samples/fiori/SideNavigation/Basic/sample.tsx
@@ -16,7 +16,7 @@ const SideNavigationGroup = createReactComponent(SideNavigationGroupClass);
 const SideNavigationItem = createReactComponent(SideNavigationItemClass);
 const SideNavigationSubItem = createReactComponent(SideNavigationSubItemClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <style>{`
@@ -81,5 +81,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/SideNavigation/CustomWidth/sample.tsx
+++ b/packages/website/docs/_samples/fiori/SideNavigation/CustomWidth/sample.tsx
@@ -17,7 +17,7 @@ const SideNavigationGroup = createReactComponent(SideNavigationGroupClass);
 const SideNavigationItem = createReactComponent(SideNavigationItemClass);
 const SideNavigationSubItem = createReactComponent(SideNavigationSubItemClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <style>{`
@@ -79,5 +79,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/SideNavigation/OverlayMode/sample.tsx
+++ b/packages/website/docs/_samples/fiori/SideNavigation/OverlayMode/sample.tsx
@@ -50,7 +50,7 @@ const Text = createReactComponent(TextClass);
 const Title = createReactComponent(TitleClass);
 const ToggleButton = createReactComponent(ToggleButtonClass);
 
-function App() {
+export const Example = () => {
   const [navOpen, setNavOpen] = useState(false);
   const [dialogOpen, setDialogOpen] = useState(false);
 
@@ -342,5 +342,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/SideNavigation/QuickAction/sample.tsx
+++ b/packages/website/docs/_samples/fiori/SideNavigation/QuickAction/sample.tsx
@@ -22,7 +22,7 @@ const Button = createReactComponent(ButtonClass);
 const Dialog = createReactComponent(DialogClass);
 const Text = createReactComponent(TextClass);
 
-function App() {
+export const Example = () => {
   const [dialogOpen, setDialogOpen] = useState(false);
   const quickActionRef = useRef(null);
 
@@ -98,5 +98,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/SideNavigation/UnselectableParentItems/sample.tsx
+++ b/packages/website/docs/_samples/fiori/SideNavigation/UnselectableParentItems/sample.tsx
@@ -11,7 +11,7 @@ const SideNavigation = createReactComponent(SideNavigationClass);
 const SideNavigationItem = createReactComponent(SideNavigationItemClass);
 const SideNavigationSubItem = createReactComponent(SideNavigationSubItemClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <style>{`
@@ -52,5 +52,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/Timeline/Basic/sample.tsx
+++ b/packages/website/docs/_samples/fiori/Timeline/Basic/sample.tsx
@@ -9,7 +9,7 @@ const Timeline = createReactComponent(TimelineClass);
 const TimelineItem = createReactComponent(TimelineItemClass);
 const Label = createReactComponent(LabelClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Timeline>
@@ -47,5 +47,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/Timeline/Horizontal/sample.tsx
+++ b/packages/website/docs/_samples/fiori/Timeline/Horizontal/sample.tsx
@@ -9,7 +9,7 @@ const Timeline = createReactComponent(TimelineClass);
 const TimelineItem = createReactComponent(TimelineItemClass);
 const Label = createReactComponent(LabelClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Timeline layout="Horizontal">
@@ -40,5 +40,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/Timeline/InCard/sample.tsx
+++ b/packages/website/docs/_samples/fiori/Timeline/InCard/sample.tsx
@@ -13,7 +13,7 @@ const Card = createReactComponent(CardClass);
 const CardHeader = createReactComponent(CardHeaderClass);
 const Label = createReactComponent(LabelClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Card>
@@ -54,5 +54,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/Timeline/WithGroups/sample.tsx
+++ b/packages/website/docs/_samples/fiori/Timeline/WithGroups/sample.tsx
@@ -13,7 +13,7 @@ const TimelineItem = createReactComponent(TimelineItemClass);
 const Avatar = createReactComponent(AvatarClass);
 const Label = createReactComponent(LabelClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Timeline layout="Vertical" id="testTimeline">
@@ -94,5 +94,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/Timeline/WithGrowing/sample.tsx
+++ b/packages/website/docs/_samples/fiori/Timeline/WithGrowing/sample.tsx
@@ -12,7 +12,7 @@ const Label = createReactComponent(LabelClass);
 
 const itemToLoad = 5;
 
-function App() {
+export const Example = () => {
   const timelineRef = useRef(null);
   const [extraItems, setExtraItems] = useState<
     { titleText: string; subtitleText: string; icon: string }[]
@@ -97,5 +97,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/Timeline/WithState/sample.tsx
+++ b/packages/website/docs/_samples/fiori/Timeline/WithState/sample.tsx
@@ -11,7 +11,7 @@ const Timeline = createReactComponent(TimelineClass);
 const TimelineGroupItem = createReactComponent(TimelineGroupItemClass);
 const TimelineItem = createReactComponent(TimelineItemClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Timeline id="test-timeline">
@@ -68,5 +68,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/UploadCollection/Basic/sample.tsx
+++ b/packages/website/docs/_samples/fiori/UploadCollection/Basic/sample.tsx
@@ -20,7 +20,7 @@ const Icon = createReactComponent(IconClass);
 const Label = createReactComponent(LabelClass);
 const Title = createReactComponent(TitleClass);
 
-function App() {
+export const Example = () => {
   const uploadCollectionRef = useRef(null);
   const [newFiles, setNewFiles] = useState<
     {
@@ -154,5 +154,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/UploadCollection/DragAndDrop/sample.tsx
+++ b/packages/website/docs/_samples/fiori/UploadCollection/DragAndDrop/sample.tsx
@@ -19,7 +19,7 @@ const Icon = createReactComponent(IconClass);
 const Label = createReactComponent(LabelClass);
 const Title = createReactComponent(TitleClass);
 
-function App() {
+export const Example = () => {
   const [items, setItems] = useState<
     {
       id: number;
@@ -155,5 +155,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/UploadCollection/RenamingFiles/sample.tsx
+++ b/packages/website/docs/_samples/fiori/UploadCollection/RenamingFiles/sample.tsx
@@ -37,7 +37,7 @@ const initialFiles = [
   },
 ];
 
-function App() {
+export const Example = () => {
   const [files, setFiles] = useState(initialFiles);
 
   const handleUploadCollectionRename = (
@@ -83,5 +83,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/UploadCollection/VariousUploadStates/sample.tsx
+++ b/packages/website/docs/_samples/fiori/UploadCollection/VariousUploadStates/sample.tsx
@@ -51,7 +51,7 @@ const initialFiles = [
   },
 ];
 
-function App() {
+export const Example = () => {
   const [files, setFiles] = useState(initialFiles);
 
   const handleUploadCollectionRetry = (
@@ -104,5 +104,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/UserMenu/Advanced/sample.tsx
+++ b/packages/website/docs/_samples/fiori/UserMenu/Advanced/sample.tsx
@@ -21,7 +21,7 @@ const UserMenuAccount = createReactComponent(UserMenuAccountClass);
 const UserMenuItem = createReactComponent(UserMenuItemClass);
 const Avatar = createReactComponent(AvatarClass);
 
-function App() {
+export const Example = () => {
   const [menuOpen, setMenuOpen] = useState(false);
   const openerRef = useRef(null);
 
@@ -154,5 +154,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/UserMenu/Basic/sample.tsx
+++ b/packages/website/docs/_samples/fiori/UserMenu/Basic/sample.tsx
@@ -21,7 +21,7 @@ const UserMenuAccount = createReactComponent(UserMenuAccountClass);
 const UserMenuItem = createReactComponent(UserMenuItemClass);
 const Avatar = createReactComponent(AvatarClass);
 
-function App() {
+export const Example = () => {
   const [menuOpen, setMenuOpen] = useState(false);
   const openerRef = useRef(null);
 
@@ -114,5 +114,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/UserSettingsDialog/Basic/sample.tsx
+++ b/packages/website/docs/_samples/fiori/UserSettingsDialog/Basic/sample.tsx
@@ -70,7 +70,7 @@ const Toast = createReactComponent(ToastClass);
 const Toolbar = createReactComponent(ToolbarClass);
 const ToolbarButton = createReactComponent(ToolbarButtonClass);
 
-function App() {
+export const Example = () => {
   const additionalDialogRef = useRef(null);
   const mobileSecondPageRef = useRef(null);
   const toastResetRef = useRef(null);
@@ -851,5 +851,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/ViewSettingsDialog/Basic/sample.tsx
+++ b/packages/website/docs/_samples/fiori/ViewSettingsDialog/Basic/sample.tsx
@@ -14,7 +14,7 @@ const ViewSettingsDialog = createReactComponent(ViewSettingsDialogClass);
 const Button = createReactComponent(ButtonClass);
 const GroupItem = createReactComponent(GroupItemClass);
 
-function App() {
+export const Example = () => {
   const [vsdOpen, setVsdOpen] = useState(false);
   const vsdResultsRef = useRef(null);
 
@@ -80,5 +80,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/Wizard/Basic/sample.tsx
+++ b/packages/website/docs/_samples/fiori/Wizard/Basic/sample.tsx
@@ -28,7 +28,7 @@ const Select = createReactComponent(SelectClass);
 const Switch = createReactComponent(SwitchClass);
 const Title = createReactComponent(TitleClass);
 
-function App() {
+export const Example = () => {
   const [step1Selected, setStep1Selected] = useState(true);
   const [step2Selected, setStep2Selected] = useState(false);
   const [step3Selected, setStep3Selected] = useState(false);
@@ -246,5 +246,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/fiori/Wizard/PageMode/sample.tsx
+++ b/packages/website/docs/_samples/fiori/Wizard/PageMode/sample.tsx
@@ -31,7 +31,7 @@ const Select = createReactComponent(SelectClass);
 const Switch = createReactComponent(SwitchClass);
 const Title = createReactComponent(TitleClass);
 
-function App() {
+export const Example = () => {
   const [dialogOpen, setDialogOpen] = useState(false);
   const wizardRef = useRef<any>(null);
   const [showPrev, setShowPrev] = useState(false);
@@ -300,5 +300,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Avatar/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/Avatar/Basic/sample.tsx
@@ -3,8 +3,6 @@ import AvatarClass from "@ui5/webcomponents/dist/Avatar.js";
 
 const Avatar = createReactComponent(AvatarClass);
 
-function App() {
+export const Example = () => {
   return <Avatar initials="FJ" />;
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Avatar/ColorSchemes/sample.tsx
+++ b/packages/website/docs/_samples/main/Avatar/ColorSchemes/sample.tsx
@@ -3,7 +3,7 @@ import AvatarClass from "@ui5/webcomponents/dist/Avatar.js";
 
 const Avatar = createReactComponent(AvatarClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Avatar colorScheme="Accent1" />
@@ -19,5 +19,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Avatar/Decorative/sample.tsx
+++ b/packages/website/docs/_samples/main/Avatar/Decorative/sample.tsx
@@ -5,7 +5,7 @@ import LabelClass from "@ui5/webcomponents/dist/Label.js";
 const Avatar = createReactComponent(AvatarClass);
 const Label = createReactComponent(LabelClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <style>{`
@@ -36,5 +36,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Avatar/Interactive/sample.tsx
+++ b/packages/website/docs/_samples/main/Avatar/Interactive/sample.tsx
@@ -6,7 +6,7 @@ import LabelClass from "@ui5/webcomponents/dist/Label.js";
 const Avatar = createReactComponent(AvatarClass);
 const Label = createReactComponent(LabelClass);
 
-function App() {
+export const Example = () => {
   const counterRef = useRef(0);
   const [labelText, setLabelText] = useState("");
 
@@ -28,5 +28,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Avatar/Shapes/sample.tsx
+++ b/packages/website/docs/_samples/main/Avatar/Shapes/sample.tsx
@@ -3,7 +3,7 @@ import AvatarClass from "@ui5/webcomponents/dist/Avatar.js";
 
 const Avatar = createReactComponent(AvatarClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Avatar shape="Circle" size="M" initials="CI" />
@@ -12,5 +12,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Avatar/Sizes/sample.tsx
+++ b/packages/website/docs/_samples/main/Avatar/Sizes/sample.tsx
@@ -3,7 +3,7 @@ import AvatarClass from "@ui5/webcomponents/dist/Avatar.js";
 
 const Avatar = createReactComponent(AvatarClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Avatar initials="XS" size="XS" />
@@ -14,5 +14,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Avatar/Styles/sample.tsx
+++ b/packages/website/docs/_samples/main/Avatar/Styles/sample.tsx
@@ -3,7 +3,7 @@ import AvatarClass from "@ui5/webcomponents/dist/Avatar.js";
 
 const Avatar = createReactComponent(AvatarClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Avatar
@@ -24,5 +24,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Avatar/Variants/sample.tsx
+++ b/packages/website/docs/_samples/main/Avatar/Variants/sample.tsx
@@ -6,7 +6,7 @@ import "@ui5/webcomponents-icons/dist/edit.js";
 const Avatar = createReactComponent(AvatarClass);
 const AvatarBadge = createReactComponent(AvatarBadgeClass);
 
-function App() {
+export const Example = () => {
   const handleInteractiveAvtClick = () => {
     console.log("Interactive avatar clicked");
   };
@@ -142,5 +142,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Avatar/WithBadge/sample.tsx
+++ b/packages/website/docs/_samples/main/Avatar/WithBadge/sample.tsx
@@ -10,7 +10,7 @@ import AvatarBadgeClass from "@ui5/webcomponents/dist/AvatarBadge.js";
 const Avatar = createReactComponent(AvatarClass);
 const AvatarBadge = createReactComponent(AvatarBadgeClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Avatar mode="Interactive" size="M" initials="JD" colorScheme="Accent5">
@@ -42,5 +42,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Avatar/WithIcon/sample.tsx
+++ b/packages/website/docs/_samples/main/Avatar/WithIcon/sample.tsx
@@ -8,7 +8,7 @@ import "@ui5/webcomponents-icons/dist/shipping-status.js";
 
 const Avatar = createReactComponent(AvatarClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Avatar icon="filter" size="XS" />
@@ -19,5 +19,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Avatar/WithImage/sample.tsx
+++ b/packages/website/docs/_samples/main/Avatar/WithImage/sample.tsx
@@ -3,7 +3,7 @@ import AvatarClass from "@ui5/webcomponents/dist/Avatar.js";
 
 const Avatar = createReactComponent(AvatarClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Avatar fallbackIcon="employee" size="XS">
@@ -24,5 +24,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/AvatarBadge/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/AvatarBadge/Basic/sample.tsx
@@ -6,7 +6,7 @@ import AvatarBadgeClass from "@ui5/webcomponents/dist/AvatarBadge.js";
 const Avatar = createReactComponent(AvatarClass);
 const AvatarBadge = createReactComponent(AvatarBadgeClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Avatar mode="Interactive" size="M">
@@ -15,5 +15,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/AvatarBadge/ValueStates/sample.tsx
+++ b/packages/website/docs/_samples/main/AvatarBadge/ValueStates/sample.tsx
@@ -10,7 +10,7 @@ import AvatarBadgeClass from "@ui5/webcomponents/dist/AvatarBadge.js";
 const Avatar = createReactComponent(AvatarClass);
 const AvatarBadge = createReactComponent(AvatarBadgeClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Avatar mode="Interactive" size="M" initials="PM" colorScheme="Accent6">
@@ -43,5 +43,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/AvatarGroup/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/AvatarGroup/Basic/sample.tsx
@@ -5,7 +5,7 @@ import AvatarGroupClass from "@ui5/webcomponents/dist/AvatarGroup.js";
 const Avatar = createReactComponent(AvatarClass);
 const AvatarGroup = createReactComponent(AvatarGroupClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <AvatarGroup>
@@ -23,5 +23,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/AvatarGroup/GroupWithPopover/sample.tsx
+++ b/packages/website/docs/_samples/main/AvatarGroup/GroupWithPopover/sample.tsx
@@ -11,7 +11,7 @@ const AvatarGroup = createReactComponent(AvatarGroupClass);
 const Popover = createReactComponent(PopoverClass);
 const Slider = createReactComponent(SliderClass);
 
-function App() {
+export const Example = () => {
   const popoverRef = useRef(null);
   const avatarGroupRef = useRef(null);
   const [groupWidth, setGroupWidth] = useState("60%");
@@ -119,5 +119,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/AvatarGroup/IndividualWithPopover/sample.tsx
+++ b/packages/website/docs/_samples/main/AvatarGroup/IndividualWithPopover/sample.tsx
@@ -13,7 +13,7 @@ const Popover = createReactComponent(PopoverClass);
 const Slider = createReactComponent(SliderClass);
 const Title = createReactComponent(TitleClass);
 
-function App() {
+export const Example = () => {
   const personPopoverRef = useRef(null);
   const peoplePopoverRef = useRef(null);
   const avatarGroupRef = useRef(null);
@@ -169,5 +169,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/AvatarGroup/TypesAndSizes/sample.tsx
+++ b/packages/website/docs/_samples/main/AvatarGroup/TypesAndSizes/sample.tsx
@@ -5,7 +5,7 @@ import AvatarGroupClass from "@ui5/webcomponents/dist/AvatarGroup.js";
 const Avatar = createReactComponent(AvatarClass);
 const AvatarGroup = createReactComponent(AvatarGroupClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <AvatarGroup type="Individual">
@@ -67,5 +67,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Bar/AccessibleRole/sample.tsx
+++ b/packages/website/docs/_samples/main/Bar/AccessibleRole/sample.tsx
@@ -9,7 +9,7 @@ const Bar = createReactComponent(BarClass);
 const Button = createReactComponent(ButtonClass);
 const Label = createReactComponent(LabelClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Label showColon={true}>Bar with two or more active items</Label>
@@ -35,5 +35,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Bar/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/Bar/Basic/sample.tsx
@@ -9,7 +9,7 @@ const Bar = createReactComponent(BarClass);
 const Button = createReactComponent(ButtonClass);
 const Label = createReactComponent(LabelClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Bar design="Header">
@@ -29,5 +29,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Breadcrumbs/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/Breadcrumbs/Basic/sample.tsx
@@ -5,7 +5,7 @@ import BreadcrumbsItemClass from "@ui5/webcomponents/dist/BreadcrumbsItem.js";
 const Breadcrumbs = createReactComponent(BreadcrumbsClass);
 const BreadcrumbsItem = createReactComponent(BreadcrumbsItemClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Breadcrumbs>
@@ -20,5 +20,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Breadcrumbs/BreadcrumbsOverflow/sample.tsx
+++ b/packages/website/docs/_samples/main/Breadcrumbs/BreadcrumbsOverflow/sample.tsx
@@ -5,7 +5,7 @@ import BreadcrumbsItemClass from "@ui5/webcomponents/dist/BreadcrumbsItem.js";
 const Breadcrumbs = createReactComponent(BreadcrumbsClass);
 const BreadcrumbsItem = createReactComponent(BreadcrumbsItemClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Breadcrumbs>
@@ -47,5 +47,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Breadcrumbs/BreadcrumbsStyles/sample.tsx
+++ b/packages/website/docs/_samples/main/Breadcrumbs/BreadcrumbsStyles/sample.tsx
@@ -5,7 +5,7 @@ import BreadcrumbsItemClass from "@ui5/webcomponents/dist/BreadcrumbsItem.js";
 const Breadcrumbs = createReactComponent(BreadcrumbsClass);
 const BreadcrumbsItem = createReactComponent(BreadcrumbsItemClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <div>
@@ -66,5 +66,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Breadcrumbs/NoCurrentPage/sample.tsx
+++ b/packages/website/docs/_samples/main/Breadcrumbs/NoCurrentPage/sample.tsx
@@ -5,7 +5,7 @@ import BreadcrumbsItemClass from "@ui5/webcomponents/dist/BreadcrumbsItem.js";
 const Breadcrumbs = createReactComponent(BreadcrumbsClass);
 const BreadcrumbsItem = createReactComponent(BreadcrumbsItemClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Breadcrumbs design="NoCurrentPage">
@@ -29,5 +29,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/BusyIndicator/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/BusyIndicator/Basic/sample.tsx
@@ -3,8 +3,6 @@ import BusyIndicatorClass from "@ui5/webcomponents/dist/BusyIndicator.js";
 
 const BusyIndicator = createReactComponent(BusyIndicatorClass);
 
-function App() {
+export const Example = () => {
   return <BusyIndicator active={true} />;
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/BusyIndicator/Sizes/sample.tsx
+++ b/packages/website/docs/_samples/main/BusyIndicator/Sizes/sample.tsx
@@ -3,7 +3,7 @@ import BusyIndicatorClass from "@ui5/webcomponents/dist/BusyIndicator.js";
 
 const BusyIndicator = createReactComponent(BusyIndicatorClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <BusyIndicator size="S" active={true} />
@@ -12,5 +12,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/BusyIndicator/TextPlacement/sample.tsx
+++ b/packages/website/docs/_samples/main/BusyIndicator/TextPlacement/sample.tsx
@@ -3,7 +3,7 @@ import BusyIndicatorClass from "@ui5/webcomponents/dist/BusyIndicator.js";
 
 const BusyIndicator = createReactComponent(BusyIndicatorClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <BusyIndicator text="Loading data from backend server.." active={true}>
@@ -19,5 +19,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/BusyIndicator/WithComponent/sample.tsx
+++ b/packages/website/docs/_samples/main/BusyIndicator/WithComponent/sample.tsx
@@ -10,7 +10,7 @@ const Button = createReactComponent(ButtonClass);
 const List = createReactComponent(ListClass);
 const ListItemStandard = createReactComponent(ListItemStandardClass);
 
-function App() {
+export const Example = () => {
   const [busy, setBusy] = useState(false);
   const [items, setItems] = useState<string[]>([]);
 
@@ -45,5 +45,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Button/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/Button/Basic/sample.tsx
@@ -4,7 +4,7 @@ import "@ui5/webcomponents-icons/dist/edit.js";
 
 const Button = createReactComponent(ButtonClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Button>Press</Button>
@@ -13,5 +13,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Button/ButtonBadge/sample.tsx
+++ b/packages/website/docs/_samples/main/Button/ButtonBadge/sample.tsx
@@ -8,7 +8,7 @@ const Button = createReactComponent(ButtonClass);
 const Label = createReactComponent(LabelClass);
 const ButtonBadge = createReactComponent(ButtonBadgeClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <div>
@@ -47,5 +47,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Button/CustomStyling/sample.tsx
+++ b/packages/website/docs/_samples/main/Button/CustomStyling/sample.tsx
@@ -3,7 +3,7 @@ import ButtonClass from "@ui5/webcomponents/dist/Button.js";
 
 const Button = createReactComponent(ButtonClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <style>{`
@@ -22,5 +22,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Button/Design/sample.tsx
+++ b/packages/website/docs/_samples/main/Button/Design/sample.tsx
@@ -3,7 +3,7 @@ import ButtonClass from "@ui5/webcomponents/dist/Button.js";
 
 const Button = createReactComponent(ButtonClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Button design="Emphasized">Emphasized</Button>
@@ -15,5 +15,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Button/EndIcon/sample.tsx
+++ b/packages/website/docs/_samples/main/Button/EndIcon/sample.tsx
@@ -5,7 +5,7 @@ import "@ui5/webcomponents-icons/dist/home.js";
 
 const Button = createReactComponent(ButtonClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Button endIcon="navigation-down-arrow">
@@ -17,5 +17,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Button/IconOnly/sample.tsx
+++ b/packages/website/docs/_samples/main/Button/IconOnly/sample.tsx
@@ -5,7 +5,7 @@ import "@ui5/webcomponents-icons/dist/account.js";
 
 const Button = createReactComponent(ButtonClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Button icon="edit" design="Default" tooltip="Edit Button" />
@@ -13,5 +13,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Button/Loading/sample.tsx
+++ b/packages/website/docs/_samples/main/Button/Loading/sample.tsx
@@ -5,7 +5,7 @@ import "@ui5/webcomponents-icons/dist/employee.js";
 
 const Button = createReactComponent(ButtonClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <div>
@@ -47,5 +47,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Button/MenuButton/sample.tsx
+++ b/packages/website/docs/_samples/main/Button/MenuButton/sample.tsx
@@ -10,7 +10,7 @@ const Button = createReactComponent(ButtonClass);
 const Menu = createReactComponent(MenuClass);
 const MenuItem = createReactComponent(MenuItemClass);
 
-function App() {
+export const Example = () => {
   const menuRef = useRef(null);
   const buttonRef = useRef(null);
   const [menuOpen, setMenuOpen] = useState(false);
@@ -79,5 +79,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Button/TextAndIcon/sample.tsx
+++ b/packages/website/docs/_samples/main/Button/TextAndIcon/sample.tsx
@@ -5,7 +5,7 @@ import "@ui5/webcomponents-icons/dist/account.js";
 
 const Button = createReactComponent(ButtonClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Button icon="edit">Edit</Button>
@@ -13,5 +13,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Calendar/Basic/main.js
+++ b/packages/website/docs/_samples/main/Calendar/Basic/main.js
@@ -1,2 +1,1 @@
-import "@ui5/webcomponents/dist/Assets-fetch.js";
 import "@ui5/webcomponents/dist/Calendar.js";

--- a/packages/website/docs/_samples/main/Calendar/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/Calendar/Basic/sample.tsx
@@ -3,8 +3,6 @@ import CalendarClass from "@ui5/webcomponents/dist/Calendar.js";
 
 const Calendar = createReactComponent(CalendarClass);
 
-function App() {
+export const Example = () => {
   return <Calendar />;
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Calendar/Bounds/main.js
+++ b/packages/website/docs/_samples/main/Calendar/Bounds/main.js
@@ -1,2 +1,1 @@
-import "@ui5/webcomponents/dist/Assets-fetch.js";
 import "@ui5/webcomponents/dist/Calendar.js";

--- a/packages/website/docs/_samples/main/Calendar/Bounds/sample.tsx
+++ b/packages/website/docs/_samples/main/Calendar/Bounds/sample.tsx
@@ -3,7 +3,7 @@ import CalendarClass from "@ui5/webcomponents/dist/Calendar.js";
 
 const Calendar = createReactComponent(CalendarClass);
 
-function App() {
+export const Example = () => {
   return (
     <Calendar
       valueFormat="dd/MM/yyyy"
@@ -13,5 +13,3 @@ function App() {
     />
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Calendar/CalendarInDifferentTimezone/main.js
+++ b/packages/website/docs/_samples/main/Calendar/CalendarInDifferentTimezone/main.js
@@ -1,2 +1,1 @@
-import "@ui5/webcomponents/dist/Assets-fetch.js";
 import "@ui5/webcomponents/dist/Calendar.js";

--- a/packages/website/docs/_samples/main/Calendar/CalendarInDifferentTimezone/sample.tsx
+++ b/packages/website/docs/_samples/main/Calendar/CalendarInDifferentTimezone/sample.tsx
@@ -3,8 +3,6 @@ import CalendarClass from "@ui5/webcomponents/dist/Calendar.js";
 
 const Calendar = createReactComponent(CalendarClass);
 
-function App() {
+export const Example = () => {
   return <Calendar />;
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Calendar/CalendarTypes/main.js
+++ b/packages/website/docs/_samples/main/Calendar/CalendarTypes/main.js
@@ -1,4 +1,3 @@
-import "@ui5/webcomponents/dist/Assets-fetch.js";
 import "@ui5/webcomponents/dist/Calendar.js";
 
 import "@ui5/webcomponents-localization/dist/features/calendar/Islamic.js"

--- a/packages/website/docs/_samples/main/Calendar/CalendarTypes/sample.tsx
+++ b/packages/website/docs/_samples/main/Calendar/CalendarTypes/sample.tsx
@@ -3,10 +3,8 @@ import CalendarClass from "@ui5/webcomponents/dist/Calendar.js";
 
 const Calendar = createReactComponent(CalendarClass);
 
-function App() {
+export const Example = () => {
   return (
     <Calendar primaryCalendarType="Japanese" secondaryCalendarType="Islamic" />
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Calendar/CalendarWeekNumbering/main.js
+++ b/packages/website/docs/_samples/main/Calendar/CalendarWeekNumbering/main.js
@@ -1,4 +1,3 @@
-import "@ui5/webcomponents/dist/Assets-fetch.js";
 import "@ui5/webcomponents/dist/Calendar.js";
 import "@ui5/webcomponents/dist/Select.js";
 import "@ui5/webcomponents/dist/Option.js";

--- a/packages/website/docs/_samples/main/Calendar/CalendarWeekNumbering/sample.tsx
+++ b/packages/website/docs/_samples/main/Calendar/CalendarWeekNumbering/sample.tsx
@@ -9,7 +9,7 @@ const Calendar = createReactComponent(CalendarClass);
 const Option = createReactComponent(OptionClass);
 const Select = createReactComponent(SelectClass);
 
-function App() {
+export const Example = () => {
   const calRef = useRef(null);
 
   const handleSelectChange = (e: UI5CustomEvent<SelectClass, "change">) => {
@@ -34,5 +34,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Calendar/CalendarWithDisabledDates/main.js
+++ b/packages/website/docs/_samples/main/Calendar/CalendarWithDisabledDates/main.js
@@ -1,2 +1,1 @@
-import "@ui5/webcomponents/dist/Assets-fetch.js";
 import "@ui5/webcomponents/dist/Calendar.js";

--- a/packages/website/docs/_samples/main/Calendar/CalendarWithDisabledDates/sample.tsx
+++ b/packages/website/docs/_samples/main/Calendar/CalendarWithDisabledDates/sample.tsx
@@ -7,7 +7,7 @@ const Calendar = createReactComponent(CalendarClass);
 const SpecialCalendarDate = createReactComponent(SpecialCalendarDateClass);
 const DateRange = createReactComponent(DateRangeClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Calendar valueFormat="dd/MM/yyyy" displayFormat="dd/MM/yyyy">
@@ -26,5 +26,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Calendar/CalendarWithLegend/main.js
+++ b/packages/website/docs/_samples/main/Calendar/CalendarWithLegend/main.js
@@ -1,4 +1,3 @@
-import "@ui5/webcomponents/dist/Assets-fetch.js";
 import "@ui5/webcomponents/dist/Calendar.js";
 import "@ui5/webcomponents/dist/CalendarLegend.js";
 import "@ui5/webcomponents/dist/CalendarLegendItem.js";

--- a/packages/website/docs/_samples/main/Calendar/CalendarWithLegend/sample.tsx
+++ b/packages/website/docs/_samples/main/Calendar/CalendarWithLegend/sample.tsx
@@ -10,7 +10,7 @@ const CalendarLegend = createReactComponent(CalendarLegendClass);
 const CalendarLegendItem = createReactComponent(CalendarLegendItemClass);
 const SpecialCalendarDate = createReactComponent(SpecialCalendarDateClass);
 
-function App() {
+export const Example = () => {
   const specialDates = useMemo(() => {
     const currentDate = new Date();
     const year = currentDate.getFullYear();
@@ -62,5 +62,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Calendar/SelectionModes/main.js
+++ b/packages/website/docs/_samples/main/Calendar/SelectionModes/main.js
@@ -1,3 +1,2 @@
-import "@ui5/webcomponents/dist/Assets-fetch.js";
 import "@ui5/webcomponents/dist/Title.js";
 import "@ui5/webcomponents/dist/Calendar.js";

--- a/packages/website/docs/_samples/main/Calendar/SelectionModes/sample.tsx
+++ b/packages/website/docs/_samples/main/Calendar/SelectionModes/sample.tsx
@@ -5,7 +5,7 @@ import TitleClass from "@ui5/webcomponents/dist/Title.js";
 const Calendar = createReactComponent(CalendarClass);
 const Title = createReactComponent(TitleClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <div
@@ -21,5 +21,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/CalendarLegend/Basic/main.js
+++ b/packages/website/docs/_samples/main/CalendarLegend/Basic/main.js
@@ -1,4 +1,3 @@
-import "@ui5/webcomponents/dist/Assets-fetch.js";
 import "@ui5/webcomponents/dist/Calendar.js";
 import "@ui5/webcomponents/dist/CalendarLegend.js";
 import "@ui5/webcomponents/dist/CalendarLegendItem.js";

--- a/packages/website/docs/_samples/main/CalendarLegend/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/CalendarLegend/Basic/sample.tsx
@@ -10,7 +10,7 @@ const CalendarLegend = createReactComponent(CalendarLegendClass);
 const CalendarLegendItem = createReactComponent(CalendarLegendItemClass);
 const SpecialCalendarDate = createReactComponent(SpecialCalendarDateClass);
 
-function App() {
+export const Example = () => {
   const specialDates = useMemo(() => {
     const currentDate = new Date();
     const year = currentDate.getFullYear();
@@ -56,5 +56,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/CalendarLegend/HideToday/sample.tsx
+++ b/packages/website/docs/_samples/main/CalendarLegend/HideToday/sample.tsx
@@ -5,7 +5,7 @@ import CalendarLegendItemClass from "@ui5/webcomponents/dist/CalendarLegendItem.
 const CalendarLegend = createReactComponent(CalendarLegendClass);
 const CalendarLegendItem = createReactComponent(CalendarLegendItemClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <CalendarLegend
@@ -38,5 +38,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/CalendarLegend/ItemTypes/sample.tsx
+++ b/packages/website/docs/_samples/main/CalendarLegend/ItemTypes/sample.tsx
@@ -5,7 +5,7 @@ import CalendarLegendItemClass from "@ui5/webcomponents/dist/CalendarLegendItem.
 const CalendarLegend = createReactComponent(CalendarLegendClass);
 const CalendarLegendItem = createReactComponent(CalendarLegendItemClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <CalendarLegend>
@@ -33,5 +33,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Card/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/Card/Basic/sample.tsx
@@ -14,7 +14,7 @@ const Icon = createReactComponent(IconClass);
 const List = createReactComponent(ListClass);
 const ListItemStandard = createReactComponent(ListItemStandardClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <style>{`
@@ -56,5 +56,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Card/MoreCards/sample.tsx
+++ b/packages/website/docs/_samples/main/Card/MoreCards/sample.tsx
@@ -16,7 +16,7 @@ const Link = createReactComponent(LinkClass);
 const Text = createReactComponent(TextClass);
 const Title = createReactComponent(TitleClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <style>{`
@@ -66,5 +66,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Card/WithList/sample.tsx
+++ b/packages/website/docs/_samples/main/Card/WithList/sample.tsx
@@ -16,7 +16,7 @@ const Icon = createReactComponent(IconClass);
 const List = createReactComponent(ListClass);
 const ListItemStandard = createReactComponent(ListItemStandardClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <style>{`
@@ -60,5 +60,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Card/WithTable/sample.tsx
+++ b/packages/website/docs/_samples/main/Card/WithTable/sample.tsx
@@ -17,7 +17,7 @@ const TableCell = createReactComponent(TableCellClass);
 const TableRow = createReactComponent(TableRowClass);
 const Text = createReactComponent(TextClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <style>{`
@@ -103,5 +103,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Card/WithTimeline/sample.tsx
+++ b/packages/website/docs/_samples/main/Card/WithTimeline/sample.tsx
@@ -11,7 +11,7 @@ const TimelineItem = createReactComponent(TimelineItemClass);
 const Card = createReactComponent(CardClass);
 const CardHeader = createReactComponent(CardHeaderClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <style>{`
@@ -49,5 +49,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Carousel/AccessibleName/sample.tsx
+++ b/packages/website/docs/_samples/main/Carousel/AccessibleName/sample.tsx
@@ -5,7 +5,7 @@ import TitleClass from "@ui5/webcomponents/dist/Title.js";
 const Carousel = createReactComponent(CarouselClass);
 const Title = createReactComponent(TitleClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <style>{`
@@ -34,5 +34,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Carousel/ArrowsPlacement/sample.tsx
+++ b/packages/website/docs/_samples/main/Carousel/ArrowsPlacement/sample.tsx
@@ -3,7 +3,7 @@ import CarouselClass from "@ui5/webcomponents/dist/Carousel.js";
 
 const Carousel = createReactComponent(CarouselClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <style>{`
@@ -19,5 +19,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Carousel/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/Carousel/Basic/sample.tsx
@@ -3,7 +3,7 @@ import CarouselClass from "@ui5/webcomponents/dist/Carousel.js";
 
 const Carousel = createReactComponent(CarouselClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <style>{`
@@ -19,5 +19,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Carousel/CardsWithHidden/sample.tsx
+++ b/packages/website/docs/_samples/main/Carousel/CardsWithHidden/sample.tsx
@@ -13,7 +13,7 @@ const Icon = createReactComponent(IconClass);
 const List = createReactComponent(ListClass);
 const ListItemStandard = createReactComponent(ListItemStandardClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <style>{`
@@ -164,5 +164,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Carousel/Cyclic/sample.tsx
+++ b/packages/website/docs/_samples/main/Carousel/Cyclic/sample.tsx
@@ -3,7 +3,7 @@ import CarouselClass from "@ui5/webcomponents/dist/Carousel.js";
 
 const Carousel = createReactComponent(CarouselClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <style>{`
@@ -19,5 +19,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Carousel/MultipleItemsPerPage/sample.tsx
+++ b/packages/website/docs/_samples/main/Carousel/MultipleItemsPerPage/sample.tsx
@@ -25,7 +25,7 @@ const Icon = createReactComponent(IconClass);
 const List = createReactComponent(ListClass);
 const ListItemStandard = createReactComponent(ListItemStandardClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <style>{`
@@ -172,5 +172,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Carousel/PageIndicatorType/sample.tsx
+++ b/packages/website/docs/_samples/main/Carousel/PageIndicatorType/sample.tsx
@@ -3,7 +3,7 @@ import CarouselClass from "@ui5/webcomponents/dist/Carousel.js";
 
 const Carousel = createReactComponent(CarouselClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <style>{`
@@ -19,5 +19,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/CheckBox/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/CheckBox/Basic/sample.tsx
@@ -3,8 +3,6 @@ import CheckBoxClass from "@ui5/webcomponents/dist/CheckBox.js";
 
 const CheckBox = createReactComponent(CheckBoxClass);
 
-function App() {
+export const Example = () => {
   return <CheckBox text="Basic" />;
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/CheckBox/Group/sample.tsx
+++ b/packages/website/docs/_samples/main/CheckBox/Group/sample.tsx
@@ -6,7 +6,7 @@ import CheckBoxClass from "@ui5/webcomponents/dist/CheckBox.js";
 const Button = createReactComponent(ButtonClass);
 const CheckBox = createReactComponent(CheckBoxClass);
 
-function App() {
+export const Example = () => {
   const formRef = useRef<HTMLFormElement>(null);
   const [output, setOutput] = useState("");
 
@@ -46,5 +46,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/CheckBox/Indeterminate/sample.tsx
+++ b/packages/website/docs/_samples/main/CheckBox/Indeterminate/sample.tsx
@@ -3,8 +3,6 @@ import CheckBoxClass from "@ui5/webcomponents/dist/CheckBox.js";
 
 const CheckBox = createReactComponent(CheckBoxClass);
 
-function App() {
+export const Example = () => {
   return <CheckBox text="indeterminate" indeterminate={true} checked={true} />;
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/CheckBox/States/sample.tsx
+++ b/packages/website/docs/_samples/main/CheckBox/States/sample.tsx
@@ -3,7 +3,7 @@ import CheckBoxClass from "@ui5/webcomponents/dist/CheckBox.js";
 
 const CheckBox = createReactComponent(CheckBoxClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <CheckBox text="Positive" valueState="Positive" />
@@ -87,5 +87,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/CheckBox/TextWrapping/sample.tsx
+++ b/packages/website/docs/_samples/main/CheckBox/TextWrapping/sample.tsx
@@ -3,7 +3,7 @@ import CheckBoxClass from "@ui5/webcomponents/dist/CheckBox.js";
 
 const CheckBox = createReactComponent(CheckBoxClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <CheckBox
@@ -22,5 +22,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/ColorPalette/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/ColorPalette/Basic/sample.tsx
@@ -5,7 +5,7 @@ import ColorPaletteItemClass from "@ui5/webcomponents/dist/ColorPaletteItem.js";
 const ColorPalette = createReactComponent(ColorPaletteClass);
 const ColorPaletteItem = createReactComponent(ColorPaletteItemClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <ColorPalette>
@@ -25,5 +25,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/ColorPalettePopover/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/ColorPalettePopover/Basic/sample.tsx
@@ -8,7 +8,7 @@ const Button = createReactComponent(ButtonClass);
 const ColorPaletteItem = createReactComponent(ColorPaletteItemClass);
 const ColorPalettePopover = createReactComponent(ColorPalettePopoverClass);
 
-function App() {
+export const Example = () => {
   const [open, setOpen] = useState(false);
 
   return (
@@ -36,5 +36,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/ColorPalettePopover/DefaultColor/sample.tsx
+++ b/packages/website/docs/_samples/main/ColorPalettePopover/DefaultColor/sample.tsx
@@ -8,7 +8,7 @@ const Button = createReactComponent(ButtonClass);
 const ColorPaletteItem = createReactComponent(ColorPaletteItemClass);
 const ColorPalettePopover = createReactComponent(ColorPalettePopoverClass);
 
-function App() {
+export const Example = () => {
   const [open, setOpen] = useState(false);
 
   return (
@@ -43,5 +43,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/ColorPalettePopover/MoreColors/sample.tsx
+++ b/packages/website/docs/_samples/main/ColorPalettePopover/MoreColors/sample.tsx
@@ -8,7 +8,7 @@ const Button = createReactComponent(ButtonClass);
 const ColorPaletteItem = createReactComponent(ColorPaletteItemClass);
 const ColorPalettePopover = createReactComponent(ColorPalettePopoverClass);
 
-function App() {
+export const Example = () => {
   const [open, setOpen] = useState(false);
 
   return (
@@ -46,5 +46,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/ColorPicker/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/ColorPicker/Basic/sample.tsx
@@ -3,8 +3,6 @@ import ColorPickerClass from "@ui5/webcomponents/dist/ColorPicker.js";
 
 const ColorPicker = createReactComponent(ColorPickerClass);
 
-function App() {
+export const Example = () => {
   return <ColorPicker value="rgba(220, 208, 255, 1)">Picker</ColorPicker>;
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/ColorPicker/Simplified/sample.tsx
+++ b/packages/website/docs/_samples/main/ColorPicker/Simplified/sample.tsx
@@ -3,12 +3,10 @@ import ColorPickerClass from "@ui5/webcomponents/dist/ColorPicker.js";
 
 const ColorPicker = createReactComponent(ColorPickerClass);
 
-function App() {
+export const Example = () => {
   return (
     <ColorPicker simplified={true} value="#F6A192">
       Picker
     </ColorPicker>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/ComboBox/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/ComboBox/Basic/sample.tsx
@@ -5,7 +5,7 @@ import ComboBoxItemClass from "@ui5/webcomponents/dist/ComboBoxItem.js";
 const ComboBox = createReactComponent(ComboBoxClass);
 const ComboBoxItem = createReactComponent(ComboBoxItemClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <ComboBox placeholder="Enter value">
@@ -18,5 +18,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/ComboBox/ClearIcon/sample.tsx
+++ b/packages/website/docs/_samples/main/ComboBox/ClearIcon/sample.tsx
@@ -5,7 +5,7 @@ import ComboBoxItemClass from "@ui5/webcomponents/dist/ComboBoxItem.js";
 const ComboBox = createReactComponent(ComboBoxClass);
 const ComboBoxItem = createReactComponent(ComboBoxItemClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <ComboBox value="Denmark" showClearIcon={true}>
@@ -18,5 +18,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/ComboBox/Filters/sample.tsx
+++ b/packages/website/docs/_samples/main/ComboBox/Filters/sample.tsx
@@ -5,7 +5,7 @@ import ComboBoxItemClass from "@ui5/webcomponents/dist/ComboBoxItem.js";
 const ComboBox = createReactComponent(ComboBoxClass);
 const ComboBoxItem = createReactComponent(ComboBoxItemClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <ComboBox placeholder="Contains Filtering" filter="Contains">
@@ -18,5 +18,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/ComboBox/Grouping/sample.tsx
+++ b/packages/website/docs/_samples/main/ComboBox/Grouping/sample.tsx
@@ -7,7 +7,7 @@ const ComboBox = createReactComponent(ComboBoxClass);
 const ComboBoxItem = createReactComponent(ComboBoxItemClass);
 const ComboBoxItemGroup = createReactComponent(ComboBoxItemGroupClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <ComboBox placeholder="Grouping of items">
@@ -29,5 +29,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/ComboBox/SameTextDifferentValues/sample.tsx
+++ b/packages/website/docs/_samples/main/ComboBox/SameTextDifferentValues/sample.tsx
@@ -7,7 +7,7 @@ import ComboBoxItemClass from "@ui5/webcomponents/dist/ComboBoxItem.js";
 const ComboBox = createReactComponent(ComboBoxClass);
 const ComboBoxItem = createReactComponent(ComboBoxItemClass);
 
-function App() {
+export const Example = () => {
   const [employeeId, setEmployeeId] = useState("-");
   const [employeeName, setEmployeeName] = useState("-");
   const [employeeDept, setEmployeeDept] = useState("-");
@@ -78,5 +78,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/ComboBox/SelectedValue/sample.tsx
+++ b/packages/website/docs/_samples/main/ComboBox/SelectedValue/sample.tsx
@@ -7,7 +7,7 @@ import ComboBoxItemClass from "@ui5/webcomponents/dist/ComboBoxItem.js";
 const ComboBox = createReactComponent(ComboBoxClass);
 const ComboBoxItem = createReactComponent(ComboBoxItemClass);
 
-function App() {
+export const Example = () => {
   const [selectedValue, setSelectedValue] = useState("DE");
 
   const handleSelectionChange = (
@@ -50,5 +50,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/ComboBox/SuggestionsWrapping/sample.tsx
+++ b/packages/website/docs/_samples/main/ComboBox/SuggestionsWrapping/sample.tsx
@@ -5,7 +5,7 @@ import ComboBoxItemClass from "@ui5/webcomponents/dist/ComboBoxItem.js";
 const ComboBox = createReactComponent(ComboBoxClass);
 const ComboBoxItem = createReactComponent(ComboBoxItemClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <ComboBox placeholder="Enter product">
@@ -16,5 +16,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/ComboBox/TwoColumnsLayout/sample.tsx
+++ b/packages/website/docs/_samples/main/ComboBox/TwoColumnsLayout/sample.tsx
@@ -5,7 +5,7 @@ import ComboBoxItemClass from "@ui5/webcomponents/dist/ComboBoxItem.js";
 const ComboBox = createReactComponent(ComboBoxClass);
 const ComboBoxItem = createReactComponent(ComboBoxItemClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <ComboBox placeholder="Two-column layout">
@@ -22,5 +22,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/DatePicker/Basic/main.js
+++ b/packages/website/docs/_samples/main/DatePicker/Basic/main.js
@@ -1,2 +1,1 @@
-import "@ui5/webcomponents/dist/Assets-fetch.js";
 import "@ui5/webcomponents/dist/DatePicker.js";

--- a/packages/website/docs/_samples/main/DatePicker/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/DatePicker/Basic/sample.tsx
@@ -3,8 +3,6 @@ import DatePickerClass from "@ui5/webcomponents/dist/DatePicker.js";
 
 const DatePicker = createReactComponent(DatePickerClass);
 
-function App() {
+export const Example = () => {
   return <DatePicker />;
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/DatePicker/CalendarTypes/main.js
+++ b/packages/website/docs/_samples/main/DatePicker/CalendarTypes/main.js
@@ -1,4 +1,3 @@
-import "@ui5/webcomponents/dist/Assets-fetch.js";
 import "@ui5/webcomponents/dist/DatePicker.js";
 
 import "@ui5/webcomponents-localization/dist/features/calendar/Islamic.js"

--- a/packages/website/docs/_samples/main/DatePicker/CalendarTypes/sample.tsx
+++ b/packages/website/docs/_samples/main/DatePicker/CalendarTypes/sample.tsx
@@ -3,7 +3,7 @@ import DatePickerClass from "@ui5/webcomponents/dist/DatePicker.js";
 
 const DatePicker = createReactComponent(DatePickerClass);
 
-function App() {
+export const Example = () => {
   return (
     <DatePicker
       primaryCalendarType="Japanese"
@@ -11,5 +11,3 @@ function App() {
     />
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/DatePicker/CalendarWeekNumbering/main.js
+++ b/packages/website/docs/_samples/main/DatePicker/CalendarWeekNumbering/main.js
@@ -1,4 +1,3 @@
-import "@ui5/webcomponents/dist/Assets-fetch.js";
 import "@ui5/webcomponents/dist/DatePicker.js";
 import "@ui5/webcomponents/dist/Select.js";
 import "@ui5/webcomponents/dist/Option.js";

--- a/packages/website/docs/_samples/main/DatePicker/CalendarWeekNumbering/sample.tsx
+++ b/packages/website/docs/_samples/main/DatePicker/CalendarWeekNumbering/sample.tsx
@@ -9,7 +9,7 @@ const DatePicker = createReactComponent(DatePickerClass);
 const Option = createReactComponent(OptionClass);
 const Select = createReactComponent(SelectClass);
 
-function App() {
+export const Example = () => {
   const dpRef = useRef(null);
 
   const handleSelectChange = (e: UI5CustomEvent<SelectClass, "change">) => {
@@ -35,5 +35,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/DatePicker/ClearIcon/main.js
+++ b/packages/website/docs/_samples/main/DatePicker/ClearIcon/main.js
@@ -1,2 +1,1 @@
-import "@ui5/webcomponents/dist/Assets-fetch.js";
 import "@ui5/webcomponents/dist/DatePicker.js";

--- a/packages/website/docs/_samples/main/DatePicker/ClearIcon/sample.tsx
+++ b/packages/website/docs/_samples/main/DatePicker/ClearIcon/sample.tsx
@@ -3,8 +3,6 @@ import DatePickerClass from "@ui5/webcomponents/dist/DatePicker.js";
 
 const DatePicker = createReactComponent(DatePickerClass);
 
-function App() {
+export const Example = () => {
   return <DatePicker showClearIcon={true} />;
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/DatePicker/CustomFormatting/main.js
+++ b/packages/website/docs/_samples/main/DatePicker/CustomFormatting/main.js
@@ -1,2 +1,1 @@
-import "@ui5/webcomponents/dist/Assets-fetch.js";
 import "@ui5/webcomponents/dist/DatePicker.js";

--- a/packages/website/docs/_samples/main/DatePicker/CustomFormatting/sample.tsx
+++ b/packages/website/docs/_samples/main/DatePicker/CustomFormatting/sample.tsx
@@ -3,8 +3,6 @@ import DatePickerClass from "@ui5/webcomponents/dist/DatePicker.js";
 
 const DatePicker = createReactComponent(DatePickerClass);
 
-function App() {
+export const Example = () => {
   return <DatePicker displayFormat="medium" valueFormat="yyyy-MM-dd" />;
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/DatePicker/DatePickerInDifferentTimezone/main.js
+++ b/packages/website/docs/_samples/main/DatePicker/DatePickerInDifferentTimezone/main.js
@@ -1,2 +1,1 @@
-import "@ui5/webcomponents/dist/Assets-fetch.js";
 import "@ui5/webcomponents/dist/DatePicker.js";

--- a/packages/website/docs/_samples/main/DatePicker/DatePickerInDifferentTimezone/sample.tsx
+++ b/packages/website/docs/_samples/main/DatePicker/DatePickerInDifferentTimezone/sample.tsx
@@ -3,8 +3,6 @@ import DatePickerClass from "@ui5/webcomponents/dist/DatePicker.js";
 
 const DatePicker = createReactComponent(DatePickerClass);
 
-function App() {
+export const Example = () => {
   return <DatePicker value="now" />;
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/DatePicker/MinMax/main.js
+++ b/packages/website/docs/_samples/main/DatePicker/MinMax/main.js
@@ -1,2 +1,1 @@
-import "@ui5/webcomponents/dist/Assets-fetch.js";
 import "@ui5/webcomponents/dist/DatePicker.js";

--- a/packages/website/docs/_samples/main/DatePicker/MinMax/sample.tsx
+++ b/packages/website/docs/_samples/main/DatePicker/MinMax/sample.tsx
@@ -3,7 +3,7 @@ import DatePickerClass from "@ui5/webcomponents/dist/DatePicker.js";
 
 const DatePicker = createReactComponent(DatePickerClass);
 
-function App() {
+export const Example = () => {
   return (
     <DatePicker
       valueFormat="dd/MM/yyyy"
@@ -13,5 +13,3 @@ function App() {
     />
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/DatePicker/State/main.js
+++ b/packages/website/docs/_samples/main/DatePicker/State/main.js
@@ -1,2 +1,1 @@
-import "@ui5/webcomponents/dist/Assets-fetch.js";
 import "@ui5/webcomponents/dist/DatePicker.js";

--- a/packages/website/docs/_samples/main/DatePicker/State/sample.tsx
+++ b/packages/website/docs/_samples/main/DatePicker/State/sample.tsx
@@ -3,7 +3,7 @@ import DatePickerClass from "@ui5/webcomponents/dist/DatePicker.js";
 
 const DatePicker = createReactComponent(DatePickerClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <DatePicker value="2024-02-29" valueState="Information">
@@ -17,5 +17,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/DateRangePicker/Basic/main.js
+++ b/packages/website/docs/_samples/main/DateRangePicker/Basic/main.js
@@ -1,2 +1,1 @@
-import "@ui5/webcomponents/dist/Assets-fetch.js";
 import "@ui5/webcomponents/dist/DateRangePicker.js";

--- a/packages/website/docs/_samples/main/DateRangePicker/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/DateRangePicker/Basic/sample.tsx
@@ -3,8 +3,6 @@ import DateRangePickerClass from "@ui5/webcomponents/dist/DateRangePicker.js";
 
 const DateRangePicker = createReactComponent(DateRangePickerClass);
 
-function App() {
+export const Example = () => {
   return <DateRangePicker />;
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/DateRangePicker/ClearIcon/main.js
+++ b/packages/website/docs/_samples/main/DateRangePicker/ClearIcon/main.js
@@ -1,2 +1,1 @@
-import "@ui5/webcomponents/dist/Assets-fetch.js";
 import "@ui5/webcomponents/dist/DateRangePicker.js";

--- a/packages/website/docs/_samples/main/DateRangePicker/ClearIcon/sample.tsx
+++ b/packages/website/docs/_samples/main/DateRangePicker/ClearIcon/sample.tsx
@@ -3,8 +3,6 @@ import DateRangePickerClass from "@ui5/webcomponents/dist/DateRangePicker.js";
 
 const DateRangePicker = createReactComponent(DateRangePickerClass);
 
-function App() {
+export const Example = () => {
   return <DateRangePicker showClearIcon={true} />;
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/DateRangePicker/CustomFormatting/main.js
+++ b/packages/website/docs/_samples/main/DateRangePicker/CustomFormatting/main.js
@@ -1,2 +1,1 @@
-import "@ui5/webcomponents/dist/Assets-fetch.js";
 import "@ui5/webcomponents/dist/DateRangePicker.js";

--- a/packages/website/docs/_samples/main/DateRangePicker/CustomFormatting/sample.tsx
+++ b/packages/website/docs/_samples/main/DateRangePicker/CustomFormatting/sample.tsx
@@ -3,8 +3,6 @@ import DateRangePickerClass from "@ui5/webcomponents/dist/DateRangePicker.js";
 
 const DateRangePicker = createReactComponent(DateRangePickerClass);
 
-function App() {
+export const Example = () => {
   return <DateRangePicker displayFormat="medium" valueFormat="yyyy-MM-dd" />;
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/DateRangePicker/DateFormat/main.js
+++ b/packages/website/docs/_samples/main/DateRangePicker/DateFormat/main.js
@@ -1,2 +1,1 @@
-import "@ui5/webcomponents/dist/Assets-fetch.js";
 import "@ui5/webcomponents/dist/DateRangePicker.js";

--- a/packages/website/docs/_samples/main/DateRangePicker/DateFormat/sample.tsx
+++ b/packages/website/docs/_samples/main/DateRangePicker/DateFormat/sample.tsx
@@ -3,7 +3,7 @@ import DateRangePickerClass from "@ui5/webcomponents/dist/DateRangePicker.js";
 
 const DateRangePicker = createReactComponent(DateRangePickerClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <DateRangePicker
@@ -38,5 +38,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/DateRangePicker/MinMax/main.js
+++ b/packages/website/docs/_samples/main/DateRangePicker/MinMax/main.js
@@ -1,2 +1,1 @@
-import "@ui5/webcomponents/dist/Assets-fetch.js";
 import "@ui5/webcomponents/dist/DateRangePicker.js";

--- a/packages/website/docs/_samples/main/DateRangePicker/MinMax/sample.tsx
+++ b/packages/website/docs/_samples/main/DateRangePicker/MinMax/sample.tsx
@@ -3,7 +3,7 @@ import DateRangePickerClass from "@ui5/webcomponents/dist/DateRangePicker.js";
 
 const DateRangePicker = createReactComponent(DateRangePickerClass);
 
-function App() {
+export const Example = () => {
   return (
     <DateRangePicker
       displayFormat="dd/MM/yyyy"
@@ -13,5 +13,3 @@ function App() {
     />
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/DateTimePicker/Basic/main.js
+++ b/packages/website/docs/_samples/main/DateTimePicker/Basic/main.js
@@ -1,2 +1,1 @@
-import "@ui5/webcomponents/dist/Assets-fetch.js";
 import "@ui5/webcomponents/dist/DateTimePicker.js";

--- a/packages/website/docs/_samples/main/DateTimePicker/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/DateTimePicker/Basic/sample.tsx
@@ -3,8 +3,6 @@ import DateTimePickerClass from "@ui5/webcomponents/dist/DateTimePicker.js";
 
 const DateTimePicker = createReactComponent(DateTimePickerClass);
 
-function App() {
+export const Example = () => {
   return <DateTimePicker />;
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/DateTimePicker/ClearIcon/main.js
+++ b/packages/website/docs/_samples/main/DateTimePicker/ClearIcon/main.js
@@ -1,2 +1,1 @@
-import "@ui5/webcomponents/dist/Assets-fetch.js";
 import "@ui5/webcomponents/dist/DateTimePicker.js";

--- a/packages/website/docs/_samples/main/DateTimePicker/ClearIcon/sample.tsx
+++ b/packages/website/docs/_samples/main/DateTimePicker/ClearIcon/sample.tsx
@@ -3,8 +3,6 @@ import DateTimePickerClass from "@ui5/webcomponents/dist/DateTimePicker.js";
 
 const DateTimePicker = createReactComponent(DateTimePickerClass);
 
-function App() {
+export const Example = () => {
   return <DateTimePicker showClearIcon={true} />;
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/DateTimePicker/CustomFormatting/main.js
+++ b/packages/website/docs/_samples/main/DateTimePicker/CustomFormatting/main.js
@@ -1,2 +1,1 @@
-import "@ui5/webcomponents/dist/Assets-fetch.js";
 import "@ui5/webcomponents/dist/DateTimePicker.js";

--- a/packages/website/docs/_samples/main/DateTimePicker/CustomFormatting/sample.tsx
+++ b/packages/website/docs/_samples/main/DateTimePicker/CustomFormatting/sample.tsx
@@ -3,10 +3,8 @@ import DateTimePickerClass from "@ui5/webcomponents/dist/DateTimePicker.js";
 
 const DateTimePicker = createReactComponent(DateTimePickerClass);
 
-function App() {
+export const Example = () => {
   return (
     <DateTimePicker displayFormat="medium" valueFormat="yyyy-MM-dd HH:mm:ss" />
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/DateTimePicker/DateTimePickerInDifferentTimezone/main.js
+++ b/packages/website/docs/_samples/main/DateTimePicker/DateTimePickerInDifferentTimezone/main.js
@@ -1,4 +1,3 @@
-import "@ui5/webcomponents/dist/Assets-fetch.js";
 import "@ui5/webcomponents/dist/DateTimePicker.js";
 import "@ui5/webcomponents/dist/Select.js";
 import "@ui5/webcomponents/dist/Option.js";

--- a/packages/website/docs/_samples/main/DateTimePicker/DateTimePickerInDifferentTimezone/sample.tsx
+++ b/packages/website/docs/_samples/main/DateTimePicker/DateTimePickerInDifferentTimezone/sample.tsx
@@ -11,7 +11,7 @@ const DateTimePicker = createReactComponent(DateTimePickerClass);
 const Option = createReactComponent(OptionClass);
 const Select = createReactComponent(SelectClass);
 
-function App() {
+export const Example = () => {
   const dtpRef = useRef(null);
 
   const handleSelectChange = (e: UI5CustomEvent<SelectClass, "change">) => {
@@ -54,5 +54,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/DateTimePicker/FormatPattern/main.js
+++ b/packages/website/docs/_samples/main/DateTimePicker/FormatPattern/main.js
@@ -1,2 +1,1 @@
-import "@ui5/webcomponents/dist/Assets-fetch.js";
 import "@ui5/webcomponents/dist/DateTimePicker.js";

--- a/packages/website/docs/_samples/main/DateTimePicker/FormatPattern/sample.tsx
+++ b/packages/website/docs/_samples/main/DateTimePicker/FormatPattern/sample.tsx
@@ -3,7 +3,7 @@ import DateTimePickerClass from "@ui5/webcomponents/dist/DateTimePicker.js";
 
 const DateTimePicker = createReactComponent(DateTimePickerClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <DateTimePicker valueFormat="dd/MM/yyyy, hh:mm" displayFormat="dd/MM/yyyy, hh:mm" />
@@ -14,5 +14,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/DateTimePicker/MinMax/main.js
+++ b/packages/website/docs/_samples/main/DateTimePicker/MinMax/main.js
@@ -1,2 +1,1 @@
-import "@ui5/webcomponents/dist/Assets-fetch.js";
 import "@ui5/webcomponents/dist/DateTimePicker.js";

--- a/packages/website/docs/_samples/main/DateTimePicker/MinMax/sample.tsx
+++ b/packages/website/docs/_samples/main/DateTimePicker/MinMax/sample.tsx
@@ -3,7 +3,7 @@ import DateTimePickerClass from "@ui5/webcomponents/dist/DateTimePicker.js";
 
 const DateTimePicker = createReactComponent(DateTimePickerClass);
 
-function App() {
+export const Example = () => {
   return (
     <DateTimePicker
       value="Jan 11, 2020, 11:11:11 AM"
@@ -14,5 +14,3 @@ function App() {
     />
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Dialog/BarInDialog/sample.tsx
+++ b/packages/website/docs/_samples/main/Dialog/BarInDialog/sample.tsx
@@ -11,7 +11,7 @@ const Button = createReactComponent(ButtonClass);
 const Dialog = createReactComponent(DialogClass);
 const Title = createReactComponent(TitleClass);
 
-function App() {
+export const Example = () => {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [dialogStateOpen, setDialogStateOpen] = useState(false);
 
@@ -85,5 +85,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Dialog/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/Dialog/Basic/sample.tsx
@@ -14,7 +14,7 @@ const Label = createReactComponent(LabelClass);
 const Toolbar = createReactComponent(ToolbarClass);
 const ToolbarButton = createReactComponent(ToolbarButtonClass);
 
-function App() {
+export const Example = () => {
   const [dialogOpen, setDialogOpen] = useState(false);
 
   return (
@@ -93,5 +93,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Dialog/DraggableAndResizable/sample.tsx
+++ b/packages/website/docs/_samples/main/Dialog/DraggableAndResizable/sample.tsx
@@ -10,7 +10,7 @@ const Dialog = createReactComponent(DialogClass);
 const Toolbar = createReactComponent(ToolbarClass);
 const ToolbarButton = createReactComponent(ToolbarButtonClass);
 
-function App() {
+export const Example = () => {
   const [dialogOpen, setDialogOpen] = useState(false);
 
   return (
@@ -44,5 +44,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Dialog/WithState/sample.tsx
+++ b/packages/website/docs/_samples/main/Dialog/WithState/sample.tsx
@@ -12,7 +12,7 @@ const Text = createReactComponent(TextClass);
 const Toolbar = createReactComponent(ToolbarClass);
 const ToolbarButton = createReactComponent(ToolbarButtonClass);
 
-function App() {
+export const Example = () => {
   const [dialogOpen, setDialogOpen] = useState(false);
 
   return (
@@ -40,5 +40,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/DynamicDateRange/Basic/main.js
+++ b/packages/website/docs/_samples/main/DynamicDateRange/Basic/main.js
@@ -1,4 +1,3 @@
-import "@ui5/webcomponents/dist/Assets-fetch.js";
 import "@ui5/webcomponents/dist/DynamicDateRange.js";
 import "@ui5/webcomponents/dist/dynamic-date-range-options/Today.js";
 import "@ui5/webcomponents/dist/dynamic-date-range-options/Yesterday.js";

--- a/packages/website/docs/_samples/main/DynamicDateRange/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/DynamicDateRange/Basic/sample.tsx
@@ -11,7 +11,7 @@ import "@ui5/webcomponents/dist/dynamic-date-range-options/DateTimeRange.js";
 const Text = createReactComponent(TextClass);
 const DynamicDateRange = createReactComponent(DynamicDateRangeClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Text>All options</Text>
@@ -25,5 +25,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/DynamicDateRange/DynamicDateRangeValueSample/main.js
+++ b/packages/website/docs/_samples/main/DynamicDateRange/DynamicDateRangeValueSample/main.js
@@ -1,4 +1,3 @@
-import "@ui5/webcomponents/dist/Assets-fetch.js";
 import "@ui5/webcomponents/dist/DynamicDateRange.js";
 import "@ui5/webcomponents/dist/dynamic-date-range-options/Today.js";
 import "@ui5/webcomponents/dist/dynamic-date-range-options/Yesterday.js";

--- a/packages/website/docs/_samples/main/DynamicDateRange/DynamicDateRangeValueSample/sample.tsx
+++ b/packages/website/docs/_samples/main/DynamicDateRange/DynamicDateRangeValueSample/sample.tsx
@@ -12,7 +12,7 @@ import "@ui5/webcomponents/dist/dynamic-date-range-options/NextOptions.js";
 
 const DynamicDateRange = createReactComponent(DynamicDateRangeClass);
 
-function App() {
+export const Example = () => {
   const ddrRef = useRef(null);
   const [selectedValue, setSelectedValue] = useState("");
   const [convertedDates, setConvertedDates] = useState("");
@@ -60,5 +60,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/ExpandableText/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/ExpandableText/Basic/sample.tsx
@@ -15,7 +15,7 @@ const TableHeaderRow = createReactComponent(TableHeaderRowClass);
 const TableRow = createReactComponent(TableRowClass);
 const ExpandableText = createReactComponent(ExpandableTextClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Table>
@@ -61,5 +61,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/ExpandableText/OverflowModePopover/sample.tsx
+++ b/packages/website/docs/_samples/main/ExpandableText/OverflowModePopover/sample.tsx
@@ -15,7 +15,7 @@ const TableHeaderRow = createReactComponent(TableHeaderRowClass);
 const TableRow = createReactComponent(TableRowClass);
 const ExpandableText = createReactComponent(ExpandableTextClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Table>
@@ -67,5 +67,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/FileUploader/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/FileUploader/Basic/sample.tsx
@@ -6,7 +6,7 @@ import "@ui5/webcomponents-icons/dist/upload.js";
 const FileUploader = createReactComponent(FileUploaderClass);
 const Label = createReactComponent(LabelClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <div style={{ height: "100px" }}>
@@ -16,5 +16,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/FileUploader/FileSizeLimit/sample.tsx
+++ b/packages/website/docs/_samples/main/FileUploader/FileSizeLimit/sample.tsx
@@ -9,7 +9,7 @@ import "@ui5/webcomponents-icons/dist/upload.js";
 const FileUploader = createReactComponent(FileUploaderClass);
 const Label = createReactComponent(LabelClass);
 
-function App() {
+export const Example = () => {
   const [valueState, setValueState] = useState<`${ValueState}`>("None");
   const [valueStateMessage, setValueStateMessage] = useState("");
 
@@ -52,5 +52,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/FileUploader/FilesFilter/sample.tsx
+++ b/packages/website/docs/_samples/main/FileUploader/FilesFilter/sample.tsx
@@ -8,7 +8,7 @@ import "@ui5/webcomponents-icons/dist/upload.js";
 const FileUploader = createReactComponent(FileUploaderClass);
 const Label = createReactComponent(LabelClass);
 
-function App() {
+export const Example = () => {
   const [images, setImages] = useState<string[]>([]);
 
   const handleFileUploaderChange = (
@@ -61,5 +61,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/FileUploader/MultipleFiles/sample.tsx
+++ b/packages/website/docs/_samples/main/FileUploader/MultipleFiles/sample.tsx
@@ -6,7 +6,7 @@ import "@ui5/webcomponents-icons/dist/upload.js";
 const FileUploader = createReactComponent(FileUploaderClass);
 const Label = createReactComponent(LabelClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <div style={{ height: "100px" }}>
@@ -16,5 +16,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/FileUploader/WithoutInput/sample.tsx
+++ b/packages/website/docs/_samples/main/FileUploader/WithoutInput/sample.tsx
@@ -8,7 +8,7 @@ const Button = createReactComponent(ButtonClass);
 const FileUploader = createReactComponent(FileUploaderClass);
 const Label = createReactComponent(LabelClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Label showColon={true} for="button-only-uploader">Choose file</Label>
@@ -20,5 +20,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Form/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/Form/Basic/sample.tsx
@@ -12,7 +12,7 @@ const Label = createReactComponent(LabelClass);
 const Slider = createReactComponent(SliderClass);
 const Text = createReactComponent(TextClass);
 
-function App() {
+export const Example = () => {
   const containerRef = useRef(null);
   const sliderRef = useRef(null);
 
@@ -65,5 +65,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Form/CustomHeader/sample.tsx
+++ b/packages/website/docs/_samples/main/Form/CustomHeader/sample.tsx
@@ -19,7 +19,7 @@ const Option = createReactComponent(OptionClass);
 const Select = createReactComponent(SelectClass);
 const Title = createReactComponent(TitleClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <style>{`
@@ -95,5 +95,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Form/Edit/sample.tsx
+++ b/packages/website/docs/_samples/main/Form/Edit/sample.tsx
@@ -23,7 +23,7 @@ const SegmentedButtonItem = createReactComponent(SegmentedButtonItemClass);
 const Select = createReactComponent(SelectClass);
 const Text = createReactComponent(TextClass);
 
-function App() {
+export const Example = () => {
   const [editable, setEditable] = useState(false);
 
   const handleSelectionChange = (
@@ -154,5 +154,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Form/EmptySpan/sample.tsx
+++ b/packages/website/docs/_samples/main/Form/EmptySpan/sample.tsx
@@ -18,7 +18,7 @@ const Select = createReactComponent(SelectClass);
 const Slider = createReactComponent(SliderClass);
 const Text = createReactComponent(TextClass);
 
-function App() {
+export const Example = () => {
   const containerRef = useRef(null);
   const sliderRef = useRef(null);
 
@@ -181,5 +181,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Form/FreeStyleForm/sample.tsx
+++ b/packages/website/docs/_samples/main/Form/FreeStyleForm/sample.tsx
@@ -38,7 +38,7 @@ const TextArea = createReactComponent(TextAreaClass);
 const TimePicker = createReactComponent(TimePickerClass);
 const Token = createReactComponent(TokenClass);
 
-function App() {
+export const Example = () => {
   const containerRef = useRef(null);
   const sliderRef = useRef(null);
 
@@ -227,5 +227,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Form/GroupColumnSpan/sample.tsx
+++ b/packages/website/docs/_samples/main/Form/GroupColumnSpan/sample.tsx
@@ -16,7 +16,7 @@ const Link = createReactComponent(LinkClass);
 const Slider = createReactComponent(SliderClass);
 const Text = createReactComponent(TextClass);
 
-function App() {
+export const Example = () => {
   const containerRef = useRef(null);
   const sliderRef = useRef(null);
 
@@ -148,5 +148,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Form/Groups/sample.tsx
+++ b/packages/website/docs/_samples/main/Form/Groups/sample.tsx
@@ -16,7 +16,7 @@ const Link = createReactComponent(LinkClass);
 const Slider = createReactComponent(SliderClass);
 const Text = createReactComponent(TextClass);
 
-function App() {
+export const Example = () => {
   const containerRef = useRef(null);
   const sliderRef = useRef(null);
 
@@ -147,5 +147,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Form/HeaderTextWrapping/sample.tsx
+++ b/packages/website/docs/_samples/main/Form/HeaderTextWrapping/sample.tsx
@@ -9,7 +9,7 @@ const FormItem = createReactComponent(FormItemClass);
 const Label = createReactComponent(LabelClass);
 const Text = createReactComponent(TextClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <div
@@ -44,5 +44,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Form/ItemColumnSpan/sample.tsx
+++ b/packages/website/docs/_samples/main/Form/ItemColumnSpan/sample.tsx
@@ -1,3 +1,4 @@
+
 import createReactComponent from "@ui5/webcomponents-base/dist/createReactComponent.js";
 import { useRef } from "react";
 import FormClass from "@ui5/webcomponents/dist/Form.js";
@@ -20,7 +21,7 @@ const Slider = createReactComponent(SliderClass);
 const Text = createReactComponent(TextClass);
 const TextArea = createReactComponent(TextAreaClass);
 
-function App() {
+export const Example = () => {
   const containerRef = useRef(null);
   const sliderRef = useRef(null);
 
@@ -97,5 +98,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Form/LabelSpan/sample.tsx
+++ b/packages/website/docs/_samples/main/Form/LabelSpan/sample.tsx
@@ -12,7 +12,7 @@ const Label = createReactComponent(LabelClass);
 const Slider = createReactComponent(SliderClass);
 const Text = createReactComponent(TextClass);
 
-function App() {
+export const Example = () => {
   const containerRef = useRef(null);
   const sliderRef = useRef(null);
 
@@ -126,5 +126,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Form/LabelsOnTop/sample.tsx
+++ b/packages/website/docs/_samples/main/Form/LabelsOnTop/sample.tsx
@@ -18,7 +18,7 @@ const Select = createReactComponent(SelectClass);
 const Slider = createReactComponent(SliderClass);
 const Text = createReactComponent(TextClass);
 
-function App() {
+export const Example = () => {
   const containerRef = useRef(null);
   const sliderRef = useRef(null);
 
@@ -115,5 +115,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Form/Layout/sample.tsx
+++ b/packages/website/docs/_samples/main/Form/Layout/sample.tsx
@@ -16,7 +16,7 @@ const Link = createReactComponent(LinkClass);
 const Slider = createReactComponent(SliderClass);
 const Text = createReactComponent(TextClass);
 
-function App() {
+export const Example = () => {
   const containerRef = useRef(null);
   const sliderRef = useRef(null);
 
@@ -448,5 +448,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Icon/BSIcons/sample.tsx
+++ b/packages/website/docs/_samples/main/Icon/BSIcons/sample.tsx
@@ -8,7 +8,7 @@ import "@ui5/webcomponents-icons-business-suite/dist/ab-testing.js";
 
 const Icon = createReactComponent(IconClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Icon name="business-suite/add-polygon" />
@@ -19,5 +19,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Icon/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/Icon/Basic/sample.tsx
@@ -8,7 +8,7 @@ import "@ui5/webcomponents-icons/dist/da-2.js";
 
 const Icon = createReactComponent(IconClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Icon name="home" />
@@ -19,5 +19,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Icon/CustomStyling/sample.tsx
+++ b/packages/website/docs/_samples/main/Icon/CustomStyling/sample.tsx
@@ -8,7 +8,7 @@ import "@ui5/webcomponents-icons/dist/da-2.js";
 
 const Icon = createReactComponent(IconClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Icon
@@ -38,5 +38,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Icon/Design/sample.tsx
+++ b/packages/website/docs/_samples/main/Icon/Design/sample.tsx
@@ -4,7 +4,7 @@ import "@ui5/webcomponents-icons/dist/da-2.js";
 
 const Icon = createReactComponent(IconClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Icon name="da-2" design="Default" />
@@ -18,5 +18,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Icon/Interactive/sample.tsx
+++ b/packages/website/docs/_samples/main/Icon/Interactive/sample.tsx
@@ -4,8 +4,6 @@ import "@ui5/webcomponents-icons/dist/home.js";
 
 const Icon = createReactComponent(IconClass);
 
-function App() {
+export const Example = () => {
   return <Icon name="home" mode="Interactive" />;
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Icon/TntIcons/sample.tsx
+++ b/packages/website/docs/_samples/main/Icon/TntIcons/sample.tsx
@@ -8,7 +8,7 @@ import "@ui5/webcomponents-icons-tnt/dist/repeater.js";
 
 const Icon = createReactComponent(IconClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Icon name="tnt/actor" />
@@ -19,5 +19,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Input/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/Input/Basic/sample.tsx
@@ -3,8 +3,6 @@ import InputClass from "@ui5/webcomponents/dist/Input.js";
 
 const Input = createReactComponent(InputClass);
 
-function App() {
+export const Example = () => {
   return <Input value="Input" />;
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Input/BuiltInFiltering/sample.tsx
+++ b/packages/website/docs/_samples/main/Input/BuiltInFiltering/sample.tsx
@@ -7,7 +7,7 @@ const Input = createReactComponent(InputClass);
 const SuggestionItem = createReactComponent(SuggestionItemClass);
 const SuggestionItemGroup = createReactComponent(SuggestionItemGroupClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Input filter="Contains" showSuggestions={true}>
@@ -25,5 +25,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Input/ClearIcon/sample.tsx
+++ b/packages/website/docs/_samples/main/Input/ClearIcon/sample.tsx
@@ -3,8 +3,6 @@ import InputClass from "@ui5/webcomponents/dist/Input.js";
 
 const Input = createReactComponent(InputClass);
 
-function App() {
+export const Example = () => {
   return <Input value="Input" showClearIcon={true} />;
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Input/CustomStyling/sample.tsx
+++ b/packages/website/docs/_samples/main/Input/CustomStyling/sample.tsx
@@ -3,7 +3,7 @@ import InputClass from "@ui5/webcomponents/dist/Input.js";
 
 const Input = createReactComponent(InputClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <style>{`
@@ -17,5 +17,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Input/CustomSuggestions/sample.tsx
+++ b/packages/website/docs/_samples/main/Input/CustomSuggestions/sample.tsx
@@ -23,7 +23,7 @@ const countries = [
   "Denmark",
 ];
 
-function App() {
+export const Example = () => {
   const [suggestions, setSuggestions] = useState<string[]>([]);
   const [inputValue, setInputValue] = useState("");
 
@@ -82,5 +82,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Input/DynamicSuggestions/sample.tsx
+++ b/packages/website/docs/_samples/main/Input/DynamicSuggestions/sample.tsx
@@ -54,7 +54,7 @@ const countries = [
   "Vietnam",
 ];
 
-function App() {
+export const Example = () => {
   const [suggestions, setSuggestions] = useState<string[]>([]);
 
   const handleInput = (e: UI5CustomEvent<InputClass, "input">) => {
@@ -83,5 +83,3 @@ function App() {
     </Input>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Input/Label/sample.tsx
+++ b/packages/website/docs/_samples/main/Input/Label/sample.tsx
@@ -5,7 +5,7 @@ import LabelClass from "@ui5/webcomponents/dist/Label.js";
 const Input = createReactComponent(InputClass);
 const Label = createReactComponent(LabelClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Label for="input" required={true} showColon={true}>
@@ -20,5 +20,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Input/Suggestions/sample.tsx
+++ b/packages/website/docs/_samples/main/Input/Suggestions/sample.tsx
@@ -44,7 +44,7 @@ const ui5_database_entries = [
   "USA",
 ];
 
-function App() {
+export const Example = () => {
   const [suggestions, setSuggestions] = useState<string[]>([]);
 
   const handleInputInput = useCallback(
@@ -75,5 +75,3 @@ function App() {
     </Input>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Input/SuggestionsWrapping/sample.tsx
+++ b/packages/website/docs/_samples/main/Input/SuggestionsWrapping/sample.tsx
@@ -5,7 +5,7 @@ import SuggestionItemClass from "@ui5/webcomponents/dist/SuggestionItem.js";
 const Input = createReactComponent(InputClass);
 const SuggestionItem = createReactComponent(SuggestionItemClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Input placeholder="Type something" showSuggestions={true}>
@@ -16,5 +16,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Input/ValueHelpDialog/sample.tsx
+++ b/packages/website/docs/_samples/main/Input/ValueHelpDialog/sample.tsx
@@ -21,7 +21,7 @@ const ListItemStandard = createReactComponent(ListItemStandardClass);
 const SuggestionItem = createReactComponent(SuggestionItemClass);
 const Title = createReactComponent(TitleClass);
 
-function App() {
+export const Example = () => {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [suggestionItems, setSuggestionItems] = useState<string[]>([]);
   const [dialogListItems, setDialogListItems] = useState<{ name: string, productId: string }[]>([]);
@@ -148,5 +148,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Input/ValueStateMessage/sample.tsx
+++ b/packages/website/docs/_samples/main/Input/ValueStateMessage/sample.tsx
@@ -5,7 +5,7 @@ import SuggestionItemClass from "@ui5/webcomponents/dist/SuggestionItem.js";
 const Input = createReactComponent(InputClass);
 const SuggestionItem = createReactComponent(SuggestionItemClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Input
@@ -23,5 +23,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Label/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/Label/Basic/sample.tsx
@@ -5,7 +5,7 @@ import LabelClass from "@ui5/webcomponents/dist/Label.js";
 const Input = createReactComponent(InputClass);
 const Label = createReactComponent(LabelClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Label>Simple Label</Label>
@@ -18,5 +18,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Label/CustomStyling/sample.tsx
+++ b/packages/website/docs/_samples/main/Label/CustomStyling/sample.tsx
@@ -3,7 +3,7 @@ import LabelClass from "@ui5/webcomponents/dist/Label.js";
 
 const Label = createReactComponent(LabelClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Label style={{ color: "var(--sapPositiveColor)", fontSize: "1.25rem" }}>
@@ -21,5 +21,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Label/TextWrapping/sample.tsx
+++ b/packages/website/docs/_samples/main/Label/TextWrapping/sample.tsx
@@ -3,7 +3,7 @@ import LabelClass from "@ui5/webcomponents/dist/Label.js";
 
 const Label = createReactComponent(LabelClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <style>{`
@@ -23,5 +23,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Label/UsageWithInputs/sample.tsx
+++ b/packages/website/docs/_samples/main/Label/UsageWithInputs/sample.tsx
@@ -15,7 +15,7 @@ const Option = createReactComponent(OptionClass);
 const Select = createReactComponent(SelectClass);
 const TextArea = createReactComponent(TextAreaClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <style>{`
@@ -62,5 +62,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Link/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/Link/Basic/sample.tsx
@@ -3,7 +3,7 @@ import LinkClass from "@ui5/webcomponents/dist/Link.js";
 
 const Link = createReactComponent(LinkClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Link href="https://www.sap.com" target="_blank">
@@ -15,5 +15,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Link/CustomStyling/sample.tsx
+++ b/packages/website/docs/_samples/main/Link/CustomStyling/sample.tsx
@@ -3,7 +3,7 @@ import LinkClass from "@ui5/webcomponents/dist/Link.js";
 
 const Link = createReactComponent(LinkClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Link
@@ -24,5 +24,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Link/Design/sample.tsx
+++ b/packages/website/docs/_samples/main/Link/Design/sample.tsx
@@ -3,7 +3,7 @@ import LinkClass from "@ui5/webcomponents/dist/Link.js";
 
 const Link = createReactComponent(LinkClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Link design="Emphasized" href="https://www.sap.com" target="_blank">
@@ -20,5 +20,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Link/TextWrapping/sample.tsx
+++ b/packages/website/docs/_samples/main/Link/TextWrapping/sample.tsx
@@ -3,7 +3,7 @@ import LinkClass from "@ui5/webcomponents/dist/Link.js";
 
 const Link = createReactComponent(LinkClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Link
@@ -27,5 +27,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Link/WithIcons/sample.tsx
+++ b/packages/website/docs/_samples/main/Link/WithIcons/sample.tsx
@@ -5,7 +5,7 @@ import "@ui5/webcomponents-icons/dist/cloud.js";
 
 const Link = createReactComponent(LinkClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Link href="https://www.sap.com" target="_blank" icon="employee">
@@ -25,5 +25,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/List/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/List/Basic/sample.tsx
@@ -6,7 +6,7 @@ import "@ui5/webcomponents-icons/dist/nutrition-activity.js";
 const List = createReactComponent(ListClass);
 const ListItemStandard = createReactComponent(ListItemStandardClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <List>
@@ -46,5 +46,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/List/DragAndDrop/sample.tsx
+++ b/packages/website/docs/_samples/main/List/DragAndDrop/sample.tsx
@@ -9,7 +9,7 @@ import "@ui5/webcomponents-icons/dist/checklist-item.js";
 const List = createReactComponent(ListClass);
 const ListItemStandard = createReactComponent(ListItemStandardClass);
 
-function App() {
+export const Example = () => {
   const [items, setItems] = useState([
     { id: "1", text: "Item #1" },
     { id: "2", text: "Item #2" },
@@ -74,5 +74,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/List/GroupHeaderStyling/sample.tsx
+++ b/packages/website/docs/_samples/main/List/GroupHeaderStyling/sample.tsx
@@ -10,7 +10,7 @@ const List = createReactComponent(ListClass);
 const ListItemGroup = createReactComponent(ListItemGroupClass);
 const ListItemStandard = createReactComponent(ListItemStandardClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <style>{`
@@ -67,5 +67,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/List/GroupHeaders/sample.tsx
+++ b/packages/website/docs/_samples/main/List/GroupHeaders/sample.tsx
@@ -12,7 +12,7 @@ const List = createReactComponent(ListClass);
 const ListItemGroup = createReactComponent(ListItemGroupClass);
 const ListItemStandard = createReactComponent(ListItemStandardClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <List selectionMode="Multiple">
@@ -88,5 +88,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/List/Growing/sample.tsx
+++ b/packages/website/docs/_samples/main/List/Growing/sample.tsx
@@ -7,7 +7,7 @@ import "@ui5/webcomponents-icons/dist/nutrition-activity.js";
 const List = createReactComponent(ListClass);
 const ListItemStandard = createReactComponent(ListItemStandardClass);
 
-function App() {
+export const Example = () => {
   const [extraItems, setExtraItems] = useState<Array<{ index: number }>>([]);
   const [loading, setLoading] = useState(false);
   const listRef = useRef(null);
@@ -93,5 +93,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/List/GrowingOnButtonPress/sample.tsx
+++ b/packages/website/docs/_samples/main/List/GrowingOnButtonPress/sample.tsx
@@ -7,7 +7,7 @@ import "@ui5/webcomponents-icons/dist/nutrition-activity.js";
 const List = createReactComponent(ListClass);
 const ListItemStandard = createReactComponent(ListItemStandardClass);
 
-function App() {
+export const Example = () => {
   const [extraItems, setExtraItems] = useState<Array<{ index: number }>>([]);
   const [loading, setLoading] = useState(false);
   const listRef = useRef(null);
@@ -93,5 +93,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/List/Modes/sample.tsx
+++ b/packages/website/docs/_samples/main/List/Modes/sample.tsx
@@ -6,7 +6,7 @@ import "@ui5/webcomponents-icons/dist/map.js";
 const List = createReactComponent(ListClass);
 const ListItemStandard = createReactComponent(ListItemStandardClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <List selectionMode="Single" headerText="Single Select Mode">
@@ -69,5 +69,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/List/MultipleDrag/sample.tsx
+++ b/packages/website/docs/_samples/main/List/MultipleDrag/sample.tsx
@@ -11,7 +11,7 @@ import "@ui5/webcomponents-icons/dist/accept.js";
 const List = createReactComponent(ListClass);
 const ListItemStandard = createReactComponent(ListItemStandardClass);
 
-function App() {
+export const Example = () => {
   const [list1Items, setList1Items] = useState([
     { id: "1", text: "Review design mockups", icon: "task" },
     { id: "2", text: "Update documentation", icon: "task" },
@@ -218,5 +218,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/List/NoData/sample.tsx
+++ b/packages/website/docs/_samples/main/List/NoData/sample.tsx
@@ -3,7 +3,7 @@ import ListClass from "@ui5/webcomponents/dist/List.js";
 
 const List = createReactComponent(ListClass);
 
-function App() {
+export const Example = () => {
   return (
     <List
       selectionMode="None"
@@ -12,5 +12,3 @@ function App() {
     />
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/List/SeparationTypes/sample.tsx
+++ b/packages/website/docs/_samples/main/List/SeparationTypes/sample.tsx
@@ -7,7 +7,7 @@ import "@ui5/webcomponents-icons/dist/shipping-status.js";
 const List = createReactComponent(ListClass);
 const ListItemStandard = createReactComponent(ListItemStandardClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <List separators="None">
@@ -27,5 +27,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/List/StickyHeader/sample.tsx
+++ b/packages/website/docs/_samples/main/List/StickyHeader/sample.tsx
@@ -8,7 +8,7 @@ const List = createReactComponent(ListClass);
 const ListItemStandard = createReactComponent(ListItemStandardClass);
 const Title = createReactComponent(TitleClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <style>{`
@@ -111,5 +111,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/List/WrappingBehavior/sample.tsx
+++ b/packages/website/docs/_samples/main/List/WrappingBehavior/sample.tsx
@@ -17,7 +17,7 @@ const ListItemStandard = createReactComponent(ListItemStandardClass);
 const Title = createReactComponent(TitleClass);
 const ExpandableText = createReactComponent(ExpandableTextClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <style>{`
@@ -138,5 +138,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Menu/AditionalText/sample.tsx
+++ b/packages/website/docs/_samples/main/Menu/AditionalText/sample.tsx
@@ -16,7 +16,7 @@ const Menu = createReactComponent(MenuClass);
 const MenuItem = createReactComponent(MenuItemClass);
 const MenuSeparator = createReactComponent(MenuSeparatorClass);
 
-function App() {
+export const Example = () => {
   const [menuOpen, setMenuOpen] = useState(false);
 
   return (
@@ -52,5 +52,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Menu/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/Menu/Basic/sample.tsx
@@ -18,7 +18,7 @@ const Menu = createReactComponent(MenuClass);
 const MenuItem = createReactComponent(MenuItemClass);
 const MenuSeparator = createReactComponent(MenuSeparatorClass);
 
-function App() {
+export const Example = () => {
   const [menuOpen, setMenuOpen] = useState(false);
 
   return (
@@ -50,5 +50,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Menu/DynamicallyAddedItems/sample.tsx
+++ b/packages/website/docs/_samples/main/Menu/DynamicallyAddedItems/sample.tsx
@@ -13,7 +13,7 @@ const Button = createReactComponent(ButtonClass);
 const Menu = createReactComponent(MenuClass);
 const MenuItem = createReactComponent(MenuItemClass);
 
-function App() {
+export const Example = () => {
   const menuSubsRef = useRef(null);
   const delayMenuRef = useRef(null);
   const [menuSubsOpen, setMenuSubsOpen] = useState(false);
@@ -95,5 +95,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Menu/ItemGroups/sample.tsx
+++ b/packages/website/docs/_samples/main/Menu/ItemGroups/sample.tsx
@@ -21,7 +21,7 @@ const MenuItem = createReactComponent(MenuItemClass);
 const MenuSeparator = createReactComponent(MenuSeparatorClass);
 const MenuItemGroup = createReactComponent(MenuItemGroupClass);
 
-function App() {
+export const Example = () => {
   const [menuOpen, setMenuOpen] = useState(false);
 
   return (
@@ -86,5 +86,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Menu/MenuEndContent/sample.tsx
+++ b/packages/website/docs/_samples/main/Menu/MenuEndContent/sample.tsx
@@ -19,7 +19,7 @@ const Menu = createReactComponent(MenuClass);
 const MenuItem = createReactComponent(MenuItemClass);
 const MenuSeparator = createReactComponent(MenuSeparatorClass);
 
-function App() {
+export const Example = () => {
   const [menuOpen, setMenuOpen] = useState(false);
 
   const handleNewAddClick = () => {
@@ -105,5 +105,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Menu/SubMenu/sample.tsx
+++ b/packages/website/docs/_samples/main/Menu/SubMenu/sample.tsx
@@ -18,7 +18,7 @@ const Menu = createReactComponent(MenuClass);
 const MenuItem = createReactComponent(MenuItemClass);
 const MenuSeparator = createReactComponent(MenuSeparatorClass);
 
-function App() {
+export const Example = () => {
   const [menuOpen, setMenuOpen] = useState(false);
 
   return (
@@ -64,5 +64,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/MessageStrip/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/MessageStrip/Basic/sample.tsx
@@ -3,8 +3,6 @@ import MessageStripClass from "@ui5/webcomponents/dist/MessageStrip.js";
 
 const MessageStrip = createReactComponent(MessageStripClass);
 
-function App() {
+export const Example = () => {
   return <MessageStrip design="Information">Information Message</MessageStrip>;
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/MessageStrip/Custom/sample.tsx
+++ b/packages/website/docs/_samples/main/MessageStrip/Custom/sample.tsx
@@ -3,7 +3,7 @@ import MessageStripClass from "@ui5/webcomponents/dist/MessageStrip.js";
 
 const MessageStrip = createReactComponent(MessageStripClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <MessageStrip design="Negative">
@@ -13,5 +13,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/MessageStrip/CustomColors/sample.tsx
+++ b/packages/website/docs/_samples/main/MessageStrip/CustomColors/sample.tsx
@@ -6,7 +6,7 @@ import "@ui5/webcomponents-icons/dist/palette.js";
 const Icon = createReactComponent(IconClass);
 const MessageStrip = createReactComponent(MessageStripClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <MessageStrip design="ColorSet2">
@@ -21,5 +21,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/MessageStrip/Design/sample.tsx
+++ b/packages/website/docs/_samples/main/MessageStrip/Design/sample.tsx
@@ -3,7 +3,7 @@ import MessageStripClass from "@ui5/webcomponents/dist/MessageStrip.js";
 
 const MessageStrip = createReactComponent(MessageStripClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <MessageStrip design="Information">Information MessageStrip</MessageStrip>
@@ -19,5 +19,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/MessageStrip/HideIconAndButton/sample.tsx
+++ b/packages/website/docs/_samples/main/MessageStrip/HideIconAndButton/sample.tsx
@@ -3,7 +3,7 @@ import MessageStripClass from "@ui5/webcomponents/dist/MessageStrip.js";
 
 const MessageStrip = createReactComponent(MessageStripClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <MessageStrip hideCloseButton={true}>Message</MessageStrip>
@@ -15,5 +15,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/MultiComboBox/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/MultiComboBox/Basic/sample.tsx
@@ -5,7 +5,7 @@ import MultiComboBoxItemClass from "@ui5/webcomponents/dist/MultiComboBoxItem.js
 const MultiComboBox = createReactComponent(MultiComboBoxClass);
 const MultiComboBoxItem = createReactComponent(MultiComboBoxItemClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <MultiComboBox placeholder="Type your value">
@@ -22,5 +22,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/MultiComboBox/ClearIcon/sample.tsx
+++ b/packages/website/docs/_samples/main/MultiComboBox/ClearIcon/sample.tsx
@@ -5,7 +5,7 @@ import MultiComboBoxItemClass from "@ui5/webcomponents/dist/MultiComboBoxItem.js
 const MultiComboBox = createReactComponent(MultiComboBoxClass);
 const MultiComboBoxItem = createReactComponent(MultiComboBoxItemClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <MultiComboBox value="Italy" noValidation={true} showClearIcon={true}>
@@ -22,5 +22,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/MultiComboBox/MultiComboBoxCustomValue/sample.tsx
+++ b/packages/website/docs/_samples/main/MultiComboBox/MultiComboBoxCustomValue/sample.tsx
@@ -5,7 +5,7 @@ import MultiComboBoxItemClass from "@ui5/webcomponents/dist/MultiComboBoxItem.js
 const MultiComboBox = createReactComponent(MultiComboBoxClass);
 const MultiComboBoxItem = createReactComponent(MultiComboBoxItemClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <MultiComboBox placeholder="Choose your state" noValidation={true}>
@@ -18,5 +18,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/MultiComboBox/MultiComboBoxGrouping/sample.tsx
+++ b/packages/website/docs/_samples/main/MultiComboBox/MultiComboBoxGrouping/sample.tsx
@@ -7,7 +7,7 @@ const MultiComboBox = createReactComponent(MultiComboBoxClass);
 const MultiComboBoxItem = createReactComponent(MultiComboBoxItemClass);
 const MultiComboBoxItemGroup = createReactComponent(MultiComboBoxItemGroupClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <MultiComboBox placeholder="Select a country">
@@ -34,5 +34,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/MultiComboBox/MultiComboBoxSelectAll/sample.tsx
+++ b/packages/website/docs/_samples/main/MultiComboBox/MultiComboBoxSelectAll/sample.tsx
@@ -5,7 +5,7 @@ import MultiComboBoxItemClass from "@ui5/webcomponents/dist/MultiComboBoxItem.js
 const MultiComboBox = createReactComponent(MultiComboBoxClass);
 const MultiComboBoxItem = createReactComponent(MultiComboBoxItemClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <MultiComboBox placeholder="Type your value" showSelectAll={true}>
@@ -22,5 +22,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/MultiComboBox/SelectedValues/sample.tsx
+++ b/packages/website/docs/_samples/main/MultiComboBox/SelectedValues/sample.tsx
@@ -5,7 +5,7 @@ import MultiComboBoxItemClass from "@ui5/webcomponents/dist/MultiComboBoxItem.js
 const MultiComboBox = createReactComponent(MultiComboBoxClass);
 const MultiComboBoxItem = createReactComponent(MultiComboBoxItemClass);
 
-function App() {
+export const Example = () => {
   return (
     <MultiComboBox placeholder="Select countries" selectedValues={["DE", "FR"]}>
       <MultiComboBoxItem text="Germany" value="DE" />
@@ -16,5 +16,3 @@ function App() {
     </MultiComboBox>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/MultiComboBox/SelectedValuesDynamic/sample.tsx
+++ b/packages/website/docs/_samples/main/MultiComboBox/SelectedValuesDynamic/sample.tsx
@@ -14,7 +14,7 @@ const MultiComboBoxItem = createReactComponent(MultiComboBoxItemClass);
 const europeanCountries = ["DE", "FR", "IT"];
 const allCountries = ["DE", "FR", "IT", "US", "CA", "JP"];
 
-function App() {
+export const Example = () => {
   const [selectedValues, setSelectedValues] = useState<string[]>([]);
 
   const handleSelectionChange = (
@@ -72,5 +72,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/MultiComboBox/SuggestionsWrapping/sample.tsx
+++ b/packages/website/docs/_samples/main/MultiComboBox/SuggestionsWrapping/sample.tsx
@@ -5,7 +5,7 @@ import MultiComboBoxItemClass from "@ui5/webcomponents/dist/MultiComboBoxItem.js
 const MultiComboBox = createReactComponent(MultiComboBoxClass);
 const MultiComboBoxItem = createReactComponent(MultiComboBoxItemClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <MultiComboBox placeholder="Enter product">
@@ -16,5 +16,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/MultiInput/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/MultiInput/Basic/sample.tsx
@@ -7,7 +7,7 @@ import TokenClass from "@ui5/webcomponents/dist/Token.js";
 const MultiInput = createReactComponent(MultiInputClass);
 const Token = createReactComponent(TokenClass);
 
-function App() {
+export const Example = () => {
   const [tokens, setTokens] = useState([
     "Argentina",
     "Mexico",
@@ -36,5 +36,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/MultiInput/SuggestionsWrapping/sample.tsx
+++ b/packages/website/docs/_samples/main/MultiInput/SuggestionsWrapping/sample.tsx
@@ -5,7 +5,7 @@ import SuggestionItemClass from "@ui5/webcomponents/dist/SuggestionItem.js";
 const MultiInput = createReactComponent(MultiInputClass);
 const SuggestionItem = createReactComponent(SuggestionItemClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <MultiInput placeholder="Type anything" showSuggestions={true}>
@@ -17,5 +17,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/MultiInput/TokenCreation/sample.tsx
+++ b/packages/website/docs/_samples/main/MultiInput/TokenCreation/sample.tsx
@@ -25,7 +25,7 @@ const suggestions = [
   "USA",
 ];
 
-function App() {
+export const Example = () => {
   const [tokens, setTokens] = useState<string[]>([]);
   const [valueState, setValueState] = useState<`${ValueState}`>("None");
   const multiInputRef = useRef(null);
@@ -99,5 +99,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Panel/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/Panel/Basic/sample.tsx
@@ -7,7 +7,7 @@ const Label = createReactComponent(LabelClass);
 const Panel = createReactComponent(PanelClass);
 const Title = createReactComponent(TitleClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Panel headerText="Panel">
@@ -22,5 +22,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Panel/CustomHeader/sample.tsx
+++ b/packages/website/docs/_samples/main/Panel/CustomHeader/sample.tsx
@@ -9,7 +9,7 @@ const Label = createReactComponent(LabelClass);
 const Panel = createReactComponent(PanelClass);
 const Title = createReactComponent(TitleClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Panel>
@@ -36,5 +36,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Panel/Fixed/sample.tsx
+++ b/packages/website/docs/_samples/main/Panel/Fixed/sample.tsx
@@ -7,7 +7,7 @@ const Label = createReactComponent(LabelClass);
 const Panel = createReactComponent(PanelClass);
 const Title = createReactComponent(TitleClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Panel headerText="Collapsed, Fixed Panel" fixed={true} collapsed={true}>
@@ -35,5 +35,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Panel/StickyHeader/sample.tsx
+++ b/packages/website/docs/_samples/main/Panel/StickyHeader/sample.tsx
@@ -7,7 +7,7 @@ const Label = createReactComponent(LabelClass);
 const Panel = createReactComponent(PanelClass);
 const Title = createReactComponent(TitleClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <div style={{ height: "250px", overflow: "scroll" }}>
@@ -72,5 +72,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Popover/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/Popover/Basic/sample.tsx
@@ -10,7 +10,7 @@ const Input = createReactComponent(InputClass);
 const Label = createReactComponent(LabelClass);
 const Popover = createReactComponent(PopoverClass);
 
-function App() {
+export const Example = () => {
   const [open, setOpen] = useState(false);
 
   return (
@@ -48,5 +48,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Popover/Placement/sample.tsx
+++ b/packages/website/docs/_samples/main/Popover/Placement/sample.tsx
@@ -10,7 +10,7 @@ const Input = createReactComponent(InputClass);
 const Label = createReactComponent(LabelClass);
 const Popover = createReactComponent(PopoverClass);
 
-function App() {
+export const Example = () => {
   const [popover1Open, setPopover1Open] = useState(false);
   const [popover2Open, setPopover2Open] = useState(false);
 
@@ -84,5 +84,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Popover/Resizable/sample.tsx
+++ b/packages/website/docs/_samples/main/Popover/Resizable/sample.tsx
@@ -10,7 +10,7 @@ const Popover = createReactComponent(PopoverClass);
 const Toolbar = createReactComponent(ToolbarClass);
 const ToolbarButton = createReactComponent(ToolbarButtonClass);
 
-function App() {
+export const Example = () => {
   const [open, setOpen] = useState(false);
 
   return (
@@ -41,5 +41,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/ProgressIndicator/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/ProgressIndicator/Basic/sample.tsx
@@ -3,8 +3,6 @@ import ProgressIndicatorClass from "@ui5/webcomponents/dist/ProgressIndicator.js
 
 const ProgressIndicator = createReactComponent(ProgressIndicatorClass);
 
-function App() {
+export const Example = () => {
   return <ProgressIndicator value={25} />;
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/ProgressIndicator/DisplayValue/sample.tsx
+++ b/packages/website/docs/_samples/main/ProgressIndicator/DisplayValue/sample.tsx
@@ -3,8 +3,6 @@ import ProgressIndicatorClass from "@ui5/webcomponents/dist/ProgressIndicator.js
 
 const ProgressIndicator = createReactComponent(ProgressIndicatorClass);
 
-function App() {
+export const Example = () => {
   return <ProgressIndicator value={25} displayValue="1/4" />;
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/ProgressIndicator/States/sample.tsx
+++ b/packages/website/docs/_samples/main/ProgressIndicator/States/sample.tsx
@@ -3,7 +3,7 @@ import ProgressIndicatorClass from "@ui5/webcomponents/dist/ProgressIndicator.js
 
 const ProgressIndicator = createReactComponent(ProgressIndicatorClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <ProgressIndicator value={25} valueState="Positive" />
@@ -13,5 +13,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/RadioButton/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/RadioButton/Basic/sample.tsx
@@ -3,7 +3,7 @@ import RadioButtonClass from "@ui5/webcomponents/dist/RadioButton.js";
 
 const RadioButton = createReactComponent(RadioButtonClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <RadioButton name="myGroup" text="Option A" />
@@ -12,5 +12,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/RadioButton/States/sample.tsx
+++ b/packages/website/docs/_samples/main/RadioButton/States/sample.tsx
@@ -3,7 +3,7 @@ import RadioButtonClass from "@ui5/webcomponents/dist/RadioButton.js";
 
 const RadioButton = createReactComponent(RadioButtonClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <RadioButton text="Option A" checked={true} name="GroupA" />
@@ -17,5 +17,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/RadioButton/TextWrapping/sample.tsx
+++ b/packages/website/docs/_samples/main/RadioButton/TextWrapping/sample.tsx
@@ -3,7 +3,7 @@ import RadioButtonClass from "@ui5/webcomponents/dist/RadioButton.js";
 
 const RadioButton = createReactComponent(RadioButtonClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <RadioButton
@@ -23,5 +23,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/RangeSlider/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/RangeSlider/Basic/sample.tsx
@@ -3,12 +3,10 @@ import RangeSliderClass from "@ui5/webcomponents/dist/RangeSlider.js";
 
 const RangeSlider = createReactComponent(RangeSliderClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <RangeSlider startValue={20} endValue={60} min={0} max={100} step={5} />
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/RangeSlider/ShowTickmarks/sample.tsx
+++ b/packages/website/docs/_samples/main/RangeSlider/ShowTickmarks/sample.tsx
@@ -3,7 +3,7 @@ import RangeSliderClass from "@ui5/webcomponents/dist/RangeSlider.js";
 
 const RangeSlider = createReactComponent(RangeSliderClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <RangeSlider
@@ -26,5 +26,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/RangeSlider/ShowTooltip/sample.tsx
+++ b/packages/website/docs/_samples/main/RangeSlider/ShowTooltip/sample.tsx
@@ -3,7 +3,7 @@ import RangeSliderClass from "@ui5/webcomponents/dist/RangeSlider.js";
 
 const RangeSlider = createReactComponent(RangeSliderClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <RangeSlider
@@ -17,5 +17,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/RatingIndicator/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/RatingIndicator/Basic/sample.tsx
@@ -5,7 +5,7 @@ import "@ui5/webcomponents-icons/dist/unfavorite.js";
 
 const RatingIndicator = createReactComponent(RatingIndicatorClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <RatingIndicator value={4} max={7} />
@@ -16,5 +16,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/RatingIndicator/CustomIcons/sample.tsx
+++ b/packages/website/docs/_samples/main/RatingIndicator/CustomIcons/sample.tsx
@@ -8,7 +8,7 @@ import "@ui5/webcomponents-icons/dist/circle-task-2.js";
 
 const RatingIndicator = createReactComponent(RatingIndicatorClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <RatingIndicator value={3} ratedIcon="heart" unratedIcon="heart-2" />
@@ -24,5 +24,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/RatingIndicator/Sizes/sample.tsx
+++ b/packages/website/docs/_samples/main/RatingIndicator/Sizes/sample.tsx
@@ -5,7 +5,7 @@ import "@ui5/webcomponents-icons/dist/unfavorite.js";
 
 const RatingIndicator = createReactComponent(RatingIndicatorClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <RatingIndicator size="S" value={2.5} readonly={true} />
@@ -16,5 +16,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/ResponsivePopover/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/ResponsivePopover/Basic/sample.tsx
@@ -10,7 +10,7 @@ const Input = createReactComponent(InputClass);
 const Label = createReactComponent(LabelClass);
 const ResponsivePopover = createReactComponent(ResponsivePopoverClass);
 
-function App() {
+export const Example = () => {
   const [open, setOpen] = useState(false);
 
   return (
@@ -48,5 +48,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/ResponsivePopover/Placement/sample.tsx
+++ b/packages/website/docs/_samples/main/ResponsivePopover/Placement/sample.tsx
@@ -10,7 +10,7 @@ const Input = createReactComponent(InputClass);
 const Label = createReactComponent(LabelClass);
 const ResponsivePopover = createReactComponent(ResponsivePopoverClass);
 
-function App() {
+export const Example = () => {
   const [popover1Open, setPopover1Open] = useState(false);
   const [popover2Open, setPopover2Open] = useState(false);
 
@@ -84,5 +84,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/SegmentedButton/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/SegmentedButton/Basic/sample.tsx
@@ -8,7 +8,7 @@ import "@ui5/webcomponents-icons/dist/italic-text.js";
 const SegmentedButton = createReactComponent(SegmentedButtonClass);
 const SegmentedButtonItem = createReactComponent(SegmentedButtonItemClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <SegmentedButton accessibleName="Font style">
@@ -28,5 +28,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/SegmentedButton/ItemsFitContent/sample.tsx
+++ b/packages/website/docs/_samples/main/SegmentedButton/ItemsFitContent/sample.tsx
@@ -8,7 +8,7 @@ import "@ui5/webcomponents-icons/dist/italic-text.js";
 const SegmentedButton = createReactComponent(SegmentedButtonClass);
 const SegmentedButtonItem = createReactComponent(SegmentedButtonItemClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <SegmentedButton accessibleName="Font style" itemsFitContent={true}>
@@ -20,5 +20,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/SegmentedButton/SelectionModes/sample.tsx
+++ b/packages/website/docs/_samples/main/SegmentedButton/SelectionModes/sample.tsx
@@ -8,7 +8,7 @@ import "@ui5/webcomponents-icons/dist/italic-text.js";
 const SegmentedButton = createReactComponent(SegmentedButtonClass);
 const SegmentedButtonItem = createReactComponent(SegmentedButtonItemClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <SegmentedButton accessibleName="Font style" selectionMode="Single">
@@ -28,5 +28,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Select/AdditionalText/sample.tsx
+++ b/packages/website/docs/_samples/main/Select/AdditionalText/sample.tsx
@@ -8,7 +8,7 @@ import "@ui5/webcomponents-icons/dist/laptop.js";
 const Option = createReactComponent(OptionClass);
 const Select = createReactComponent(SelectClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Select>
@@ -21,5 +21,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Select/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/Select/Basic/sample.tsx
@@ -8,7 +8,7 @@ import "@ui5/webcomponents-icons/dist/laptop.js";
 const Option = createReactComponent(OptionClass);
 const Select = createReactComponent(SelectClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Select value="tablet">
@@ -25,5 +25,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Select/CustomOptions/sample.tsx
+++ b/packages/website/docs/_samples/main/Select/CustomOptions/sample.tsx
@@ -9,7 +9,7 @@ const Icon = createReactComponent(IconClass);
 const OptionCustom = createReactComponent(OptionCustomClass);
 const Select = createReactComponent(SelectClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Select>
@@ -40,5 +40,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Select/Selection/sample.tsx
+++ b/packages/website/docs/_samples/main/Select/Selection/sample.tsx
@@ -11,7 +11,7 @@ const Option = createReactComponent(OptionClass);
 const Select = createReactComponent(SelectClass);
 const Text = createReactComponent(TextClass);
 
-function App() {
+export const Example = () => {
   const [selectedValue, setSelectedValue] = useState("DE");
 
   const handleCountrySelectChange = (
@@ -44,5 +44,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Select/States/sample.tsx
+++ b/packages/website/docs/_samples/main/Select/States/sample.tsx
@@ -6,7 +6,7 @@ import "@ui5/webcomponents-icons/dist/meal.js";
 const Option = createReactComponent(OptionClass);
 const Select = createReactComponent(SelectClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Select valueState="Positive" value="apple">
@@ -97,5 +97,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Slider/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/Slider/Basic/sample.tsx
@@ -3,12 +3,10 @@ import SliderClass from "@ui5/webcomponents/dist/Slider.js";
 
 const Slider = createReactComponent(SliderClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Slider value={20} min={0} max={100} step={5} />
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Slider/ShowTickmarks/sample.tsx
+++ b/packages/website/docs/_samples/main/Slider/ShowTickmarks/sample.tsx
@@ -3,7 +3,7 @@ import SliderClass from "@ui5/webcomponents/dist/Slider.js";
 
 const Slider = createReactComponent(SliderClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Slider value={20} min={0} max={100} step={5} showTickmarks={true} />
@@ -18,5 +18,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Slider/ShowTooltip/sample.tsx
+++ b/packages/website/docs/_samples/main/Slider/ShowTooltip/sample.tsx
@@ -3,12 +3,10 @@ import SliderClass from "@ui5/webcomponents/dist/Slider.js";
 
 const Slider = createReactComponent(SliderClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Slider value={20} min={0} max={100} step={5} showTooltip={true} />
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/SplitButton/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/SplitButton/Basic/sample.tsx
@@ -3,8 +3,6 @@ import SplitButtonClass from "@ui5/webcomponents/dist/SplitButton.js";
 
 const SplitButton = createReactComponent(SplitButtonClass);
 
-function App() {
+export const Example = () => {
   return <SplitButton>Split Button</SplitButton>;
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/SplitButton/Design/sample.tsx
+++ b/packages/website/docs/_samples/main/SplitButton/Design/sample.tsx
@@ -3,7 +3,7 @@ import SplitButtonClass from "@ui5/webcomponents/dist/SplitButton.js";
 
 const SplitButton = createReactComponent(SplitButtonClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <SplitButton design="Emphasized">Emphasized</SplitButton>
@@ -15,5 +15,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/SplitButton/OpeningMenu/sample.tsx
+++ b/packages/website/docs/_samples/main/SplitButton/OpeningMenu/sample.tsx
@@ -11,7 +11,7 @@ const Menu = createReactComponent(MenuClass);
 const MenuItem = createReactComponent(MenuItemClass);
 const SplitButton = createReactComponent(SplitButtonClass);
 
-function App() {
+export const Example = () => {
   const menuRef = useRef(null);
   const splitBtnRef = useRef(null);
 
@@ -41,5 +41,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/StepInput/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/StepInput/Basic/sample.tsx
@@ -3,8 +3,6 @@ import StepInputClass from "@ui5/webcomponents/dist/StepInput.js";
 
 const StepInput = createReactComponent(StepInputClass);
 
-function App() {
+export const Example = () => {
   return <StepInput />;
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/StepInput/MinMax/sample.tsx
+++ b/packages/website/docs/_samples/main/StepInput/MinMax/sample.tsx
@@ -3,8 +3,6 @@ import StepInputClass from "@ui5/webcomponents/dist/StepInput.js";
 
 const StepInput = createReactComponent(StepInputClass);
 
-function App() {
+export const Example = () => {
   return <StepInput value={0} min={-50} max={50} step={10} />;
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/StepInput/States/sample.tsx
+++ b/packages/website/docs/_samples/main/StepInput/States/sample.tsx
@@ -3,7 +3,7 @@ import StepInputClass from "@ui5/webcomponents/dist/StepInput.js";
 
 const StepInput = createReactComponent(StepInputClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <StepInput disabled={true} value={5} />
@@ -34,5 +34,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/StepInput/ValuePrecision/sample.tsx
+++ b/packages/website/docs/_samples/main/StepInput/ValuePrecision/sample.tsx
@@ -3,10 +3,8 @@ import StepInputClass from "@ui5/webcomponents/dist/StepInput.js";
 
 const StepInput = createReactComponent(StepInputClass);
 
-function App() {
+export const Example = () => {
   return (
     <StepInput value={5} min={0} max={10} step={0.5} valuePrecision={1} />
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Switch/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/Switch/Basic/sample.tsx
@@ -3,7 +3,7 @@ import SwitchClass from "@ui5/webcomponents/dist/Switch.js";
 
 const Switch = createReactComponent(SwitchClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Switch />
@@ -13,5 +13,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Switch/Design/sample.tsx
+++ b/packages/website/docs/_samples/main/Switch/Design/sample.tsx
@@ -3,7 +3,7 @@ import SwitchClass from "@ui5/webcomponents/dist/Switch.js";
 
 const Switch = createReactComponent(SwitchClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Switch design="Graphical" />
@@ -13,5 +13,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/TabContainer/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/TabContainer/Basic/sample.tsx
@@ -14,7 +14,7 @@ const Tab = createReactComponent(TabClass);
 const TabSeparator = createReactComponent(TabSeparatorClass);
 const TabContainer = createReactComponent(TabContainerClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <TabContainer>
@@ -59,5 +59,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/TabContainer/NestedTabs/sample.tsx
+++ b/packages/website/docs/_samples/main/TabContainer/NestedTabs/sample.tsx
@@ -5,7 +5,7 @@ import TabContainerClass from "@ui5/webcomponents/dist/TabContainer.js";
 const Tab = createReactComponent(TabClass);
 const TabContainer = createReactComponent(TabContainerClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <TabContainer>
@@ -47,5 +47,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/TabContainer/OverflowMode/sample.tsx
+++ b/packages/website/docs/_samples/main/TabContainer/OverflowMode/sample.tsx
@@ -5,7 +5,7 @@ import TabContainerClass from "@ui5/webcomponents/dist/TabContainer.js";
 const Tab = createReactComponent(TabClass);
 const TabContainer = createReactComponent(TabContainerClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <TabContainer overflowMode="End" collapsed>
@@ -36,5 +36,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/TabContainer/OverflowModeStartAndEnd/sample.tsx
+++ b/packages/website/docs/_samples/main/TabContainer/OverflowModeStartAndEnd/sample.tsx
@@ -5,7 +5,7 @@ import TabContainerClass from "@ui5/webcomponents/dist/TabContainer.js";
 const Tab = createReactComponent(TabClass);
 const TabContainer = createReactComponent(TabContainerClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <TabContainer overflowMode="StartAndEnd" collapsed>
@@ -36,5 +36,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/TabContainer/ReorderTabs/sample.tsx
+++ b/packages/website/docs/_samples/main/TabContainer/ReorderTabs/sample.tsx
@@ -7,7 +7,7 @@ import TabContainerClass from "@ui5/webcomponents/dist/TabContainer.js";
 const Tab = createReactComponent(TabClass);
 const TabContainer = createReactComponent(TabContainerClass);
 
-function App() {
+export const Example = () => {
   const tabContainerRef = useRef(null);
 
   useEffect(() => {
@@ -82,5 +82,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/TabContainer/ReorderTabsFixedTabs/sample.tsx
+++ b/packages/website/docs/_samples/main/TabContainer/ReorderTabsFixedTabs/sample.tsx
@@ -9,7 +9,7 @@ const Tab = createReactComponent(TabClass);
 const TabSeparator = createReactComponent(TabSeparatorClass);
 const TabContainer = createReactComponent(TabContainerClass);
 
-function App() {
+export const Example = () => {
   const tabContainerRef = useRef(null);
 
   useEffect(() => {
@@ -85,5 +85,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/TabContainer/ReorderTabsMaxNestingLevel/sample.tsx
+++ b/packages/website/docs/_samples/main/TabContainer/ReorderTabsMaxNestingLevel/sample.tsx
@@ -12,7 +12,7 @@ const StepInput = createReactComponent(StepInputClass);
 const Tab = createReactComponent(TabClass);
 const TabContainer = createReactComponent(TabContainerClass);
 
-function App() {
+export const Example = () => {
   const tabContainerRef = useRef(null);
   const maxNestingLevelRef = useRef(1);
 
@@ -123,5 +123,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/TabContainer/TabLayout/sample.tsx
+++ b/packages/website/docs/_samples/main/TabContainer/TabLayout/sample.tsx
@@ -8,7 +8,7 @@ import TabContainerClass from "@ui5/webcomponents/dist/TabContainer.js";
 const Tab = createReactComponent(TabClass);
 const TabContainer = createReactComponent(TabContainerClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <TabContainer tabLayout="Standard" collapsed>
@@ -19,5 +19,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/TabContainer/TabLayoutInline/sample.tsx
+++ b/packages/website/docs/_samples/main/TabContainer/TabLayoutInline/sample.tsx
@@ -8,7 +8,7 @@ import TabContainerClass from "@ui5/webcomponents/dist/TabContainer.js";
 const Tab = createReactComponent(TabClass);
 const TabContainer = createReactComponent(TabContainerClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <TabContainer tabLayout="Inline" collapsed>
@@ -19,5 +19,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/TabContainer/TextOnlyTabs/sample.tsx
+++ b/packages/website/docs/_samples/main/TabContainer/TextOnlyTabs/sample.tsx
@@ -5,7 +5,7 @@ import TabContainerClass from "@ui5/webcomponents/dist/TabContainer.js";
 const Tab = createReactComponent(TabClass);
 const TabContainer = createReactComponent(TabContainerClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <TabContainer>
@@ -36,5 +36,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/TabContainer/TransparentDesign/sample.tsx
+++ b/packages/website/docs/_samples/main/TabContainer/TransparentDesign/sample.tsx
@@ -7,7 +7,7 @@ const Tab = createReactComponent(TabClass);
 const Text = createReactComponent(TextClass);
 const TabContainer = createReactComponent(TabContainerClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <TabContainer
@@ -55,5 +55,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Table/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/Table/Basic/sample.tsx
@@ -13,7 +13,7 @@ const TableHeaderCell = createReactComponent(TableHeaderCellClass);
 const TableHeaderRow = createReactComponent(TableHeaderRowClass);
 const TableRow = createReactComponent(TableRowClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Table id="table" overflowMode="Popin">
@@ -113,5 +113,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Table/ColumnWidths/sample.tsx
+++ b/packages/website/docs/_samples/main/Table/ColumnWidths/sample.tsx
@@ -17,7 +17,7 @@ const TableHeaderCell = createReactComponent(TableHeaderCellClass);
 const TableHeaderRow = createReactComponent(TableHeaderRowClass);
 const TableRow = createReactComponent(TableRowClass);
 
-function App() {
+export const Example = () => {
   const tableRef = useRef(null);
 
   const handleSliderChange = (e: UI5CustomEvent<SliderClass, "change">) => {
@@ -116,5 +116,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Table/DragAndDrop/sample.tsx
+++ b/packages/website/docs/_samples/main/Table/DragAndDrop/sample.tsx
@@ -14,7 +14,7 @@ const TableHeaderCell = createReactComponent(TableHeaderCellClass);
 const TableHeaderRow = createReactComponent(TableHeaderRowClass);
 const TableRow = createReactComponent(TableRowClass);
 
-function App() {
+export const Example = () => {
   const tableRef = useRef(null);
 
   useEffect(() => {
@@ -166,5 +166,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Table/Growing/sample.tsx
+++ b/packages/website/docs/_samples/main/Table/Growing/sample.tsx
@@ -18,7 +18,7 @@ const TableRow = createReactComponent(TableRowClass);
 
 const MAX_GROW = 3;
 
-function App() {
+export const Example = () => {
   const [extraRows, setExtraRows] = useState<
     Array<{ key: number; name: string; code: string }>
   >([]);
@@ -171,5 +171,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Table/HAlign/sample.tsx
+++ b/packages/website/docs/_samples/main/Table/HAlign/sample.tsx
@@ -13,7 +13,7 @@ const TableHeaderCell = createReactComponent(TableHeaderCellClass);
 const TableHeaderRow = createReactComponent(TableHeaderRowClass);
 const TableRow = createReactComponent(TableRowClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Table id="table" overflowMode="Popin">
@@ -121,5 +121,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Table/HeaderCellActionAI/sample.tsx
+++ b/packages/website/docs/_samples/main/Table/HeaderCellActionAI/sample.tsx
@@ -21,7 +21,7 @@ const Text = createReactComponent(TextClass);
 const TableHeaderCellActionAI = createReactComponent(TableHeaderCellActionAIClass);
 const Table = createReactComponent(TableClass);
 
-function App() {
+export const Example = () => {
   const popoverRef = useRef(null);
   const aiActionProductRef = useRef(null);
   const aiActionPriceRef = useRef(null);
@@ -182,5 +182,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Table/Interactive/sample.tsx
+++ b/packages/website/docs/_samples/main/Table/Interactive/sample.tsx
@@ -17,7 +17,7 @@ const TableHeaderRow = createReactComponent(TableHeaderRowClass);
 const TableRow = createReactComponent(TableRowClass);
 const Toast = createReactComponent(ToastClass);
 
-function App() {
+export const Example = () => {
   const toastRef = useRef(null);
 
   const handleTableRowClick = (e: UI5CustomEvent<TableClass, "row-click">) => {
@@ -129,5 +129,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Table/NoDataSlot/sample.tsx
+++ b/packages/website/docs/_samples/main/Table/NoDataSlot/sample.tsx
@@ -9,7 +9,7 @@ const Table = createReactComponent(TableClass);
 const TableHeaderCell = createReactComponent(TableHeaderCellClass);
 const TableHeaderRow = createReactComponent(TableHeaderRowClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Table id="table" overflowMode="Popin">
@@ -37,5 +37,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Table/Popin/sample.tsx
+++ b/packages/website/docs/_samples/main/Table/Popin/sample.tsx
@@ -25,7 +25,7 @@ const TableRow = createReactComponent(TableRowClass);
 
 const HIDDEN_COLUMNS = ["dimensionsCol", "weightCol"];
 
-function App() {
+export const Example = () => {
   const tableRef = useRef(null);
 
   const setPopinState = (hideDetails: boolean) => {
@@ -189,5 +189,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Table/RowAction/sample.tsx
+++ b/packages/website/docs/_samples/main/Table/RowAction/sample.tsx
@@ -46,7 +46,7 @@ const handlers: Record<string, (row: any) => void> = {
   },
 };
 
-function App() {
+export const Example = () => {
   const handleTableRowActionClick = (
     e: UI5CustomEvent<TableClass, "row-action-click">,
   ) => {
@@ -202,5 +202,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Table/RowActionNavigation/sample.tsx
+++ b/packages/website/docs/_samples/main/Table/RowActionNavigation/sample.tsx
@@ -17,7 +17,7 @@ const TableHeaderRow = createReactComponent(TableHeaderRowClass);
 const TableRow = createReactComponent(TableRowClass);
 const TableRowActionNavigation = createReactComponent(TableRowActionNavigationClass);
 
-function App() {
+export const Example = () => {
   const handleTableRowActionClick = (
     e: UI5CustomEvent<TableClass, "row-action-click">,
   ) => {
@@ -126,5 +126,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Table/ScrollMode/sample.tsx
+++ b/packages/website/docs/_samples/main/Table/ScrollMode/sample.tsx
@@ -13,7 +13,7 @@ const TableHeaderCell = createReactComponent(TableHeaderCellClass);
 const TableHeaderRow = createReactComponent(TableHeaderRowClass);
 const TableRow = createReactComponent(TableRowClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Table id="table" overflowMode="Scroll">
@@ -115,5 +115,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Table/ScrollToLoad/sample.tsx
+++ b/packages/website/docs/_samples/main/Table/ScrollToLoad/sample.tsx
@@ -18,7 +18,7 @@ const TableRow = createReactComponent(TableRowClass);
 
 const MAX_GROW = 20;
 
-function App() {
+export const Example = () => {
   const [extraRows, setExtraRows] = useState<
     Array<{ key: number; name: string; code: string }>
   >([]);
@@ -171,5 +171,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Table/Selection/sample.tsx
+++ b/packages/website/docs/_samples/main/Table/Selection/sample.tsx
@@ -20,7 +20,7 @@ const TableHeaderRow = createReactComponent(TableHeaderRowClass);
 const TableRow = createReactComponent(TableRowClass);
 const TableSelection = createReactComponent(TableSelectionClass);
 
-function App() {
+export const Example = () => {
   const selectionRef = useRef(null);
 
   const handleSelectionGroupChange = (e: React.FormEvent<HTMLDivElement>) => {
@@ -145,5 +145,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Table/SelectionMulti/sample.tsx
+++ b/packages/website/docs/_samples/main/Table/SelectionMulti/sample.tsx
@@ -18,7 +18,7 @@ const TableHeaderRow = createReactComponent(TableHeaderRowClass);
 const TableRow = createReactComponent(TableRowClass);
 const TableSelectionMulti = createReactComponent(TableSelectionMultiClass);
 
-function App() {
+export const Example = () => {
   const selectionRef = useRef(null);
   const oldSelectedSetRef = useRef(null);
 
@@ -201,5 +201,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Table/SelectionSingle/sample.tsx
+++ b/packages/website/docs/_samples/main/Table/SelectionSingle/sample.tsx
@@ -18,7 +18,7 @@ const TableHeaderRow = createReactComponent(TableHeaderRowClass);
 const TableRow = createReactComponent(TableRowClass);
 const TableSelectionSingle = createReactComponent(TableSelectionSingleClass);
 
-function App() {
+export const Example = () => {
   const selectionRef = useRef(null);
 
   const handleSelectionChange = () => {
@@ -160,5 +160,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Table/StickyHeader/sample.tsx
+++ b/packages/website/docs/_samples/main/Table/StickyHeader/sample.tsx
@@ -13,7 +13,7 @@ const TableHeaderCell = createReactComponent(TableHeaderCellClass);
 const TableHeaderRow = createReactComponent(TableHeaderRowClass);
 const TableRow = createReactComponent(TableRowClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Table style={{ height: "150px" }} id="table">
@@ -184,5 +184,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Table/StickyHeaderContainer/sample.tsx
+++ b/packages/website/docs/_samples/main/Table/StickyHeaderContainer/sample.tsx
@@ -17,7 +17,7 @@ const TableHeaderRow = createReactComponent(TableHeaderRowClass);
 const TableRow = createReactComponent(TableRowClass);
 const Title = createReactComponent(TitleClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <div style={{ height: "150px", overflow: "auto" }}>
@@ -200,5 +200,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Table/Virtualizer/sample.tsx
+++ b/packages/website/docs/_samples/main/Table/Virtualizer/sample.tsx
@@ -54,7 +54,7 @@ async function fetchProducts(first: number, last: number): Promise<Product[]> {
   return products;
 }
 
-function App() {
+export const Example = () => {
   const [rows, setRows] = useState<
     Array<{ position: number; product: Product }>
   >([]);
@@ -117,5 +117,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Tag/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/Tag/Basic/sample.tsx
@@ -3,12 +3,10 @@ import TagClass from "@ui5/webcomponents/dist/Tag.js";
 
 const Tag = createReactComponent(TagClass);
 
-function App() {
+export const Example = () => {
   return (
     <Tag design="Set1" colorScheme="6">
       Tag Text
     </Tag>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Tag/Designs/sample.tsx
+++ b/packages/website/docs/_samples/main/Tag/Designs/sample.tsx
@@ -3,7 +3,7 @@ import TagClass from "@ui5/webcomponents/dist/Tag.js";
 
 const Tag = createReactComponent(TagClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <div
@@ -39,5 +39,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Tag/Interactive/sample.tsx
+++ b/packages/website/docs/_samples/main/Tag/Interactive/sample.tsx
@@ -3,12 +3,10 @@ import TagClass from "@ui5/webcomponents/dist/Tag.js";
 
 const Tag = createReactComponent(TagClass);
 
-function App() {
+export const Example = () => {
   return (
     <Tag design="Positive" interactive={true} wrappingType="None">
       Success
     </Tag>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Tag/Set1/sample.tsx
+++ b/packages/website/docs/_samples/main/Tag/Set1/sample.tsx
@@ -3,7 +3,7 @@ import TagClass from "@ui5/webcomponents/dist/Tag.js";
 
 const Tag = createReactComponent(TagClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <div
@@ -48,5 +48,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Tag/Set2/sample.tsx
+++ b/packages/website/docs/_samples/main/Tag/Set2/sample.tsx
@@ -3,7 +3,7 @@ import TagClass from "@ui5/webcomponents/dist/Tag.js";
 
 const Tag = createReactComponent(TagClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <div
@@ -48,5 +48,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Tag/Size/sample.tsx
+++ b/packages/website/docs/_samples/main/Tag/Size/sample.tsx
@@ -3,7 +3,7 @@ import TagClass from "@ui5/webcomponents/dist/Tag.js";
 
 const Tag = createReactComponent(TagClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <div
@@ -22,5 +22,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Tag/WrappingTypes/sample.tsx
+++ b/packages/website/docs/_samples/main/Tag/WrappingTypes/sample.tsx
@@ -3,7 +3,7 @@ import TagClass from "@ui5/webcomponents/dist/Tag.js";
 
 const Tag = createReactComponent(TagClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <div
@@ -22,5 +22,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Text/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/Text/Basic/sample.tsx
@@ -3,8 +3,6 @@ import TextClass from "@ui5/webcomponents/dist/Text.js";
 
 const Text = createReactComponent(TextClass);
 
-function App() {
+export const Example = () => {
   return <Text>Simple Text</Text>;
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Text/CustomStyling/sample.tsx
+++ b/packages/website/docs/_samples/main/Text/CustomStyling/sample.tsx
@@ -3,7 +3,7 @@ import TextClass from "@ui5/webcomponents/dist/Text.js";
 
 const Text = createReactComponent(TextClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Text style={{ color: "var(--sapPositiveColor)", fontSize: "1.25rem" }}>
@@ -21,5 +21,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Text/EmptyIndicatorMode/sample.tsx
+++ b/packages/website/docs/_samples/main/Text/EmptyIndicatorMode/sample.tsx
@@ -3,8 +3,6 @@ import TextClass from "@ui5/webcomponents/dist/Text.js";
 
 const Text = createReactComponent(TextClass);
 
-function App() {
+export const Example = () => {
   return <Text emptyIndicatorMode="On" />;
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Text/Hyphenation/sample.tsx
+++ b/packages/website/docs/_samples/main/Text/Hyphenation/sample.tsx
@@ -3,7 +3,7 @@ import TextClass from "@ui5/webcomponents/dist/Text.js";
 
 const Text = createReactComponent(TextClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Text style={{ hyphens: "auto", width: "60px" }}>
@@ -16,5 +16,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Text/MaxLines/sample.tsx
+++ b/packages/website/docs/_samples/main/Text/MaxLines/sample.tsx
@@ -3,7 +3,7 @@ import TextClass from "@ui5/webcomponents/dist/Text.js";
 
 const Text = createReactComponent(TextClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Text maxLines={1}>
@@ -52,5 +52,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Text/RenderWhiteSpace/sample.tsx
+++ b/packages/website/docs/_samples/main/Text/RenderWhiteSpace/sample.tsx
@@ -3,7 +3,7 @@ import TextClass from "@ui5/webcomponents/dist/Text.js";
 
 const Text = createReactComponent(TextClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Text style={{ whiteSpace: "pre", width: "300px" }}>
@@ -14,5 +14,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/TextArea/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/TextArea/Basic/sample.tsx
@@ -3,8 +3,6 @@ import TextAreaClass from "@ui5/webcomponents/dist/TextArea.js";
 
 const TextArea = createReactComponent(TextAreaClass);
 
-function App() {
+export const Example = () => {
   return <TextArea placeholder="Type message..." />;
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/TextArea/Growing/sample.tsx
+++ b/packages/website/docs/_samples/main/TextArea/Growing/sample.tsx
@@ -3,7 +3,7 @@ import TextAreaClass from "@ui5/webcomponents/dist/TextArea.js";
 
 const TextArea = createReactComponent(TextAreaClass);
 
-function App() {
+export const Example = () => {
   return (
     <TextArea
       growing={true}
@@ -12,5 +12,3 @@ function App() {
     />
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/TextArea/MaxLength/sample.tsx
+++ b/packages/website/docs/_samples/main/TextArea/MaxLength/sample.tsx
@@ -6,7 +6,7 @@ import TextAreaClass from "@ui5/webcomponents/dist/TextArea.js";
 
 const TextArea = createReactComponent(TextAreaClass);
 
-function App() {
+export const Example = () => {
   const [valueState, setValueState] = useState<`${ValueState}`>("None");
 
   const handleTextAreaInput = (e: UI5CustomEvent<TextAreaClass, "input">) => {
@@ -25,5 +25,3 @@ function App() {
     />
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/TextArea/States/sample.tsx
+++ b/packages/website/docs/_samples/main/TextArea/States/sample.tsx
@@ -3,7 +3,7 @@ import TextAreaClass from "@ui5/webcomponents/dist/TextArea.js";
 
 const TextArea = createReactComponent(TextAreaClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <TextArea disabled={true} />
@@ -18,5 +18,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/TimePicker/Basic/main.js
+++ b/packages/website/docs/_samples/main/TimePicker/Basic/main.js
@@ -1,2 +1,1 @@
-import "@ui5/webcomponents/dist/Assets-fetch.js";
 import "@ui5/webcomponents/dist/TimePicker.js";

--- a/packages/website/docs/_samples/main/TimePicker/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/TimePicker/Basic/sample.tsx
@@ -3,8 +3,6 @@ import TimePickerClass from "@ui5/webcomponents/dist/TimePicker.js";
 
 const TimePicker = createReactComponent(TimePickerClass);
 
-function App() {
+export const Example = () => {
   return <TimePicker />;
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/TimePicker/CustomFormatting/main.js
+++ b/packages/website/docs/_samples/main/TimePicker/CustomFormatting/main.js
@@ -1,2 +1,1 @@
-import "@ui5/webcomponents/dist/Assets-fetch.js";
 import "@ui5/webcomponents/dist/TimePicker.js";

--- a/packages/website/docs/_samples/main/TimePicker/CustomFormatting/sample.tsx
+++ b/packages/website/docs/_samples/main/TimePicker/CustomFormatting/sample.tsx
@@ -3,11 +3,8 @@ import TimePickerClass from "@ui5/webcomponents/dist/TimePicker.js";
 
 const TimePicker = createReactComponent(TimePickerClass);
 
-function App() {
+export const Example = () => {
   return (
       <TimePicker valueFormat="hh:mm:ss" displayFormat="hh:mm:ss a" />
   );
 }
-
-export default App;
-

--- a/packages/website/docs/_samples/main/TimePicker/States/main.js
+++ b/packages/website/docs/_samples/main/TimePicker/States/main.js
@@ -1,2 +1,1 @@
-import "@ui5/webcomponents/dist/Assets-fetch.js";
 import "@ui5/webcomponents/dist/TimePicker.js";

--- a/packages/website/docs/_samples/main/TimePicker/States/sample.tsx
+++ b/packages/website/docs/_samples/main/TimePicker/States/sample.tsx
@@ -3,7 +3,7 @@ import TimePickerClass from "@ui5/webcomponents/dist/TimePicker.js";
 
 const TimePicker = createReactComponent(TimePickerClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <TimePicker disabled={true} />
@@ -21,5 +21,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/TimePicker/TimePickerInDifferentTimezone/main.js
+++ b/packages/website/docs/_samples/main/TimePicker/TimePickerInDifferentTimezone/main.js
@@ -1,2 +1,1 @@
-import "@ui5/webcomponents/dist/Assets-fetch.js";
 import "@ui5/webcomponents/dist/TimePicker.js";

--- a/packages/website/docs/_samples/main/TimePicker/TimePickerInDifferentTimezone/sample.tsx
+++ b/packages/website/docs/_samples/main/TimePicker/TimePickerInDifferentTimezone/sample.tsx
@@ -3,8 +3,6 @@ import TimePickerClass from "@ui5/webcomponents/dist/TimePicker.js";
 
 const TimePicker = createReactComponent(TimePickerClass);
 
-function App() {
+export const Example = () => {
   return <TimePicker value="now" />;
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Title/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/Title/Basic/sample.tsx
@@ -3,7 +3,7 @@ import TitleClass from "@ui5/webcomponents/dist/Title.js";
 
 const Title = createReactComponent(TitleClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Title level="H1" size="H1">
@@ -27,5 +27,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Title/WrappingType/sample.tsx
+++ b/packages/website/docs/_samples/main/Title/WrappingType/sample.tsx
@@ -3,7 +3,7 @@ import TitleClass from "@ui5/webcomponents/dist/Title.js";
 
 const Title = createReactComponent(TitleClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Title style={{ width: "15ch" }} level="H5" wrapping-type="None">
@@ -18,5 +18,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Toast/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/Toast/Basic/sample.tsx
@@ -6,7 +6,7 @@ import ToastClass from "@ui5/webcomponents/dist/Toast.js";
 const Button = createReactComponent(ButtonClass);
 const Toast = createReactComponent(ToastClass);
 
-function App() {
+export const Example = () => {
   const [open, setOpen] = useState(false);
 
   return (
@@ -18,5 +18,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Toast/Duration/sample.tsx
+++ b/packages/website/docs/_samples/main/Toast/Duration/sample.tsx
@@ -6,7 +6,7 @@ import ToastClass from "@ui5/webcomponents/dist/Toast.js";
 const Button = createReactComponent(ButtonClass);
 const Toast = createReactComponent(ToastClass);
 
-function App() {
+export const Example = () => {
   const [open, setOpen] = useState(false);
 
   return (
@@ -18,5 +18,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Toast/Placement/sample.tsx
+++ b/packages/website/docs/_samples/main/Toast/Placement/sample.tsx
@@ -6,7 +6,7 @@ import ToastClass from "@ui5/webcomponents/dist/Toast.js";
 const Button = createReactComponent(ButtonClass);
 const Toast = createReactComponent(ToastClass);
 
-function App() {
+export const Example = () => {
   const [open, setOpen] = useState(false);
 
   return (
@@ -22,5 +22,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/ToggleButton/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/ToggleButton/Basic/sample.tsx
@@ -4,7 +4,7 @@ import "@ui5/webcomponents-icons/dist/edit.js";
 
 const ToggleButton = createReactComponent(ToggleButtonClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <ToggleButton>Toggle</ToggleButton>
@@ -12,5 +12,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/ToggleButton/Design/sample.tsx
+++ b/packages/website/docs/_samples/main/ToggleButton/Design/sample.tsx
@@ -3,7 +3,7 @@ import ToggleButtonClass from "@ui5/webcomponents/dist/ToggleButton.js";
 
 const ToggleButton = createReactComponent(ToggleButtonClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <ToggleButton design="Emphasized">Emphasized</ToggleButton>
@@ -15,5 +15,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/ToggleButton/IconOnly/sample.tsx
+++ b/packages/website/docs/_samples/main/ToggleButton/IconOnly/sample.tsx
@@ -5,7 +5,7 @@ import "@ui5/webcomponents-icons/dist/account.js";
 
 const ToggleButton = createReactComponent(ToggleButtonClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <ToggleButton icon="edit" design="Default" tooltip="Edit Button" />
@@ -17,5 +17,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Token/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/Token/Basic/sample.tsx
@@ -3,7 +3,7 @@ import TokenClass from "@ui5/webcomponents/dist/Token.js";
 
 const Token = createReactComponent(TokenClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Token text="green" />
@@ -13,5 +13,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Token/TokenInMultiInput/sample.tsx
+++ b/packages/website/docs/_samples/main/Token/TokenInMultiInput/sample.tsx
@@ -7,7 +7,7 @@ import TokenClass from "@ui5/webcomponents/dist/Token.js";
 const MultiInput = createReactComponent(MultiInputClass);
 const Token = createReactComponent(TokenClass);
 
-function App() {
+export const Example = () => {
   const [tokens, setTokens] = useState([
     { text: "green", selected: false },
     { text: "healthy", selected: true },
@@ -52,5 +52,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Tokenizer/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/Tokenizer/Basic/sample.tsx
@@ -7,7 +7,7 @@ import TokenizerClass from "@ui5/webcomponents/dist/Tokenizer.js";
 const Token = createReactComponent(TokenClass);
 const Tokenizer = createReactComponent(TokenizerClass);
 
-function App() {
+export const Example = () => {
   const [tokens, setTokens] = useState([
     "Andora",
     "Bulgaria",
@@ -40,5 +40,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Tokenizer/MultiLine/sample.tsx
+++ b/packages/website/docs/_samples/main/Tokenizer/MultiLine/sample.tsx
@@ -7,7 +7,7 @@ import TokenizerClass from "@ui5/webcomponents/dist/Tokenizer.js";
 const Token = createReactComponent(TokenClass);
 const Tokenizer = createReactComponent(TokenizerClass);
 
-function App() {
+export const Example = () => {
   const [tokens, setTokens] = useState([
     "Andora",
     "Bulgaria",
@@ -49,5 +49,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Toolbar/AlwaysOverflowingItems/sample.tsx
+++ b/packages/website/docs/_samples/main/Toolbar/AlwaysOverflowingItems/sample.tsx
@@ -9,7 +9,7 @@ import "@ui5/webcomponents-icons/dist/decline.js";
 const Toolbar = createReactComponent(ToolbarClass);
 const ToolbarButton = createReactComponent(ToolbarButtonClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Toolbar>
@@ -29,5 +29,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Toolbar/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/Toolbar/Basic/sample.tsx
@@ -9,7 +9,7 @@ import "@ui5/webcomponents-icons/dist/decline.js";
 const Toolbar = createReactComponent(ToolbarClass);
 const ToolbarButton = createReactComponent(ToolbarButtonClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Toolbar>
@@ -28,5 +28,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Toolbar/ItemsAlignment/sample.tsx
+++ b/packages/website/docs/_samples/main/Toolbar/ItemsAlignment/sample.tsx
@@ -9,7 +9,7 @@ import "@ui5/webcomponents-icons/dist/decline.js";
 const Toolbar = createReactComponent(ToolbarClass);
 const ToolbarButton = createReactComponent(ToolbarButtonClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Toolbar align-content="Start">
@@ -28,5 +28,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Toolbar/NeverOverflowingItems/sample.tsx
+++ b/packages/website/docs/_samples/main/Toolbar/NeverOverflowingItems/sample.tsx
@@ -9,7 +9,7 @@ import "@ui5/webcomponents-icons/dist/decline.js";
 const Toolbar = createReactComponent(ToolbarClass);
 const ToolbarButton = createReactComponent(ToolbarButtonClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Toolbar>
@@ -37,5 +37,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Toolbar/SpacerAndSeparator/sample.tsx
+++ b/packages/website/docs/_samples/main/Toolbar/SpacerAndSeparator/sample.tsx
@@ -13,7 +13,7 @@ const ToolbarButton = createReactComponent(ToolbarButtonClass);
 const ToolbarSeparator = createReactComponent(ToolbarSeparatorClass);
 const ToolbarSpacer = createReactComponent(ToolbarSpacerClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Toolbar>
@@ -29,5 +29,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Toolbar/ToolbarItem/sample.tsx
+++ b/packages/website/docs/_samples/main/Toolbar/ToolbarItem/sample.tsx
@@ -23,7 +23,7 @@ const Toolbar = createReactComponent(ToolbarClass);
 const ToolbarItem = createReactComponent(ToolbarItemClass);
 const MultiComboBoxItem = createReactComponent(MultiComboBoxItemClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <style>{`
@@ -97,5 +97,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Tree/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/Tree/Basic/sample.tsx
@@ -7,7 +7,7 @@ import "@ui5/webcomponents-icons/dist/copy.js";
 const Tree = createReactComponent(TreeClass);
 const TreeItem = createReactComponent(TreeItemClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Tree>
@@ -38,5 +38,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Tree/CustomTreeItems/sample.tsx
+++ b/packages/website/docs/_samples/main/Tree/CustomTreeItems/sample.tsx
@@ -13,7 +13,7 @@ const Title = createReactComponent(TitleClass);
 const Tree = createReactComponent(TreeClass);
 const TreeItemCustom = createReactComponent(TreeItemCustomClass);
 
-function App() {
+export const Example = () => {
   return (
     <>
       <Tree>
@@ -50,5 +50,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/main/Tree/DragAndDrop/sample.tsx
+++ b/packages/website/docs/_samples/main/Tree/DragAndDrop/sample.tsx
@@ -11,7 +11,7 @@ const Title = createReactComponent(TitleClass);
 const Tree = createReactComponent(TreeClass);
 const TreeItem = createReactComponent(TreeItemClass);
 
-function App() {
+export const Example = () => {
   const treeRef = useRef(null);
 
   useEffect(() => {
@@ -144,5 +144,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/patterns/AIAcknowledgement/ScrollToAccept/sample.tsx
+++ b/packages/website/docs/_samples/patterns/AIAcknowledgement/ScrollToAccept/sample.tsx
@@ -18,7 +18,7 @@ const Panel = createReactComponent(PanelClass);
 const Text = createReactComponent(TextClass);
 const Title = createReactComponent(TitleClass);
 
-function App() {
+export const Example = () => {
   const dialogRef = useRef(null);
   const checkboxRef = useRef(null);
   const [acceptDisabled, setAcceptDisabled] = useState(true);
@@ -367,5 +367,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/patterns/AIAcknowledgement/StandardAcknowledgement/sample.tsx
+++ b/packages/website/docs/_samples/patterns/AIAcknowledgement/StandardAcknowledgement/sample.tsx
@@ -14,7 +14,7 @@ const Link = createReactComponent(LinkClass);
 const Text = createReactComponent(TextClass);
 const Title = createReactComponent(TitleClass);
 
-function App() {
+export const Example = () => {
   const [dialogOpen, setDialogOpen] = useState(true);
 
   const handleDialogClose = useCallback(() => {
@@ -65,5 +65,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/patterns/AIGuidedPrompt/Dialog/sample.tsx
+++ b/packages/website/docs/_samples/patterns/AIGuidedPrompt/Dialog/sample.tsx
@@ -37,7 +37,7 @@ const TextArea = createReactComponent(TextAreaClass);
 const Toast = createReactComponent(ToastClass);
 const Token = createReactComponent(TokenClass);
 
-function App() {
+export const Example = () => {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [aiButtonState, setAiButtonState] = useState("generate");
   const [busyActive, setBusyActive] = useState(false);
@@ -340,5 +340,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/patterns/AIQuickPrompt/sample.tsx
+++ b/packages/website/docs/_samples/patterns/AIQuickPrompt/sample.tsx
@@ -33,7 +33,7 @@ const TextArea = createReactComponent(TextAreaClass);
 const Toast = createReactComponent(ToastClass);
 const Token = createReactComponent(TokenClass);
 
-function App() {
+export const Example = () => {
   const [buttonState, setButtonState] = useState("generate");
   const [busyActive, setBusyActive] = useState(false);
   const [outputValue, setOutputValue] = useState("");
@@ -408,5 +408,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/docs/_samples/patterns/AIRegenerate/Basic/sample.tsx
+++ b/packages/website/docs/_samples/patterns/AIRegenerate/Basic/sample.tsx
@@ -35,7 +35,7 @@ const DEFAULT_OUTPUT1 =
 const DEFAULT_OUTPUT2 =
   "Experience the future of cooking with our state-of-the-art smart oven. This innovative appliance offers a range of features to enhance your culinary skills, including precise temperature control and multiple cooking modes. The smart oven connects to your smartphone, allowing you to monitor and adjust settings remotely. With its sleek design and intuitive interface, cooking has never been easier or more enjoyable. Whether you're baking, roasting, or broiling, this smart oven ensures perfect results every time. Upgrade your kitchen and transform the way you cook.";
 
-function App() {
+export const Example = () => {
   const [aiButtonState, setAiButtonState] = useState("regenerate");
   const [dialogOpen, setDialogOpen] = useState(false);
   const [skipDialog, setSkipDialog] = useState(false);
@@ -272,5 +272,3 @@ function App() {
     </>
   );
 }
-
-export default App;

--- a/packages/website/src/components/Editor/ReactPlayground.tsx
+++ b/packages/website/src/components/Editor/ReactPlayground.tsx
@@ -439,8 +439,8 @@ function executeCode(transpiledCode: string): { element: React.ReactNode | null;
       const { useState, useEffect, useCallback, useMemo, useRef, Fragment } = React;
       ${transpiledCode}
       // Return the default export or last expression
-      if (typeof App !== 'undefined') return React.createElement(App);
       if (typeof Example !== 'undefined') return React.createElement(Example);
+      if (typeof App !== 'undefined') return React.createElement(App);
       if (typeof Demo !== 'undefined') return React.createElement(Demo);
       return null;
       `
@@ -644,7 +644,7 @@ export default function ReactPlayground({ code, editorVisible = false, onCodeCha
       {editorVisible && MonacoEditor && (
         <div className={styles.editorContainer} onKeyDown={(e) => { if (e.key === "/") e.stopPropagation(); }}>
           <div className={styles.tabBar}>
-            <span className={styles.tab}>App.tsx</span>
+            <span className={styles.tab}>Example.tsx</span>
             <span className={styles.reactVersion}>React &gt;=18</span>
           </div>
           <MonacoEditor

--- a/packages/website/src/components/Editor/index.js
+++ b/packages/website/src/components/Editor/index.js
@@ -369,14 +369,14 @@ export default function Editor({ html, js, css, react, mainFile = "main.js", can
     if (!gistConfig.files["playground-support.js"]) {
       gistConfig.files["playground-support.js"] = {
         name: "playground-support.js",
-        content: playgroundSupport({ theme, textDirection, contentDensity, iframeId }),
+        content: playgroundSupport({ theme, textDirection, contentDensity, iframeId, cldrBaseUrl: calcImports()["@ui5/webcomponents-localization/"] + "dist/generated/assets/cldr/" }),
         hidden: true
       };
     } else {
       //  update existing playground support with current settings
       gistConfig.files["playground-support.js"] = {
         ...gistConfig.files["playground-support.js"],
-        content: playgroundSupport({ theme, textDirection, contentDensity, iframeId }),
+        content: playgroundSupport({ theme, textDirection, contentDensity, iframeId, cldrBaseUrl: calcImports()["@ui5/webcomponents-localization/"] + "dist/generated/assets/cldr/" }),
         hidden: true
       };
     }
@@ -422,7 +422,7 @@ export default function Editor({ html, js, css, react, mainFile = "main.js", can
           content: addHeadContent(fixAssetPaths(_html)),
         },
         "playground-support.js": {
-          content: playgroundSupport({ theme, textDirection, contentDensity, iframeId }),
+          content: playgroundSupport({ theme, textDirection, contentDensity, iframeId, cldrBaseUrl: calcImports()["@ui5/webcomponents-localization/"] + "dist/generated/assets/cldr/" }),
           hidden: true,
         },
         [mainFile]: {
@@ -539,7 +539,7 @@ ${fixAssetPaths(_js)}`,
     // setting has changed but exising project config is there
     // update the playground-support.js only with the new settings so refresh works correctly
     const newConfig = JSON.parse(JSON.stringify(projectRef.current.config));
-    newConfig.files["playground-support.js"].content = playgroundSupport({ theme, textDirection, contentDensity, iframeId });
+    newConfig.files["playground-support.js"].content = playgroundSupport({ theme, textDirection, contentDensity, iframeId, cldrBaseUrl: calcImports()["@ui5/webcomponents-localization/"] + "dist/generated/assets/cldr/" });
     projectRef.current.config = newConfig;
   }, [theme, contentDensity, textDirection]);
 

--- a/packages/website/src/components/Editor/playground-support.js
+++ b/packages/website/src/components/Editor/playground-support.js
@@ -136,6 +136,15 @@ const loadAndCheck2 = async (themeName) => {
 ["sap_fiori_3", "sap_fiori_3_dark", "sap_fiori_3_hcb", "sap_fiori_3_hcw", "sap_horizon", "sap_horizon_dark", "sap_horizon_hcb", "sap_horizon_hcw"]
     .forEach(themeName => registerThemePropertiesLoader("@ui5/webcomponents-theming", themeName, loadAndCheck2));
 
+// CLDR locale data loaders - use absolute URLs to avoid import.meta.url issues in the playground sandbox
+import { registerLocaleDataLoader } from "@ui5/webcomponents-base/dist/asset-registries/LocaleData.js";
+const cldrBaseUrl = "${settings.cldrBaseUrl}";
+const availableLocales = ["ar","ar_EG","ar_SA","bg","ca","cnr","cs","da","de","de_AT","de_CH","el","el_CY","en","en_AU","en_GB","en_HK","en_IE","en_IN","en_NZ","en_PG","en_SG","en_ZA","es","es_AR","es_BO","es_CL","es_CO","es_MX","es_PE","es_UY","es_VE","et","fa","fi","fr","fr_BE","fr_CA","fr_CH","fr_LU","he","hi","hr","hu","id","it","it_CH","ja","kk","ko","lt","lv","ms","mk","nb","nl","nl_BE","pl","pt","pt_PT","ro","ru","ru_UA","sk","sl","sr","sr_Latn","sv","th","tr","uk","vi","zh_CN","zh_HK","zh_SG","zh_TW"];
+availableLocales.forEach(localeId => registerLocaleDataLoader(localeId, async () => {
+    const response = await fetch(cldrBaseUrl + localeId + ".json");
+    return response.json();
+}));
+
 import { setTheme } from "@ui5/webcomponents-base/dist/config/Theme.js";
 import applyDirection from "@ui5/webcomponents-base/dist/locale/applyDirection.js";
 


### PR DESCRIPTION
## Summary

- **Fix CLDR crash for regional locales (en-GB, en-AU, de-AT, etc.):** Replace `Assets-fetch.js` with `Assets.js` in 34 date/calendar/time samples. The fetch-based variant uses `import.meta.url` which resolves incorrectly inside the playground-elements service worker sandbox, causing CLDR data to silently fail to load. Users with plain `en` locale were unaffected due to a hardcoded CDN fallback, but regional locales like `en-GB` crashed with `Cannot read properties of undefined (reading 'ca-gregorian')`.
- **Rename React sample exports:** Change `function App()` / `export default App` to `export const Example = () => {}` across all 379 React `sample.tsx` files for a cleaner, more concise export pattern.
- **Update ReactPlayground.tsx:** Prioritize `Example` detection, rename editor tab from `App.tsx` to `Example.tsx`.

## Test plan
- [ ] Open DatePicker sample on nightly with browser locale set to `en-GB` — verify no CLDR error
- [ ] Verify React samples render correctly (toggle to React view on any component page)
- [ ] Verify editing React code in the playground still works (live preview updates)