### PR TITLE
feat(ui5-timeline-header-bar): introduce filterInfoBar slot for active filter display

### DIFF
--- a/packages/fiori/cypress/specs/Timeline.cy.tsx
+++ b/packages/fiori/cypress/specs/Timeline.cy.tsx
@@ -813,4 +813,90 @@ describe("Timeline Header Bar", () => {
 			cy.get("[ui5-timeline-item]").eq(0).should("have.attr", "title-text", "Meeting with John");
 		});
 	});
+
+	describe("Filter Info Bar slot", () => {
+		it("should render filter info bar when slot content is provided", () => {
+			cy.mount(
+				<Timeline>
+					<TimelineHeaderBar slot="headerBar" showFilter filterBy="Status">
+						<div slot="filterInfoBar" id="my-filter-bar">Filtered by: Open</div>
+					</TimelineHeaderBar>
+					<TimelineItem titleText="Meeting" />
+				</Timeline>
+			);
+
+			cy.get("[ui5-timeline-header-bar]")
+				.shadow()
+				.find(".ui5-timeline-filter-info-bar")
+				.should("exist");
+
+			cy.get("[ui5-timeline-header-bar]")
+				.find("#my-filter-bar")
+				.should("exist");
+		});
+
+		it("should not render filter info bar wrapper when slot is empty", () => {
+			cy.mount(
+				<Timeline>
+					<TimelineHeaderBar slot="headerBar" showFilter filterBy="Status">
+						<TimelineFilterOption text="Open" />
+					</TimelineHeaderBar>
+					<TimelineItem titleText="Meeting" />
+				</Timeline>
+			);
+
+			cy.get("[ui5-timeline-header-bar]")
+				.shadow()
+				.find(".ui5-timeline-filter-info-bar")
+				.should("not.exist");
+		});
+
+		it("should show filter info bar when content is dynamically added", () => {
+			cy.mount(
+				<Timeline>
+					<TimelineHeaderBar slot="headerBar" showFilter filterBy="Status">
+						<TimelineFilterOption text="Open" />
+					</TimelineHeaderBar>
+					<TimelineItem titleText="Meeting" />
+				</Timeline>
+			);
+
+			cy.get("[ui5-timeline-header-bar]")
+				.shadow()
+				.find(".ui5-timeline-filter-info-bar")
+				.should("not.exist");
+
+			cy.get("[ui5-timeline-header-bar]").then($headerBar => {
+				const infoDiv = document.createElement("div");
+				infoDiv.slot = "filterInfoBar";
+				infoDiv.id = "dynamic-filter-bar";
+				infoDiv.textContent = "Filtered by: Open";
+				$headerBar[0].appendChild(infoDiv);
+			});
+
+			cy.get("[ui5-timeline-header-bar]")
+				.shadow()
+				.find(".ui5-timeline-filter-info-bar")
+				.should("exist");
+		});
+
+		it("should render filter info bar between toolbar and dialog", () => {
+			cy.mount(
+				<Timeline>
+					<TimelineHeaderBar slot="headerBar" showFilter filterBy="Status">
+						<TimelineFilterOption text="Open" />
+						<div slot="filterInfoBar">Filtered by: Open</div>
+					</TimelineHeaderBar>
+					<TimelineItem titleText="Meeting" />
+				</Timeline>
+			);
+
+			cy.get("[ui5-timeline-header-bar]")
+				.shadow()
+				.find(".ui5-timeline-filter-info-bar")
+				.should("exist")
+				.prev("[ui5-toolbar]")
+				.should("exist");
+		});
+	});
 });

--- a/packages/fiori/src/TimelineHeaderBar.ts
+++ b/packages/fiori/src/TimelineHeaderBar.ts
@@ -205,6 +205,18 @@ class TimelineHeaderBar extends UI5Element {
 	@slot({ type: HTMLElement, "default": true, invalidateOnChildChange: true })
 	filterOptions!: Slot<TimelineFilterOption>;
 
+	/**
+	 * Defines the content displayed below the toolbar as a filter info bar.
+	 *
+	 * Use this slot to show active filter summary information
+	 * along with a clear action. The application controls the content entirely.
+	 *
+	 * @public
+	 * @since 2.23.0
+	 */
+	@slot({ type: HTMLElement })
+	filterInfoBar!: Slot<HTMLElement>;
+
 	@i18n("@ui5/webcomponents-fiori")
 	static i18nBundle: I18nBundle;
 
@@ -253,6 +265,10 @@ class TimelineHeaderBar extends UI5Element {
 
 	get _filterDialogCancelText() {
 		return TimelineHeaderBar.i18nBundle.getText(TIMELINE_FILTER_DIALOG_CANCEL);
+	}
+
+	get _hasFilterInfoBar(): boolean {
+		return !!this.filterInfoBar.length;
 	}
 
 	_onSearchInput(e: CustomEvent) {

--- a/packages/fiori/src/TimelineHeaderBarTemplate.tsx
+++ b/packages/fiori/src/TimelineHeaderBarTemplate.tsx
@@ -59,6 +59,12 @@ export default function TimelineHeaderBarTemplate(this: TimelineHeaderBar) {
 			)}
 		</Toolbar>
 
+		{this._hasFilterInfoBar && (
+			<div class="ui5-timeline-filter-info-bar">
+				<slot name="filterInfoBar"></slot>
+			</div>
+		)}
+
 		{/* Filter Dialog */}
 		{this.showFilter && (
 			<Dialog

--- a/packages/fiori/src/themes/TimelineHeaderBar.css
+++ b/packages/fiori/src/themes/TimelineHeaderBar.css
@@ -15,3 +15,9 @@
 .ui5-timeline-filter-list {
 	width: 100%;
 }
+
+.ui5-timeline-filter-info-bar {
+	border-block-start: 0.0625rem solid var(--sapToolbar_SeparatorColor);
+	padding-block: 0.5rem;
+	padding-inline: 0.5rem;
+}

--- a/packages/fiori/test/pages/TimelineFilterInfoBar.html
+++ b/packages/fiori/test/pages/TimelineFilterInfoBar.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<meta charset="utf-8">
+	<title>Timeline — filterInfoBar Slot</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+
+	<script src="%VITE_BUNDLE_PATH%" type="module"></script>
+	<style>
+		body {
+			background-color: var(--sapBackgroundColor, #f5f6f7);
+			font-family: "72", "72full", Arial, Helvetica, sans-serif;
+			padding: 2rem;
+		}
+
+		.filter-info-content {
+			display: flex;
+			align-items: center;
+			gap: 0.5rem;
+			font-size: 0.875rem;
+			font-family: "72", "72full", Arial, Helvetica, sans-serif;
+		}
+
+		.filter-info-content .filter-info-text {
+			flex: 1;
+		}
+	</style>
+</head>
+
+<body>
+
+	<ui5-timeline id="timeline" accessible-name="Project Activity Feed">
+		<ui5-timeline-header-bar slot="headerBar" show-search show-filter show-sort filter-by="Category">
+			<ui5-timeline-filter-option text="Meetings"></ui5-timeline-filter-option>
+			<ui5-timeline-filter-option text="Development"></ui5-timeline-filter-option>
+			<ui5-timeline-filter-option text="Releases"></ui5-timeline-filter-option>
+		</ui5-timeline-header-bar>
+
+		<ui5-timeline-item data-category="Meetings" data-date="2024-03-10T09:00"
+			title-text="Sprint Planning" subtitle-text="10.03.2024 09:00"
+			icon="calendar" name="Sarah Chen">
+			Kick-off for Sprint 24. Estimated velocity: 42 story points.
+		</ui5-timeline-item>
+
+		<ui5-timeline-item data-category="Development" data-date="2024-03-10T11:30"
+			title-text="PR #487 — Auth Module Refactor" subtitle-text="10.03.2024 11:30"
+			icon="developer-settings" name="James Rivera">
+			Replaced legacy session handling with JWT tokens.
+		</ui5-timeline-item>
+
+		<ui5-timeline-item data-category="Meetings" data-date="2024-03-10T14:00"
+			title-text="Client Requirements Call" subtitle-text="10.03.2024 14:00"
+			icon="phone" name="Emily Watson">
+			Discussed Q2 roadmap priorities.
+		</ui5-timeline-item>
+
+		<ui5-timeline-item data-category="Development" data-date="2024-03-10T16:00"
+			title-text="API Documentation Update" subtitle-text="10.03.2024 16:00"
+			icon="document" name="Arun Patel">
+			Added OpenAPI specs for new endpoints.
+		</ui5-timeline-item>
+
+		<ui5-timeline-item data-category="Releases" data-date="2024-03-11T06:00"
+			title-text="Deploy v2.5.1 to Staging" subtitle-text="11.03.2024 06:00"
+			icon="upload" name="DevOps Pipeline" state="Positive">
+			Staging deployment successful.
+		</ui5-timeline-item>
+
+		<ui5-timeline-item data-category="Meetings" data-date="2024-03-12T09:00"
+			title-text="Post-Release Retrospective" subtitle-text="12.03.2024 09:00"
+			icon="group" name="Full Team">
+			Key takeaway: improve staging parity with prod.
+		</ui5-timeline-item>
+	</ui5-timeline>
+
+<script>
+	const timeline = document.getElementById("timeline");
+	let headerBar;
+	let allItems;
+	let infoBarElement;
+	const state = { searchQuery: "", selectedCategories: [], sortOrder: "Ascending" };
+
+	function getHeaderBar() {
+		if (!headerBar) {
+			headerBar = timeline.querySelector("ui5-timeline-header-bar");
+		}
+		return headerBar;
+	}
+
+	function applyFilters() {
+		if (!allItems) {
+			allItems = [...timeline.querySelectorAll("[ui5-timeline-item]")];
+		}
+
+		allItems.forEach(item => item.remove());
+
+		let visibleItems = allItems.filter(item => {
+			const text = [item.titleText, item.name, item.subtitleText, item.textContent]
+				.join(" ").toLowerCase();
+			const matchesSearch = !state.searchQuery || text.includes(state.searchQuery);
+			const matchesCategory = state.selectedCategories.length === 0
+				|| state.selectedCategories.includes(item.dataset.category);
+			return matchesSearch && matchesCategory;
+		});
+
+		visibleItems.sort((itemA, itemB) => {
+			const dateA = new Date(itemA.dataset.date || 0);
+			const dateB = new Date(itemB.dataset.date || 0);
+			return state.sortOrder === "Ascending" ? dateA - dateB : dateB - dateA;
+		});
+
+		visibleItems.forEach(item => timeline.appendChild(item));
+	}
+
+	function updateFilterInfoBar() {
+		if (state.selectedCategories.length > 0) {
+			if (!infoBarElement) {
+				infoBarElement = document.createElement("div");
+				infoBarElement.slot = "filterInfoBar";
+				infoBarElement.classList.add("filter-info-content");
+
+				const textElement = document.createElement("ui5-text");
+				textElement.classList.add("filter-info-text");
+
+				const clearButton = document.createElement("ui5-button");
+				clearButton.icon = "decline";
+				clearButton.design = "Transparent";
+				clearButton.tooltip = "Clear filters";
+				clearButton.addEventListener("click", clearFilters);
+
+				infoBarElement.appendChild(textElement);
+				infoBarElement.appendChild(clearButton);
+				getHeaderBar().appendChild(infoBarElement);
+			}
+
+			infoBarElement.querySelector(".filter-info-text").textContent =
+				"Filtered By: " + state.selectedCategories.join(", ");
+		} else if (infoBarElement) {
+			infoBarElement.remove();
+			infoBarElement = null;
+		}
+	}
+
+	function clearFilters() {
+		getHeaderBar().querySelectorAll("ui5-timeline-filter-option")
+			.forEach(option => { option.selected = false; });
+
+		state.selectedCategories = [];
+		updateFilterInfoBar();
+		applyFilters();
+	}
+
+	timeline.addEventListener("search", event => {
+		state.searchQuery = event.detail.value.toLowerCase();
+		applyFilters();
+	});
+
+	timeline.addEventListener("filter", event => {
+		state.selectedCategories = event.detail.selectedOptions;
+		updateFilterInfoBar();
+		applyFilters();
+	});
+
+	timeline.addEventListener("sort", event => {
+		state.sortOrder = event.detail.sortOrder;
+		applyFilters();
+	});
+</script>
+
+</body>
+</html>

--- a/packages/website/docs/_components_pages/fiori/Timeline/Timeline.mdx
+++ b/packages/website/docs/_components_pages/fiori/Timeline/Timeline.mdx
@@ -4,9 +4,6 @@ import InCard from "../../../_samples/fiori/Timeline/InCard/InCard.md";
 import WithGroups from "../../../_samples/fiori/Timeline/WithGroups/WithGroups.md";
 import WithState from "../../../_samples/fiori/Timeline/WithState/WithState.md";
 import WithGrowing from "../../../_samples/fiori/Timeline/WithGrowing/WithGrowing.md";
-import WithSearch from "../../../_samples/fiori/Timeline/WithSearch/WithSearch.md";
-import WithFilter from "../../../_samples/fiori/Timeline/WithFilter/WithFilter.md";
-import WithHeaderBar from "../../../_samples/fiori/Timeline/WithHeaderBar/WithHeaderBar.md";
 
 <%COMPONENT_OVERVIEW%>
 
@@ -35,15 +32,3 @@ import WithHeaderBar from "../../../_samples/fiori/Timeline/WithHeaderBar/WithHe
 ### Timeline with Growing
 
 <WithGrowing/>
-
-### Timeline with Search
-
-<WithSearch />
-
-### Timeline with Filter and Sort
-
-<WithFilter />
-
-### Timeline with Header Bar (Combined)
-
-<WithHeaderBar />

--- a/packages/website/docs/_components_pages/fiori/Timeline/TimelineHeaderBar.mdx
+++ b/packages/website/docs/_components_pages/fiori/Timeline/TimelineHeaderBar.mdx
@@ -1,0 +1,25 @@
+---
+slug: ../TimelineHeaderBar
+---
+
+import WithSearch from "../../../_samples/fiori/Timeline/WithSearch/WithSearch.md";
+import WithFilter from "../../../_samples/fiori/Timeline/WithFilter/WithFilter.md";
+import WithHeaderBar from "../../../_samples/fiori/Timeline/WithHeaderBar/WithHeaderBar.md";
+
+<%COMPONENT_OVERVIEW%>
+
+## Search
+
+<WithSearch />
+
+## Filter and Sort
+
+<WithFilter />
+
+## Combined (Search + Filter + Sort + Filter Info Bar)
+
+The `ui5-timeline-header-bar` exposes a `filterInfoBar` slot where the application can show active filter information with a clear action. The component provides the styled container; the application controls the content entirely.
+
+<WithHeaderBar />
+
+<%COMPONENT_METADATA%>

--- a/packages/website/docs/_samples/fiori/Timeline/WithHeaderBar/main.js
+++ b/packages/website/docs/_samples/fiori/Timeline/WithHeaderBar/main.js
@@ -2,6 +2,8 @@ import "@ui5/webcomponents-fiori/dist/Timeline.js";
 import "@ui5/webcomponents-fiori/dist/TimelineItem.js";
 import "@ui5/webcomponents-fiori/dist/TimelineHeaderBar.js";
 import "@ui5/webcomponents-fiori/dist/TimelineFilterOption.js";
+import "@ui5/webcomponents/dist/Button.js";
+import "@ui5/webcomponents/dist/Text.js";
 
 import "@ui5/webcomponents-icons/dist/calendar.js";
 import "@ui5/webcomponents-icons/dist/developer-settings.js";
@@ -9,8 +11,12 @@ import "@ui5/webcomponents-icons/dist/phone.js";
 import "@ui5/webcomponents-icons/dist/document.js";
 import "@ui5/webcomponents-icons/dist/upload.js";
 import "@ui5/webcomponents-icons/dist/group.js";
+import "@ui5/webcomponents-icons/dist/decline.js";
 
 const timeline = document.getElementById("timeline");
+const filterInfoBar = document.getElementById("filter-info-bar");
+const filterInfoText = document.getElementById("filter-info-text");
+const clearFiltersButton = document.getElementById("clear-filters");
 const state = { searchQuery: "", selectedCategories: [], sortOrder: "Ascending" };
 let allItems;
 
@@ -19,10 +25,8 @@ function applyFilters() {
         allItems = [...timeline.querySelectorAll("[ui5-timeline-item]")];
     }
 
-    // Remove all items from DOM
     allItems.forEach((item) => item.remove());
 
-    // Filter items matching both search and category criteria
     let visibleItems = allItems.filter((item) => {
         const text = [item.titleText, item.name, item.subtitleText, item.textContent]
             .join(" ").toLowerCase();
@@ -32,15 +36,22 @@ function applyFilters() {
         return matchesSearch && matchesCategory;
     });
 
-    // Sort by date
     visibleItems.sort((itemA, itemB) => {
         const dateA = new Date(itemA.dataset.date || 0);
         const dateB = new Date(itemB.dataset.date || 0);
         return state.sortOrder === "Ascending" ? dateA - dateB : dateB - dateA;
     });
 
-    // Re-add matching items to the DOM
     visibleItems.forEach((item) => timeline.appendChild(item));
+}
+
+function updateFilterInfoBar() {
+    if (state.selectedCategories.length > 0) {
+        filterInfoText.textContent = "Filtered By: " + state.selectedCategories.join(", ");
+        filterInfoBar.style.display = "flex";
+    } else {
+        filterInfoBar.style.display = "none";
+    }
 }
 
 timeline.addEventListener("search", (event) => {
@@ -50,10 +61,21 @@ timeline.addEventListener("search", (event) => {
 
 timeline.addEventListener("filter", (event) => {
     state.selectedCategories = event.detail.selectedOptions;
+    updateFilterInfoBar();
     applyFilters();
 });
 
 timeline.addEventListener("sort", (event) => {
     state.sortOrder = event.detail.sortOrder;
+    applyFilters();
+});
+
+clearFiltersButton.addEventListener("click", () => {
+    const headerBar = timeline.querySelector("ui5-timeline-header-bar");
+    headerBar.querySelectorAll("ui5-timeline-filter-option")
+        .forEach((option) => { option.selected = false; });
+
+    state.selectedCategories = [];
+    updateFilterInfoBar();
     applyFilters();
 });

--- a/packages/website/docs/_samples/fiori/Timeline/WithHeaderBar/sample.html
+++ b/packages/website/docs/_samples/fiori/Timeline/WithHeaderBar/sample.html
@@ -16,6 +16,11 @@
             <ui5-timeline-filter-option text="Meetings"></ui5-timeline-filter-option>
             <ui5-timeline-filter-option text="Development"></ui5-timeline-filter-option>
             <ui5-timeline-filter-option text="Releases"></ui5-timeline-filter-option>
+
+            <div slot="filterInfoBar" id="filter-info-bar" style="display: none; align-items: center; gap: 0.5rem;">
+                <ui5-text id="filter-info-text" style="flex: 1;"></ui5-text>
+                <ui5-button id="clear-filters" icon="decline" design="Transparent" tooltip="Clear filters"></ui5-button>
+            </div>
         </ui5-timeline-header-bar>
 
         <ui5-timeline-item data-category="Meetings" data-date="2024-03-10T09:00" title-text="Sprint Planning" subtitle-text="10.03.2024 09:00" icon="calendar" name="Sarah Chen">

--- a/packages/website/docs/_samples/fiori/Timeline/WithHeaderBar/sample.tsx
+++ b/packages/website/docs/_samples/fiori/Timeline/WithHeaderBar/sample.tsx
@@ -5,17 +5,22 @@ import TimelineClass from "@ui5/webcomponents-fiori/dist/Timeline.js";
 import TimelineItemClass from "@ui5/webcomponents-fiori/dist/TimelineItem.js";
 import TimelineHeaderBarClass from "@ui5/webcomponents-fiori/dist/TimelineHeaderBar.js";
 import TimelineFilterOptionClass from "@ui5/webcomponents-fiori/dist/TimelineFilterOption.js";
+import ButtonClass from "@ui5/webcomponents/dist/Button.js";
+import TextClass from "@ui5/webcomponents/dist/Text.js";
 import "@ui5/webcomponents-icons/dist/calendar.js";
 import "@ui5/webcomponents-icons/dist/developer-settings.js";
 import "@ui5/webcomponents-icons/dist/phone.js";
 import "@ui5/webcomponents-icons/dist/document.js";
 import "@ui5/webcomponents-icons/dist/upload.js";
 import "@ui5/webcomponents-icons/dist/group.js";
+import "@ui5/webcomponents-icons/dist/decline.js";
 
 const Timeline = createReactComponent(TimelineClass);
 const TimelineItem = createReactComponent(TimelineItemClass);
 const TimelineHeaderBar = createReactComponent(TimelineHeaderBarClass);
 const TimelineFilterOption = createReactComponent(TimelineFilterOptionClass);
+const Button = createReactComponent(ButtonClass);
+const Text = createReactComponent(TextClass);
 
 const allItems = [
 	{ titleText: "Sprint Planning", subtitleText: "10.03.2024 09:00", icon: "calendar", name: "Sarah Chen", category: "Meetings", date: "2024-03-10T09:00", content: "Kick-off for Sprint 24. Estimated velocity: 42 story points." },
@@ -58,13 +63,24 @@ function App() {
 		setSortOrder(event.detail.sortOrder);
 	};
 
+	const handleClearFilters = () => {
+		setSelectedCategories([]);
+	};
+
 	return (
 		<>
 			<Timeline onSearch={handleSearch} onFilter={handleFilter} onSort={handleSort}>
 				<TimelineHeaderBar slot="headerBar" showSearch={true} showFilter={true} showSort={true} filterBy="Category">
-					<TimelineFilterOption text="Meetings" />
-					<TimelineFilterOption text="Development" />
-					<TimelineFilterOption text="Releases" />
+					<TimelineFilterOption text="Meetings" selected={selectedCategories.includes("Meetings")} />
+					<TimelineFilterOption text="Development" selected={selectedCategories.includes("Development")} />
+					<TimelineFilterOption text="Releases" selected={selectedCategories.includes("Releases")} />
+
+					{selectedCategories.length > 0 && (
+						<div slot="filterInfoBar" style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+							<Text style={{ flex: 1 }}>Filtered By: {selectedCategories.join(", ")}</Text>
+							<Button icon="decline" design="Transparent" tooltip="Clear filters" onClick={handleClearFilters} />
+						</div>
+					)}
 				</TimelineHeaderBar>
 
 				{visibleItems.map((item, index) => (


### PR DESCRIPTION
## Overview

When filters are applied via `ui5-timeline-header-bar`, there is no visual indication of what is currently filtered. App developers need a way to show "Filtered By: X, Y" information below the toolbar with a clear action.

## What We Did

- Added `filterInfoBar` named slot to `ui5-timeline-header-bar` for app-controlled filter summary content
- Added RTL-safe CSS using logical properties (`border-block-start`, `padding-block`, `padding-inline`)
- Updated the `WithHeaderBar` playground sample (HTML, JS, React) to demonstrate the slot with `ui5-text` + clear button
- Created `TimelineHeaderBar.mdx` sub-component page in the playground (Search, Filter+Sort, Combined samples)
- Moved header-bar-related samples from `Timeline.mdx` to the new `TimelineHeaderBar.mdx` page
- Created isolated test page `TimelineFilterInfoBar.html` for manual testing

## What This Adds

- **filterInfoBar slot** — app provides arbitrary content (text, tokens, buttons) below the toolbar; component provides the container
- **Playground documentation** — `TimelineHeaderBar` now has its own sub-component page under Timeline, making the slot discoverable for app developers
- **Sample code** — demonstrates the full flow: filter → show info bar → clear filters, using `ui5-text` and `ui5-button` for Fiori UX consistency

## Short Demo

<img width="1170" height="834" alt="2026-04-21_10-56-05 (1)" src="https://github.com/user-attachments/assets/78cacf30-6df9-40d1-8c96-f01751d07a5a" />
