### PR TITLE
fix(localization): use correct language tag format

### DIFF
--- a/packages/localization/src/sap/base/i18n/Formatting.ts
+++ b/packages/localization/src/sap/base/i18n/Formatting.ts
@@ -1,6 +1,6 @@
 import { getLegacyDateCalendarCustomizing } from "@ui5/webcomponents-base/dist/config/FormatSettings.js";
-import { getLanguage } from "@ui5/webcomponents-base/dist/config/Language.js";
 import { getCalendarType } from "@ui5/webcomponents-base/dist/config/CalendarType.js";
+import getLocale from "@ui5/webcomponents-base/dist/locale/getLocale.js";
 
 const emptyFn = () => {};
 
@@ -10,7 +10,7 @@ const emptyFn = () => {};
 const Formatting = {
 	getABAPDateFormat: emptyFn,
 	getCustomIslamicCalendarData: getLegacyDateCalendarCustomizing,
-	getLanguageTag: () => getLanguage() || "en",
+	getLanguageTag: () => getLocale().toString(),
 	getCalendarType,
 	getTrailingCurrencyCode: () => true,
 	getCustomLocaleData: () => ({}),

--- a/packages/localization/src/sap/base/i18n/Localization.ts
+++ b/packages/localization/src/sap/base/i18n/Localization.ts
@@ -1,5 +1,5 @@
-import { getLanguage } from "@ui5/webcomponents-base/dist/config/Language.js";
 import { getTimezone as getConfigTimezone } from "@ui5/webcomponents-base/dist/config/Timezone.js";
+import getLocale from "@ui5/webcomponents-base/dist/locale/getLocale.js";
 
 const M_ISO639_OLD_TO_NEW = {
 	"iw": "he",
@@ -12,9 +12,9 @@ const getModernLanguage = (sLanguage: string) => {
 
 const Localization = {
 	getModernLanguage,
-	getLanguageTag: () => getLanguage() || "en",
+	getLanguageTag: () => getLocale().toString(),
 	getTimezone: () => getConfigTimezone() || Intl.DateTimeFormat().resolvedOptions().timeZone,
-	setTimezone: () => {},
+	setTimezone: () => { },
 };
 
 export default Localization;

--- a/packages/main/cypress/specs/base/LocalizationShim.cy.tsx
+++ b/packages/main/cypress/specs/base/LocalizationShim.cy.tsx
@@ -1,0 +1,138 @@
+import { setLanguage } from "@ui5/webcomponents-base/dist/config/Language.js";
+import { resetConfiguration } from "@ui5/webcomponents-base/dist/InitialConfiguration.js";
+import Formatting from "@ui5/webcomponents-localization/dist/sap/base/i18n/Formatting.js";
+import Localization from "@ui5/webcomponents-localization/dist/sap/base/i18n/Localization.js";
+
+const setLang = async (lang: string) => {
+	await setLanguage(lang);
+};
+
+const reset = () => {
+	resetConfiguration(true);
+};
+
+describe("Localization shim - getLanguageTag", () => {
+	afterEach(() => {
+		reset();
+	});
+
+	it("returns the configured language as a full BCP47 tag", () => {
+		cy.wrap(null).then(async () => {
+			await setLang("de-DE");
+		});
+
+		cy.wrap(Localization)
+			.invoke("getLanguageTag")
+			.should("equal", "de-DE");
+	});
+
+	it("preserves region subtag (en-US)", () => {
+		cy.wrap(null).then(async () => {
+			await setLang("en-US");
+		});
+
+		cy.wrap(Localization)
+			.invoke("getLanguageTag")
+			.should("equal", "en-US");
+	});
+
+	it("preserves region subtag (en-GB)", () => {
+		cy.wrap(null).then(async () => {
+			await setLang("en-GB");
+		});
+
+		cy.wrap(Localization)
+			.invoke("getLanguageTag")
+			.should("equal", "en-GB");
+	});
+
+	it("lowercases the language part", () => {
+		cy.wrap(null).then(async () => {
+			await setLang("DE");
+		});
+
+		cy.wrap(Localization)
+			.invoke("getLanguageTag")
+			.should("satisfy", (tag: string) => tag.startsWith("de"));
+	});
+
+	it("handles language with script subtag (zh-Hans)", () => {
+		cy.wrap(null).then(async () => {
+			await setLang("zh-Hans");
+		});
+
+		cy.wrap(Localization)
+			.invoke("getLanguageTag")
+			.should("equal", "zh-Hans");
+	});
+
+	it("handles language with script and region (zh-Hans-CN)", () => {
+		cy.wrap(null).then(async () => {
+			await setLang("zh-Hans-CN");
+		});
+
+		cy.wrap(Localization)
+			.invoke("getLanguageTag")
+			.should("equal", "zh-Hans-CN");
+	});
+
+	it("returns a string, not an object", () => {
+		cy.wrap(null).then(async () => {
+			await setLang("fr-FR");
+		});
+
+		cy.wrap(Localization)
+			.invoke("getLanguageTag")
+			.should("be.a", "string");
+	});
+});
+
+describe("Formatting shim - getLanguageTag", () => {
+	afterEach(() => {
+		reset();
+	});
+
+	it("returns the configured language as a full BCP47 tag", () => {
+		cy.wrap(null).then(async () => {
+			await setLang("de-DE");
+		});
+
+		cy.wrap(Formatting)
+			.invoke("getLanguageTag")
+			.should("equal", "de-DE");
+	});
+
+	it("returns the same value as Localization.getLanguageTag", () => {
+		cy.wrap(null).then(async () => {
+			await setLang("ja-JP");
+		});
+
+		cy.wrap(Formatting)
+			.invoke("getLanguageTag")
+			.then(formattingTag => {
+				cy.wrap(Localization)
+					.invoke("getLanguageTag")
+					.should("equal", formattingTag);
+			});
+	});
+
+	it("preserves region subtag (en-US)", () => {
+		cy.wrap(null).then(async () => {
+			await setLang("en-US");
+		});
+
+		cy.wrap(Formatting)
+			.invoke("getLanguageTag")
+			.should("equal", "en-US");
+	});
+
+	it("returns a string, not an object", () => {
+		cy.wrap(null).then(async () => {
+			await setLang("fr-FR");
+		});
+
+		cy.wrap(Formatting)
+			.invoke("getLanguageTag")
+			.should("be.a", "string");
+	});
+});


### PR DESCRIPTION
Replaced `getLanguage() || "en"` with `getLocale().toString()` in both `Formatting.getLanguageTag()` and `Localization.getLanguageTag()`.

`getLanguage()` returns only a bare language code (e.g. "en", "de"), losing region and script subtags. `getLocale()` returns a parsed Locale object whose `toString()` reconstructs the full BCP47 tag (e.g. "en-US", "zh-Hans-CN"), matching the value OpenUI5's `LanguageTag.toString()` would produce. This ensures CLDR-based formatting uses the correct locale-specific rules (date order, number separators, week start day).

Also adds Cypress tests for both shims covering region subtags, script subtags, and return type.

Related to: https://github.com/UI5/webcomponents/pull/13312
Fixes: https://github.com/UI5/webcomponents/issues/13382