### PR TITLE
make @types/openui5 a dev dependency

### DIFF
--- a/packages/localization/package.json
+++ b/packages/localization/package.json
@@ -33,13 +33,13 @@
     "@babel/generator": "^7.24.6",
     "@babel/parser": "^7.24.6",
     "@openui5/sap.ui.core": "1.146.0",
+    "@types/openui5": "^1.146.0",
     "@ui5/webcomponents-tools": "2.22.0-rc.3",
     "babel-plugin-amd-to-esm": "^2.0.3",
     "estree-walk": "^2.2.0",
     "resolve": "^1.20.0"
   },
   "dependencies": {
-    "@types/openui5": "^1.146.0",
     "@ui5/webcomponents-base": "2.22.0-rc.3"
   }
 }


### PR DESCRIPTION
when installing the webcomponents, they pull in @types/openui5 as a dependency, although it should be a dev dependency.
This leads to conflicts in our repository, since we use patch-package to patch incorrect types in that package, but additional copy added by webcomponents is overwriting them again...

fix #13459


