### PR TITLE
WIP(ui5-view-settings-dialog): add announcements on OK/Cancel press

### DIFF
--- a/packages/fiori/src/ViewSettingsDialog.ts
+++ b/packages/fiori/src/ViewSettingsDialog.ts
@@ -42,6 +42,8 @@ import {
 	VSD_FILTER_TOOLTIP,
 	VSD_GROUP_TOOLTIP,
 	VSD_RESET_BUTTON_ACTION,
+	VSD_CONFIRM_BUTTON_ACTION,
+	VSD_CANCEL_BUTTON_ACTION,
 	VSD_FILTER_ITEM_LABEL_TEXT,
 } from "./generated/i18n/i18n-defaults.js";
 
@@ -556,6 +558,14 @@ class ViewSettingsDialog extends UI5Element {
 		return ViewSettingsDialog.i18nBundle.getText(VSD_RESET_BUTTON_ACTION);
 	}
 
+	get _confirmButtonAction() {
+		return ViewSettingsDialog.i18nBundle.getText(VSD_CONFIRM_BUTTON_ACTION);
+	}
+
+	get _cancelButtonAction() {
+		return ViewSettingsDialog.i18nBundle.getText(VSD_CANCEL_BUTTON_ACTION);
+	}
+
 	get _isPhone() {
 		return isPhone();
 	}
@@ -819,6 +829,7 @@ class ViewSettingsDialog extends UI5Element {
 		this.open = false;
 		this._confirmedSettings = this._currentSettings;
 
+		announce(this._confirmButtonAction, InvisibleMessageMode.Assertive);
 		this.fireDecoratorEvent("confirm", this.eventsParams);
 	}
 
@@ -828,6 +839,7 @@ class ViewSettingsDialog extends UI5Element {
 	_cancelSettings() {
 		this._restoreSettings(this._confirmedSettings);
 
+		announce(this._cancelButtonAction, InvisibleMessageMode.Assertive);
 		this.fireDecoratorEvent("cancel", this.eventsParams);
 		this.open = false;
 	}

--- a/packages/fiori/src/i18n/messagebundle.properties
+++ b/packages/fiori/src/i18n/messagebundle.properties
@@ -290,6 +290,12 @@ VSD_RESET_BUTTON=Reset
 #XMSG: View Settings Dialog Reset button invisible message text
 VSD_RESET_BUTTON_ACTION=Reset has reverted all settings to initial state
 
+#XMSG: View Settings Dialog Confirm button invisible message text
+VSD_CONFIRM_BUTTON_ACTION=Settings have been confirmed
+
+#XMSG: View Settings Dialog Cancel button invisible message text
+VSD_CANCEL_BUTTON_ACTION=Settings changes have been cancelled
+
 #XTOL View Settings Dialog Sort button tooltop text
 VSD_SORT_TOOLTIP=Sort
 


### PR DESCRIPTION
In `ui5-view-settings-dialog` there is already announcement for resetting the state (pressing **Reset** button)to the initial one, but for closing with **OK** or **Cancel** buttons there is nothing announced. There should be announcement in both cases, because visual impaired user might not understand what happens on closing of the **ViewSettingsDialog** - when the **OK** button is pressed, there are changes in the settings that VSD contains, and this should be clear to the user; when the **Cancel** button is pressed, all changes made since the last VSD opening are abandoned, and this also should be announced clearly, so the user to be aware of what is happening.