### PR TITLE
fix(ui5-multi-combobox): open overflow popover on Enter in readonly mode

### DIFF
--- a/packages/main/cypress/specs/MultiComboBox.cy.tsx
+++ b/packages/main/cypress/specs/MultiComboBox.cy.tsx
@@ -4371,6 +4371,29 @@ describe("Keyboard Handling", () => {
 			.should("have.length", 3);
 	});
 
+	it("Should open overflow popover on Enter when MCB is readonly", () => {
+		cy.mount(
+			<MultiComboBox noValidation={true} readonly={true}>
+				<MultiComboBoxItem selected={true} text="Item 1"></MultiComboBoxItem>
+				<MultiComboBoxItem selected={true} text="Item 2"></MultiComboBoxItem>
+			</MultiComboBox>
+		);
+
+		cy.get("[ui5-multi-combobox]")
+			.shadow()
+			.find("input")
+			.realClick();
+
+		cy.realPress("Enter");
+
+		cy.get("[ui5-multi-combobox]")
+			.shadow()
+			.find("[ui5-tokenizer]")
+			.shadow()
+			.find<ResponsivePopover>("[ui5-responsive-popover]")
+			.ui5ResponsivePopoverOpened();
+	});
+
 	it("Should open/close popover on keyboard combination ctrl + i", () => {
 		cy.mount(
 			<MultiComboBox noValidation={true}>

--- a/packages/main/src/MultiComboBox.ts
+++ b/packages/main/src/MultiComboBox.ts
@@ -1435,6 +1435,11 @@ class MultiComboBox extends UI5Element implements IFormInputElement {
 	}
 
 	_handleEnter() {
+		if (this.readonly) {
+			this._tokenizer.open = true;
+			return;
+		}
+
 		const lowerCaseValue = this.value.toLowerCase();
 		const matchingItem = this._getItems().find(item => (!item.isGroupItem && item.text!.toLowerCase() === lowerCaseValue));
 		const oldValueState = this.valueState;


### PR DESCRIPTION
When the focus is on the input of a readonly MultiComboBox, pressing Enter now opens the tokenizer overflow popover to show all tokens.

Fixes: #13445
