### PR TITLE
fix(ui5-dialog): clamp min-width and min-height to viewport at high zoom levels

### DIFF
--- a/packages/main/src/themes/Dialog.css
+++ b/packages/main/src/themes/Dialog.css
@@ -1,8 +1,8 @@
 @import "./InvisibleTextStyles.css";
 
 :host {
-	min-width: 20rem;
-	min-height: 6rem;
+	min-width: min(20rem, 90vw);
+	min-height: min(6rem, 90vh);
 	max-height: 94%;
 	max-width: 90%;
 	flex-direction: column;


### PR DESCRIPTION
At 200% browser zoom, rem-based min-width (20rem) can exceed the 90% max-width constraint, causing the dialog to overflow the viewport and become unusable on small or zoomed screens.

Use CSS min() to cap min-width and min-height against 90vw/90vh so the dialog always fits within the visible area regardless of zoom level.

Fixes #11715
