### PR TITLE
fix(ui5-timeline-header-bar): remove unused property

### DIFF
--- a/packages/fiori/src/TimelineHeaderBar.ts
+++ b/packages/fiori/src/TimelineHeaderBar.ts
@@ -160,14 +160,6 @@ class TimelineHeaderBar extends UI5Element {
 	showSort = false;
 
 	/**
-	 * Shows the filter by date option.
-	 * @default false
-	 * @public
-	 */
-	@property({ type: Boolean })
-	showFilterByDate = false;
-
-	/**
 	 * The current filter category label.
 	 * @default ""
 	 * @public

--- a/packages/website/src/components/Editor/monaco-ui5-types.d.ts
+++ b/packages/website/src/components/Editor/monaco-ui5-types.d.ts
@@ -2281,7 +2281,6 @@ interface TimelineHeaderBarProps extends UI5BaseProps {
   showSearch?: boolean;
   showFilter?: boolean;
   showSort?: boolean;
-  showFilterByDate?: boolean;
   filterBy?: string;
   searchValue?: string;
   sortOrder?: "Ascending" | "Descending";


### PR DESCRIPTION
Remove unused prop missed from the PoC stage.