### PR TITLE
feat(ui5-toolbar): align theming tokens with Horizon spec

### DIFF
--- a/packages/main/src/themes/Toolbar.css
+++ b/packages/main/src/themes/Toolbar.css
@@ -5,9 +5,9 @@
 	align-items: center;
 	justify-content: flex-end;
 	box-sizing: border-box;
-	border-bottom: 0.0625rem solid var(--sapGroup_ContentBorderColor);
+	border-bottom: var(--sapGroup_TitleBorderWidth) solid var(--sapGroup_TitleBorderColor);
 	padding: 0 var(--_ui5-toolbar-padding-left) 0 var(--_ui5-toolbar-padding-right);
-	background-color: var(--sapList_HeaderBackground);
+	background-color: var(--sapToolbar_Background);
 }
 
 :host([align-content="Start"]) {

--- a/packages/main/src/themes/base/sizes-parameters.css
+++ b/packages/main/src/themes/base/sizes-parameters.css
@@ -149,7 +149,7 @@
 
 	/* Toolbar */
 	--_ui5-toolbar-separator-height: 2rem;
-	--_ui5-toolbar-height: 2.75rem;
+	--_ui5-toolbar-height: var(--sapElement_LineHeight);
 	--_ui5_toolbar_overflow_padding: 0.25rem 0.5rem;
 
 	/* DynamicPageTitle */
@@ -370,7 +370,7 @@
 
 		/* Toolbar */
 		--_ui5-toolbar-separator-height: 1.5rem;
-		--_ui5-toolbar-height: 2rem;
+		--_ui5-toolbar-height: var(--sapElement_Compact_LineHeight);
 		--_ui5_toolbar_overflow_padding: 0.1875rem 0.375rem;
 
 		/* DynamicPageTitle */


### PR DESCRIPTION
Update theming tokens to align with the latest Horizon design specification:                                                       
  - border-bottom: updated to use --sapGroup_TitleBorderWidth and --sapGroup_TitleBorderColor                                                  
  - background-color: updated to use --sapToolbar_Background
  - height: updated to use --sapElement_LineHeight (cozy) and --sapElement_Compact_LineHeight (compact)
  
  JIRA: BGSOFUIPIRIN-7040