### PR TITLE
fix(ui5-date-range-picker): stabilize tests

### DIFF
--- a/packages/main/cypress/specs/DateRangePicker.cy.tsx
+++ b/packages/main/cypress/specs/DateRangePicker.cy.tsx
@@ -1398,6 +1398,7 @@ describe("DateRangePicker - Two Calendars Feature", () => {
 				.ui5DateRangePickerGetCalendar()
 				.shadow()
 				.find(".ui5-cal-overlay-container")
+				.should("exist")
 				.should("not.have.class", "ui5-cal-overlay-hidden");
 		});
 	});

--- a/packages/main/cypress/specs/DateRangePicker.cy.tsx
+++ b/packages/main/cypress/specs/DateRangePicker.cy.tsx
@@ -1397,6 +1397,13 @@ describe("DateRangePicker - Two Calendars Feature", () => {
 			cy.get<DateRangePicker>("@dateRangePicker")
 				.ui5DateRangePickerGetCalendar()
 				.shadow()
+				.find("[ui5-monthpicker]")
+				.should("exist")
+				.should("not.have.attr", "hidden");
+
+			cy.get<DateRangePicker>("@dateRangePicker")
+				.ui5DateRangePickerGetCalendar()
+				.shadow()
 				.find(".ui5-cal-overlay-container")
 				.should("exist")
 				.should("not.have.class", "ui5-cal-overlay-hidden");

--- a/packages/main/cypress/support/commands/DateRangePicker.commands.ts
+++ b/packages/main/cypress/support/commands/DateRangePicker.commands.ts
@@ -88,12 +88,12 @@ Cypress.Commands.add("ui5DateRangePickerClickDateInCalendar", { prevSubject: tru
 });
 
 Cypress.Commands.add("ui5DateRangePickerVerifySelectedDatesInCalendar", { prevSubject: true }, (subject: JQuery<DateRangePicker>, calendarIndex: number) => {
-       cy.wrap(subject)
-	       .ui5DateRangePickerGetDayPicker(calendarIndex)
-	       .should("exist")
-	       .shadow()
-	       .find(".ui5-dp-item--selected")
-	       .should("exist");
+	cy.wrap(subject)
+		.ui5DateRangePickerGetDayPicker(calendarIndex)
+		.should("exist")
+		.shadow()
+		.find(".ui5-dp-item--selected")
+		.should("exist");
 });
 
 Cypress.Commands.add("ui5DateRangePickerClickNavigationButton", { prevSubject: true }, (subject: JQuery<DateRangePicker>, button: "next" | "prev") => {

--- a/packages/main/cypress/support/commands/DateRangePicker.commands.ts
+++ b/packages/main/cypress/support/commands/DateRangePicker.commands.ts
@@ -88,11 +88,12 @@ Cypress.Commands.add("ui5DateRangePickerClickDateInCalendar", { prevSubject: tru
 });
 
 Cypress.Commands.add("ui5DateRangePickerVerifySelectedDatesInCalendar", { prevSubject: true }, (subject: JQuery<DateRangePicker>, calendarIndex: number) => {
-	cy.wrap(subject)
-		.ui5DateRangePickerGetDayPicker(calendarIndex)
-		.shadow()
-		.find(".ui5-dp-item--selected")
-		.should("exist");
+       cy.wrap(subject)
+	       .ui5DateRangePickerGetDayPicker(calendarIndex)
+	       .should("exist")
+	       .shadow()
+	       .find(".ui5-dp-item--selected")
+	       .should("exist");
 });
 
 Cypress.Commands.add("ui5DateRangePickerClickNavigationButton", { prevSubject: true }, (subject: JQuery<DateRangePicker>, button: "next" | "prev") => {


### PR DESCRIPTION
This PR stabilizes the ui5-date-range-picker Cypress tests by adding proper assertions to ensure elements exist before interacting with them.