### PR TITLE
fix(ui5-card): remove max-height constraint from subtitle to prevent text clipping for tall-character languages

### DIFF
--- a/packages/main/cypress/specs/Card.cy.tsx
+++ b/packages/main/cypress/specs/Card.cy.tsx
@@ -335,4 +335,34 @@ describe("Card Accessibility", () => {
 				.should("have.attr", "aria-labelledby", `${headerId2}-title ${headerId2}-subtitle`);
 		});
 	});
+
+	it("Tests that subtitle text is not cut off for languages requiring more vertical space", () => {
+		cy.mount(
+			<Card>
+				<CardHeader
+					slot="header"
+					id="headerHindi"
+					titleText="Title"
+					subtitleText="आपके डिवाइस या फ़ाइल सर्वर से फ़ाइल">
+				</CardHeader>
+			</Card>
+		);
+
+		// Verify the subtitle element's scrollHeight equals its offsetHeight (no clipping)
+		cy.get("#headerHindi")
+			.shadow()
+			.find(".ui5-card-header-subtitle")
+			.then($subtitle => {
+				expect($subtitle[0].scrollHeight).to.be.lte($subtitle[0].offsetHeight + 1);
+			});
+
+		// Verify no max-height is set on the subtitle
+		cy.get("#headerHindi")
+			.shadow()
+			.find(".ui5-card-header-subtitle")
+			.should($el => {
+				const maxHeight = getComputedStyle($el[0]).maxHeight;
+				expect(maxHeight).to.equal("none");
+			});
+	});
 });

--- a/packages/main/src/themes/CardHeader.css
+++ b/packages/main/src/themes/CardHeader.css
@@ -136,7 +136,6 @@
 	font-weight: normal;
 	color: var(--sapTile_TextColor);
 	margin-top: var(--_ui5_card_header_subtitle_margin_top);
-	max-height: 2.1rem;
 }
 
 .ui5-card-header .ui5-card-header-text .ui5-card-header-title,


### PR DESCRIPTION
## Description

The `ui5-card-header` subtitle text was being visually cut off for languages
that require more vertical space per line, such as Hindi. This was caused by
a hardcoded `max-height: 2.1rem` on the subtitle element, which is calculated
based on Latin character height and does not accommodate the taller glyphs and
diacritics found in other scripts.

The `-webkit-line-clamp: 2` rule already enforces the two-line limit correctly
for all languages, making the `max-height` constraint redundant and harmful.

## Changes

- Removed `max-height: 2.1rem` from `.ui5-card-header-subtitle` in `CardHeader.css`
- Added a Cypress test to verify no `max-height` is applied to the subtitle

## How to Test

1. Open a `ui5-card-header` with a `subtitleText` containing Hindi text, e.g.:
   `आपके डिवाइस या फ़ाइल सर्वर से फ़ाइल (xlsx, csv, txt, आदि)`
2. Verify the subtitle text is fully visible and not clipped at the bottom.

Before:
<img width="305" height="278" alt="Screenshot 2026-04-20 at 10 14 36" src="https://github.com/user-attachments/assets/bf0f2062-5669-45c5-b7af-b834d8e8fba8" />

After:
<img width="308" height="288" alt="Screenshot 2026-04-20 at 10 14 24" src="https://github.com/user-attachments/assets/f222d8d9-642a-4bbc-859a-ff61e8238938" />


Fixes #13379