### PR TITLE
fix(ui5-li): remove redundant "Is Active" accessibility announcement

### DIFF
--- a/packages/main/cypress/specs/List.cy.tsx
+++ b/packages/main/cypress/specs/List.cy.tsx
@@ -360,12 +360,13 @@ describe("List - Accessibility", () => {
 			</List>
 		);
 
-		// assert
+		// assert - "Is Active" should NOT be announced for type="Active"
+		// The type property indicates behavior (clickable), not state (selected)
 		cy.get("#active").invoke("prop", "_id").then(_id => {
 			cy.get("#active")
 				.shadow()
 				.find(`#${_id}-invisibleText`)
-				.should("have.text", "Is Active");
+				.should("not.have.text", "Is Active");
 		});
 
 		cy.get("#inactive").invoke("prop", "_id").then(_id => {

--- a/packages/main/src/ListItem.ts
+++ b/packages/main/src/ListItem.ts
@@ -26,7 +26,6 @@ import {
 	DELETE,
 	ARIA_LABEL_LIST_ITEM_CHECKBOX,
 	ARIA_LABEL_LIST_ITEM_RADIO_BUTTON,
-	LIST_ITEM_ACTIVE,
 	LIST_ITEM_SELECTED,
 	LIST_ITEM_NOT_SELECTED,
 } from "./generated/i18n/i18n-defaults.js";
@@ -475,7 +474,6 @@ abstract class ListItem extends ListItemBase {
 		const texts = [
 			this._accInfo.listItemAriaLabel,
 			this.accessibleName,
-			this.typeActive ? ListItem.i18nBundle.getText(LIST_ITEM_ACTIVE) : undefined,
 		].filter(Boolean);
 
 		return texts.join(" ");

--- a/packages/main/src/i18n/messagebundle.properties
+++ b/packages/main/src/i18n/messagebundle.properties
@@ -360,9 +360,6 @@ LINK_EMPHASIZED=Emphasized
 #XACT: ARIA announcement for the interactive nature of the list
 LIST_ROLE_DESCRIPTION=List with interactive items. To move to the content press F2.
 
-#XACT: ARIA announcement for the active clickable list items
-LIST_ITEM_ACTIVE=Is Active
-
 #XACT: ARIA announcement for the position of the list items in an entire list
 LIST_ITEM_POSITION=List item {0} of {1}
 


### PR DESCRIPTION
The type="Active" property indicates the item's interactive behavior (clickable), not its state. Screen readers were repeatedly announcing "Is Active" on every list item with type="Active", which was confusing and non-specific.

Selected/not-selected state is already properly announced separately via aria-selected and ariaSelectedText in aria-describedby.

Changes:
- Remove LIST_ITEM_ACTIVE from ariaLabelledByText getter
- Remove unused LIST_ITEM_ACTIVE import from ListItem.ts
- Update accessibility test to verify "Is Active" is not announced
- Remove LIST_ITEM_ACTIVE from default messagebundle.properties

Fixes: #13265
