### PR TITLE
test(ui5-color-palette-popover): investigation of failing tests in pipeline

### DIFF
--- a/packages/main/cypress/specs/ColorPalettePopover.cy.tsx
+++ b/packages/main/cypress/specs/ColorPalettePopover.cy.tsx
@@ -543,7 +543,7 @@ describe("Color Popover Palette arrow keys navigation", () => {
 });
 
 describe("Color Popover Palette Home and End keyboard navigation", () => {
-    it.skip("should navigate with Home/End when showDefaultColor is set", () => {
+    it("should navigate with Home/End when showDefaultColor is set", () => {
         cy.mount(
             <SimplePalettePopover showDefaultColor={true} />
         );
@@ -551,67 +551,34 @@ describe("Color Popover Palette Home and End keyboard navigation", () => {
         cy.get("[ui5-color-palette-popover]")
             .ui5ColorPalettePopoverOpen({ opener: "btnPalette" });
 
-        cy.get("[ui5-color-palette-popover]")
-            .should("have.attr", "open");
+        // Default Color button should be focused initially
+        cy.focused()
+            .should("have.attr", "aria-label", "Default Color");
 
-        cy.get("[ui5-color-palette-popover]")
-            .ui5GetColorPaletteInPopover()
-            .as("colorPalette");
-
-        cy.get("@colorPalette")
-            .ui5GetColorPaletteDefaultButton()
-            .as("defaultColorButton")
-            .should("be.visible")
-            .and("have.focus");
-
-        cy.get("@defaultColorButton")
-            .should("have.focus")
-            .shadow()
-            .find("button[data-sap-focus-ref]")
-            .should("have.focus");
-
-        cy.get("@defaultColorButton")
+        // End → last color item (red)
+        cy.focused()
             .realPress("End");
 
-        cy.get("[ui5-color-palette-popover]")
-            .ui5GetColorPaletteItem(3)
-            .as("lastColorPaletteItem")
-            .should("be.visible")
-            .and("have.attr", "value", "red");
-
-        cy.get("@lastColorPaletteItem")
-            .should("have.focus")
-            .shadow()
-            .find(".ui5-cp-item")
+        cy.focused()
             .should("have.attr", "tabindex", "0")
             .and("have.attr", "aria-label")
             .and("include", "red");
 
+        // Home → first color item (cyan)
         cy.focused()
             .realPress("Home");
 
-        cy.get("[ui5-color-palette-popover]")
-            .ui5GetColorPaletteItem(0)
-            .as("firstColorPaletteItem")
-            .should("be.visible")
-            .and("have.attr", "value", "cyan");
-
-        cy.get("@firstColorPaletteItem")
-            .should("have.focus")
-            .shadow()
-            .find(".ui5-cp-item")
+        cy.focused()
             .should("have.attr", "tabindex", "0")
             .and("have.attr", "aria-label")
             .and("include", "cyan");
 
+        // Home again → Default Color button
         cy.focused()
             .realPress("Home");
 
         cy.focused()
             .should("have.attr", "aria-label", "Default Color");
-
-        cy.get("@defaultColorButton")
-            .should("have.focus");
     });
 
     it("should navigate with Home/End keys when showMoreColors is set", () => {
@@ -640,42 +607,31 @@ describe("Color Popover Palette Home and End keyboard navigation", () => {
             .should("have.attr", "aria-label", "More Colors...");
     });
 
-    it.skip("should navigate with Home/End when showDefaultColor & showMoreColors are set", () => {
+    it("should navigate with Home/End when showDefaultColor & showMoreColors are set", () => {
         cy.mount(
             <SimplePalettePopover showDefaultColor={true} showMoreColors={true} />
         );
 
-        cy.get<ColorPalettePopover>("[ui5-color-palette-popover]")
-            .as("colorPalettePopover")
+        cy.get("[ui5-color-palette-popover]")
             .ui5ColorPalettePopoverOpen({ opener: "btnPalette" });
 
-        cy.get<ColorPalette>("@colorPalettePopover")
-            .ui5GetColorPaletteInPopover()
-            .as("colorPalette");
+        // Default Color button should be focused initially
+        cy.focused()
+            .should("have.attr", "aria-label", "Default Color");
 
-        cy.get("@colorPalette")
-            .ui5GetColorPaletteDefaultButton()
-            .as("defaultColorButton");
-
-        cy.get("@defaultColorButton")
-            .should("have.focus")
+        // End → More Colors button
+        cy.focused()
             .realPress("End");
 
-        cy.get("@colorPalette")
-            .ui5GetColorPaletteMoreColorsButton()
-            .as("moreColorsButton")
-            .should("be.visible");
+        cy.focused()
+            .should("have.attr", "aria-label", "More Colors...");
 
-        cy.get("@moreColorsButton")
-            .should("exist")
-            .and("be.visible")
-            .and("have.focus");
-
-        cy.get("@moreColorsButton")
+        // Home → Default Color button
+        cy.focused()
             .realPress("Home");
 
-        cy.get("@defaultColorButton")
-            .should("have.focus");
+        cy.focused()
+            .should("have.attr", "aria-label", "Default Color");
     });
 
     it("should navigate with End key", () => {

--- a/packages/main/src/ColorPalette.ts
+++ b/packages/main/src/ColorPalette.ts
@@ -725,11 +725,8 @@ class ColorPalette extends UI5Element {
 	 */
 	_focusDefaultColor(): boolean {
 		if (this.showDefaultColor && this._defaultColorButton) {
-			const focusDomRef = this._defaultColorButton.getFocusDomRef();
-			if (focusDomRef) {
-				focusDomRef.focus();
-				return true;
-			}
+			this._defaultColorButton.focus();
+			return true;
 		}
 		return false;
 	}
@@ -740,11 +737,8 @@ class ColorPalette extends UI5Element {
 	 */
 	_focusMoreColors(): boolean {
 		if (this.showMoreColors && this._moreColorsButton) {
-			const focusDomRef = this._moreColorsButton.getFocusDomRef();
-			if (focusDomRef) {
-				focusDomRef.focus();
-				return true;
-			}
+			this._moreColorsButton.focus();
+			return true;
 		}
 		return false;
 	}

--- a/packages/main/src/ColorPalette.ts
+++ b/packages/main/src/ColorPalette.ts
@@ -725,8 +725,11 @@ class ColorPalette extends UI5Element {
 	 */
 	_focusDefaultColor(): boolean {
 		if (this.showDefaultColor && this._defaultColorButton) {
-			this._defaultColorButton.focus();
-			return true;
+			const focusDomRef = this._defaultColorButton.getFocusDomRef();
+			if (focusDomRef) {
+				focusDomRef.focus();
+				return true;
+			}
 		}
 		return false;
 	}
@@ -737,8 +740,11 @@ class ColorPalette extends UI5Element {
 	 */
 	_focusMoreColors(): boolean {
 		if (this.showMoreColors && this._moreColorsButton) {
-			this._moreColorsButton.focus();
-			return true;
+			const focusDomRef = this._moreColorsButton.getFocusDomRef();
+			if (focusDomRef) {
+				focusDomRef.focus();
+				return true;
+			}
 		}
 		return false;
 	}

--- a/packages/main/src/ColorPaletteTemplate.tsx
+++ b/packages/main/src/ColorPaletteTemplate.tsx
@@ -18,13 +18,14 @@ export default function ColorPaletteTemplate(this: ColorPalette) {
 				onMouseDown={this._onmousedown}
 			>
 				{this.showDefaultColor &&
-					<div class="ui5-cp-default-color-button-wrapper">
+					<div class="ui5-cp-default-color-button-wrapper"
+						onKeyDown={this._onDefaultColorKeyDown}
+						onKeyUp={this._onDefaultColorKeyUp}
+					>
 						<Button
 							class="ui5-cp-default-color-button"
 							design="Transparent"
 							onClick={this._onDefaultColorClick}
-							onKeyUp={this._onDefaultColorKeyUp}
-							onKeyDown={this._onDefaultColorKeyDown}
 						>
 							{this.colorPaletteDefaultColorText}
 						</Button>
@@ -42,13 +43,14 @@ export default function ColorPaletteTemplate(this: ColorPalette) {
 				</div>
 
 				{this.showMoreColors &&
-					<div class="ui5-cp-more-colors-wrapper">
+					<div class="ui5-cp-more-colors-wrapper"
+						onKeyDown={this._onMoreColorsKeyDown}
+					>
 						<div class="ui5-cp-separator"></div>
 						<Button
 							design="Transparent"
 							class="ui5-cp-more-colors"
 							onClick={this._openMoreColorsDialog}
-							onKeyDown={this._onMoreColorsKeyDown}
 						>
 							{this.colorPaletteMoreColorsText}
 						</Button>


### PR DESCRIPTION
This PR is for investigation purposes only — not for merging.

## Deep AI Analysis ( to be verified )

### What was going wrong?

Preact has an internal system for handling events that cross **shadow DOM boundaries**. It uses a counter to avoid processing the same event twice.

Here's what was happening:

1. You press a key inside a `<ui5-button>` — the event fires inside the button's **shadow root**
2. That event then bubbles up to the `<ui5-button>` host element sitting inside `ColorPalette`'s shadow DOM
3. **The problem:** Preact sometimes sees this as a duplicate event and **skips the handler** — especially if `ColorPalette` re-rendered between step 1 and step 2

**The result?** Key handlers like `_onDefaultColorKeyDown` and `_onMoreColorsKeyDown` **silently don't fire**, so focus stays stuck on the original element.

### What did we change?

We moved the `onKeyDown` and `onKeyUp` handlers **from** the `<Button>` elements **to** their parent `<div>` wrappers.

### Why does this fix it?

The issue boils down to **how many shadow DOM boundaries** the event crosses:

- **Before:** The event crossed **two boundaries** (button shadow root → button host → ColorPalette shadow DOM). Preact's deduplication system could get confused and skip the second handler.
- **After:** The handler lives on a plain `<div>` in the **same shadow DOM scope**. The event only passes through **one** Preact proxy, so there's no deduplication race and no skipped handlers.


 The deduplication logic lives in the vendored Preact source at `preact.module.js` in the event proxy.

