### PR TITLE
refactor(ui5-table): implement empty area rendering with custom focus outline

### DIFF
--- a/packages/main/cypress/specs/Table.cy.tsx
+++ b/packages/main/cypress/specs/Table.cy.tsx
@@ -8,6 +8,7 @@ import TableHeaderCell from "../../src/TableHeaderCell.js";
 import TableHeaderCellActionAI from "../../src/TableHeaderCellActionAI.js";
 import Label from "../../src/Label.js";
 import Input from "../../src/Input.js";
+import TableRowAction from "../../src/TableRowAction.js";
 import Bar from "../../src/Bar.js";
 import Title from "../../src/Title.js";
 import Slider from "../../src/Slider.js";
@@ -443,7 +444,7 @@ describe("Table - Popin Mode", () => {
 				for (const cell of row.cells) {
 					if (cell._popin) {
 						popinCellCount++;
-						const popinText = cell._headerCell.popinText || cell._headerCell.textContent;
+						const popinText = cell._headerCell!.popinText || cell._headerCell!.textContent;
 						if (cell.shadowRoot!.textContent === `${popinText}:`) {
 							validPopinTextCount++;
 						}
@@ -883,26 +884,24 @@ describe("Table - Navigated Rows", () => {
 			</Table>
 		);
 
-		cy.get("#row1")
-			.shadow()
-			.find("#navigated-cell")
+		// Navigated cell rendered on all rows and header row
+		cy.get("[ui5-table-header-row]").shadow().find("#navigated-cell")
+			.should("exist")
+			.should("have.attr", "aria-hidden", "true");
+		cy.get("[ui5-table-header-row]").shadow().find("#navigated-cell")
+			.should("have.attr", "data-excluded-from-navigation");
+
+		cy.get("#row1").shadow().find("#navigated-cell")
 			.should("exist")
 			.should("have.attr", "data-excluded-from-navigation");
 
-		cy.get("#row2")
-			.shadow()
-			.find("#navigated-cell")
+		cy.get("#row2").shadow().find("#navigated-cell")
 			.should("exist")
 			.should("have.attr", "data-excluded-from-navigation");
 
-		cy.get("#row1")
-			.shadow()
-			.find("#navigated")
-			.as("navigated1");
-
-		cy.get("#row2")
-			.shadow()
-			.find("#navigated")
+		// Navigated indicator differs between navigated and non-navigated rows
+		cy.get("#row1").shadow().find("#navigated").as("navigated1");
+		cy.get("#row2").shadow().find("#navigated")
 			.then($navigated2 => {
 				cy.get("@navigated1")
 					.should($navigated1 => {
@@ -1191,5 +1190,177 @@ describe("Table - Cell Merging", () => {
 		cy.get("#r2cA").find("ui5-label").should("not.have.css", "opacity", "0");
 		cy.get("#r2cA").should("have.css", "border-top-color", TRANSPARENT);
 		cy.get("#row2").shadow().find("#selection-cell").should("have.css", "border-top-color", TRANSPARENT);
+	});
+});
+
+describe("Table - Dummy Cell", () => {
+	it("should render dummy cell with border and nofocus when all columns have fixed widths", () => {
+		cy.mount(
+			<Table id="table">
+				<TableHeaderRow slot="headerRow">
+					<TableHeaderCell width="200px">Product</TableHeaderCell>
+					<TableHeaderCell width="40%">Supplier</TableHeaderCell>
+				</TableHeaderRow>
+				<TableRow id="row1">
+					<TableCell><Label>Product 1</Label></TableCell>
+					<TableCell><Label>Supplier 1</Label></TableCell>
+				</TableRow>
+				<TableRow id="row2" interactive>
+					<TableCell><Label>Product 2</Label></TableCell>
+					<TableCell><Label>Supplier 2</Label></TableCell>
+				</TableRow>
+			</Table>
+		);
+
+		cy.get("[ui5-table-header-row]").shadow().find("#dummy-cell").should("exist");
+		cy.get("#row1").shadow().find("#dummy-cell").should("exist");
+
+		// Should have left border
+		cy.get("[ui5-table-header-row]").shadow().find("#dummy-cell")
+			.should("not.have.css", "border-inline-start-width", "0px");
+		cy.get("#row1").shadow().find("#dummy-cell")
+			.should("not.have.css", "border-inline-start-width", "0px");
+
+		// Should have data-excluded-from-navigation="nofocus" and data-border-merged when no popin
+		cy.get("#row1").shadow().find("#dummy-cell")
+			.should("have.attr", "data-excluded-from-navigation", "nofocus")
+			.should("have.attr", "data-border-merged");
+
+		// Should not focus row or fire row-click when clicking dummy cell
+		cy.get("#table").invoke("on", "row-click", cy.stub().as("rowClickHandler"));
+		cy.get("#row2").shadow().find("#dummy-cell").realClick();
+		cy.get("#row2").should("not.be.focused");
+		cy.get("#row2").should("not.have.attr", "_active");
+		cy.get("@rowClickHandler").should("not.have.been.called");
+	});
+
+	it("should not render dummy cell when columns are flexible", () => {
+		const cases = [
+			{ widths: ["200px", "auto"] },
+			{ widths: ["Auto"] },
+			{ widths: ["200px", undefined] },
+		];
+
+		cases.forEach(({ widths }) => {
+			cy.mount(
+				<Table id="table">
+					<TableHeaderRow slot="headerRow">
+						{widths.map((w, i) => (
+							<TableHeaderCell width={w}>{`Col ${i}`}</TableHeaderCell>
+						))}
+					</TableHeaderRow>
+					<TableRow id="row1">
+						{widths.map((_, i) => (
+							<TableCell><Label>{`Cell ${i}`}</Label></TableCell>
+						))}
+					</TableRow>
+				</Table>
+			);
+
+			cy.get("[ui5-table-header-row]").shadow().find("#dummy-cell").should("not.exist");
+			cy.get("#row1").shadow().find("#dummy-cell").should("not.exist");
+		});
+	});
+
+	it("should render dummy cell after actions when no popin and before actions when popin", () => {
+		cy.mount(
+			<Table id="table" rowActionCount={2} overflowMode="Popin">
+				<TableHeaderRow slot="headerRow">
+					<TableHeaderCell width="200px" minWidth="200px">Product</TableHeaderCell>
+					<TableHeaderCell width="200px" minWidth="200px">Supplier</TableHeaderCell>
+				</TableHeaderRow>
+				<TableRow id="row1">
+					<TableCell><Label>Product 1</Label></TableCell>
+					<TableCell><Label>Supplier 1</Label></TableCell>
+					<TableRowAction slot="actions" icon="edit" text="Edit"></TableRowAction>
+					<TableRowAction slot="actions" icon="delete" text="Delete"></TableRowAction>
+				</TableRow>
+			</Table>
+		);
+
+		// No popin: dummy cell is after actions cell (rightmost) in both row and header row
+		cy.get("#row1").shadow().then($shadow => {
+			const dummyCell = $shadow.find("#dummy-cell")[0];
+			const actionsCell = $shadow.find("#actions-cell")[0];
+			const position = dummyCell.compareDocumentPosition(actionsCell);
+			// eslint-disable-next-line no-bitwise
+			expect(position & Node.DOCUMENT_POSITION_PRECEDING).to.be.greaterThan(0);
+		});
+		cy.get("[ui5-table-header-row]").shadow().then($shadow => {
+			const dummyCell = $shadow.find("#dummy-cell")[0];
+			const actionsCell = $shadow.find("#actions-cell")[0];
+			const position = dummyCell.compareDocumentPosition(actionsCell);
+			// eslint-disable-next-line no-bitwise
+			expect(position & Node.DOCUMENT_POSITION_PRECEDING).to.be.greaterThan(0);
+		});
+
+		// Shrink to trigger popin: dummy cell moves before actions cell
+		cy.get("ui5-table").invoke("css", "width", "250px");
+		// eslint-disable-next-line cypress/no-unnecessary-waiting
+		cy.wait(50);
+
+		cy.get("#row1").should("have.attr", "_haspopin");
+		cy.get("#row1").shadow().then($shadow => {
+			const dummyCell = $shadow.find("#dummy-cell")[0];
+			const actionsCell = $shadow.find("#actions-cell")[0];
+			const position = dummyCell.compareDocumentPosition(actionsCell);
+			// eslint-disable-next-line no-bitwise
+			expect(position & Node.DOCUMENT_POSITION_FOLLOWING).to.be.greaterThan(0);
+		});
+		cy.get("[ui5-table-header-row]").shadow().then($shadow => {
+			const dummyCell = $shadow.find("#dummy-cell")[0];
+			const actionsCell = $shadow.find("#actions-cell")[0];
+			const position = dummyCell.compareDocumentPosition(actionsCell);
+			// eslint-disable-next-line no-bitwise
+			expect(position & Node.DOCUMENT_POSITION_FOLLOWING).to.be.greaterThan(0);
+		});
+	});
+
+	it("should adapt dummy cell border and navigation attribute when row has popin", () => {
+		cy.mount(
+			<Table id="table" overflowMode="Popin">
+				<TableHeaderRow slot="headerRow">
+					<TableHeaderCell width="200px" minWidth="200px">Product</TableHeaderCell>
+					<TableHeaderCell width="200px" minWidth="200px">Supplier</TableHeaderCell>
+				</TableHeaderRow>
+				<TableRow id="row1">
+					<TableCell><Label>Product 1</Label></TableCell>
+					<TableCell><Label>Supplier 1</Label></TableCell>
+				</TableRow>
+			</Table>
+		);
+
+		// At full width: left border visible, nofocus attribute on both row and header row
+		cy.get("#row1").shadow().find("#dummy-cell")
+			.should("not.have.css", "border-inline-start-width", "0px")
+			.should("have.attr", "data-excluded-from-navigation", "nofocus");
+		cy.get("[ui5-table-header-row]").shadow().find("#dummy-cell")
+			.should("have.attr", "data-excluded-from-navigation", "nofocus");
+
+		// Shrink to trigger popin
+		cy.get("ui5-table").invoke("css", "width", "250px");
+		// eslint-disable-next-line cypress/no-unnecessary-waiting
+		cy.wait(50);
+
+		cy.get("#row1").should("have.attr", "_haspopin");
+
+		// Left border removed, data-excluded-from-navigation without nofocus
+		cy.get("#row1").shadow().find("#dummy-cell")
+			.should("have.css", "border-inline-start-width", "0px")
+			.should("have.attr", "data-excluded-from-navigation", "");
+		cy.get("[ui5-table-header-row]").shadow().find("#dummy-cell")
+			.should("have.attr", "data-excluded-from-navigation", "");
+
+		// Expand again, border and nofocus should return
+		cy.get("ui5-table").invoke("css", "width", "800px");
+		// eslint-disable-next-line cypress/no-unnecessary-waiting
+		cy.wait(50);
+
+		cy.get("#row1").should("not.have.attr", "_haspopin");
+		cy.get("#row1").shadow().find("#dummy-cell")
+			.should("not.have.css", "border-inline-start-width", "0px")
+			.should("have.attr", "data-excluded-from-navigation", "nofocus");
+		cy.get("[ui5-table-header-row]").shadow().find("#dummy-cell")
+			.should("have.attr", "data-excluded-from-navigation", "nofocus");
 	});
 });

--- a/packages/main/cypress/specs/Table.cy.tsx
+++ b/packages/main/cypress/specs/Table.cy.tsx
@@ -430,8 +430,6 @@ describe("Table - Popin Mode", () => {
 		cy.get("ui5-table").then($table => {
 			$table.css("width", "150px");
 		});
-
-		// eslint-disable-next-line cypress/no-unnecessary-waiting
 		cy.wait(50);
 
 		cy.get("ui5-table").then($table => {
@@ -1145,7 +1143,7 @@ describe("Table - Cell Merging", () => {
 		cy.wait(50);
 
 		// Merged cell border should fall back to normal border color (not transparent)
-		cy.get("#row2").should("have.attr", "_haspopin");
+		cy.get("#row2").should("have.attr", "_has-popin");
 		cy.get("#r2cA").should("not.have.css", "border-top-color", TRANSPARENT);
 		cy.get("#row2").shadow().find("#selection-cell").should("not.have.css", "border-top-color", TRANSPARENT);
 
@@ -1283,42 +1281,38 @@ describe("Table - Dummy Cell", () => {
 			const dummyCell = $shadow.find("#dummy-cell")[0];
 			const actionsCell = $shadow.find("#actions-cell")[0];
 			const position = dummyCell.compareDocumentPosition(actionsCell);
-			// eslint-disable-next-line no-bitwise
 			expect(position & Node.DOCUMENT_POSITION_PRECEDING).to.be.greaterThan(0);
 		});
 		cy.get("[ui5-table-header-row]").shadow().then($shadow => {
 			const dummyCell = $shadow.find("#dummy-cell")[0];
 			const actionsCell = $shadow.find("#actions-cell")[0];
 			const position = dummyCell.compareDocumentPosition(actionsCell);
-			// eslint-disable-next-line no-bitwise
 			expect(position & Node.DOCUMENT_POSITION_PRECEDING).to.be.greaterThan(0);
 		});
 
 		// Shrink to trigger popin: dummy cell moves before actions cell
 		cy.get("ui5-table").invoke("css", "width", "250px");
-		// eslint-disable-next-line cypress/no-unnecessary-waiting
 		cy.wait(50);
 
-		cy.get("#row1").should("have.attr", "_haspopin");
+		cy.get("#row1").should("have.attr", "_has-popin");
 		cy.get("#row1").shadow().then($shadow => {
 			const dummyCell = $shadow.find("#dummy-cell")[0];
 			const actionsCell = $shadow.find("#actions-cell")[0];
 			const position = dummyCell.compareDocumentPosition(actionsCell);
-			// eslint-disable-next-line no-bitwise
 			expect(position & Node.DOCUMENT_POSITION_FOLLOWING).to.be.greaterThan(0);
 		});
 		cy.get("[ui5-table-header-row]").shadow().then($shadow => {
 			const dummyCell = $shadow.find("#dummy-cell")[0];
 			const actionsCell = $shadow.find("#actions-cell")[0];
 			const position = dummyCell.compareDocumentPosition(actionsCell);
-			// eslint-disable-next-line no-bitwise
 			expect(position & Node.DOCUMENT_POSITION_FOLLOWING).to.be.greaterThan(0);
 		});
 	});
 
-	it("should adapt dummy cell border and navigation attribute when row has popin", () => {
+	it("should adapt dummy cell border, navigation attribute, and custom focus outline with popin", () => {
 		cy.mount(
 			<Table id="table" overflowMode="Popin">
+				<TableSelectionMulti slot="features" />
 				<TableHeaderRow slot="headerRow">
 					<TableHeaderCell width="200px" minWidth="200px">Product</TableHeaderCell>
 					<TableHeaderCell width="200px" minWidth="200px">Supplier</TableHeaderCell>
@@ -1337,12 +1331,20 @@ describe("Table - Dummy Cell", () => {
 		cy.get("[ui5-table-header-row]").shadow().find("#dummy-cell")
 			.should("have.attr", "data-excluded-from-navigation", "nofocus");
 
-		// Shrink to trigger popin
+		// Focus row - custom outline should be applied
+		cy.get("#row1").should("have.attr", "_render-dummy-cell");
+		cy.get("#row1").should("not.have.attr", "_has-popin");
+		cy.realPress("Tab");
+		cy.get("#row1").shadow().find("[data-ui5-custom-outline='start']").should("exist");
+		cy.get("#row1").find("[data-ui5-custom-outline='end']").should("exist");
+		cy.get("#row1").shadow().find("#dummy-cell")
+			.should("not.have.attr", "data-ui5-custom-outline");
+
+		// Shrink to trigger popin to test custom outline is removed
 		cy.get("ui5-table").invoke("css", "width", "250px");
-		// eslint-disable-next-line cypress/no-unnecessary-waiting
 		cy.wait(50);
 
-		cy.get("#row1").should("have.attr", "_haspopin");
+		cy.get("#row1").should("have.attr", "_has-popin");
 
 		// Left border removed, data-excluded-from-navigation without nofocus
 		cy.get("#row1").shadow().find("#dummy-cell")
@@ -1351,16 +1353,17 @@ describe("Table - Dummy Cell", () => {
 		cy.get("[ui5-table-header-row]").shadow().find("#dummy-cell")
 			.should("have.attr", "data-excluded-from-navigation", "");
 
-		// Expand again, border and nofocus should return
+		// Expand back - border and nofocus should return, custom outline reapplied via onAfterRendering
 		cy.get("ui5-table").invoke("css", "width", "800px");
-		// eslint-disable-next-line cypress/no-unnecessary-waiting
 		cy.wait(50);
 
-		cy.get("#row1").should("not.have.attr", "_haspopin");
+		cy.get("#row1").should("not.have.attr", "_has-popin");
 		cy.get("#row1").shadow().find("#dummy-cell")
 			.should("not.have.css", "border-inline-start-width", "0px")
 			.should("have.attr", "data-excluded-from-navigation", "nofocus");
 		cy.get("[ui5-table-header-row]").shadow().find("#dummy-cell")
 			.should("have.attr", "data-excluded-from-navigation", "nofocus");
+		cy.get("#row1").shadow().find("[data-ui5-custom-outline='start']").should("exist");
+		cy.get("#row1").find("[data-ui5-custom-outline='end']").should("exist");
 	});
 });

--- a/packages/main/src/Table.ts
+++ b/packages/main/src/Table.ts
@@ -457,7 +457,7 @@ class Table extends UI5Element {
 	onBeforeRendering(): void {
 		this._renderNavigated = this.rows.some(row => row.navigated);
 		[...this.headerRow, ...this.rows].forEach((row, index) => {
-			row._rowActionCount = this.rowActionCount;
+			row._rowActionCount = this.rows.length > 0 ? this.rowActionCount : 0;
 			row._renderNavigated = this._renderNavigated;
 			row._renderDummyCell = !this._hasFlexibleColumns;
 			row._alternate = this.alternateRowColors && index % 2 === 0;
@@ -659,7 +659,7 @@ class Table extends UI5Element {
 		}
 
 		// Row Action Cell Width
-		if (this.rowActionCount > 0) {
+		if (this.rowActionCount > 0 && this.rows.length > 0) {
 			widths.push(`calc(var(--_ui5_button_base_min_width) * ${this.rowActionCount} + var(--_ui5_table_row_actions_gap) * ${this.rowActionCount - 1} + var(--_ui5_table_cell_horizontal_padding) * 2)`);
 		}
 
@@ -718,7 +718,7 @@ class Table extends UI5Element {
 		if (this._isRowSelectorRequired) {
 			ariaColCount++;
 		}
-		if (this.rowActionCount > 0) {
+		if (this.rowActionCount > 0 && this.rows.length > 0) {
 			ariaColCount++;
 		}
 		if (this.headerRow[0]._popinCells.length > 0) {

--- a/packages/main/src/Table.ts
+++ b/packages/main/src/Table.ts
@@ -457,8 +457,9 @@ class Table extends UI5Element {
 	onBeforeRendering(): void {
 		this._renderNavigated = this.rows.some(row => row.navigated);
 		[...this.headerRow, ...this.rows].forEach((row, index) => {
-			row._renderNavigated = this._renderNavigated;
 			row._rowActionCount = this.rowActionCount;
+			row._renderNavigated = this._renderNavigated;
+			row._renderDummyCell = !this._hasFlexibleColumns;
 			row._alternate = this.alternateRowColors && index % 2 === 0;
 		});
 
@@ -649,6 +650,14 @@ class Table extends UI5Element {
 			return width;
 		}));
 
+		// Dummy Cell Width (before actions when popin, after navigated otherwise)
+		const dummyColumnWidth = !this._hasFlexibleColumns ? "minmax(0, 1fr)" : "";
+		const hasPopinCells = this.headerRow[0]._popinCells.length > 0;
+
+		if (dummyColumnWidth && hasPopinCells) {
+			widths.push(dummyColumnWidth);
+		}
+
 		// Row Action Cell Width
 		if (this.rowActionCount > 0) {
 			widths.push(`calc(var(--_ui5_button_base_min_width) * ${this.rowActionCount} + var(--_ui5_table_row_actions_gap) * ${this.rowActionCount - 1} + var(--_ui5_table_cell_horizontal_padding) * 2)`);
@@ -659,7 +668,15 @@ class Table extends UI5Element {
 			widths.push(`var(--_ui5_table_navigated_cell_width)`);
 		}
 
+		if (dummyColumnWidth && !hasPopinCells) {
+			widths.push(dummyColumnWidth);
+		}
+
 		return widths.join(" ");
+	}
+
+	get _hasFlexibleColumns(): boolean {
+		return this.headerRow?.[0]?._visibleCells.some(cell => !isValidColumnWidth(cell.width));
 	}
 
 	get _isRowSelectorRequired() {

--- a/packages/main/src/TableCell.ts
+++ b/packages/main/src/TableCell.ts
@@ -34,9 +34,9 @@ class TableCell extends TableCellBase {
 	/**
 	 * Defines whether the cell is visually merged with the cell directly above it.
 	 *
-	 * This is useful when consecutive cells in a column have the same value and should visually appear as a single merged cell.
+	 * This is useful if consecutive cells in a column have the same value and should visually appear as a single merged cell.
 	 * Although the cell is visually merged with the previous one, its content must still be provided for accessibility purposes.
-	 * **Note:** This feature is disabled when cells are rendered as popin, and should remain `false` for interactive cell content.
+	 * **Note:** This feature is disabled when cells are rendered as a popin, and should remain `false` for interactive cell content.
 	 *
 	 * @default false
 	 * @since 2.21.0

--- a/packages/main/src/TableHeaderRowTemplate.tsx
+++ b/packages/main/src/TableHeaderRowTemplate.tsx
@@ -54,9 +54,30 @@ export default function TableHeaderRowTemplate(this: TableHeaderRow, ariaColInde
 				return [<slot name={cell._individualSlot}></slot>];
 			})}
 
+			{ this._renderDummyCell && this._popinCells.length > 0 &&
+				<TableHeaderCell id="dummy-cell" role="none" aria-hidden={true}
+					data-excluded-from-navigation="">
+				</TableHeaderCell>
+			}
+
 			{ this._rowActionCount > 0 &&
 				<TableHeaderCell id="actions-cell" aria-colindex={ariaColIndex++}>
 					<div id="actions-cell-content">{this._i18nRowActions}</div>
+				</TableHeaderCell>
+			}
+
+			{ this._renderNavigated &&
+				<TableHeaderCell id="navigated-cell"
+					data-excluded-from-navigation
+					aria-hidden={true}
+					role="none"
+				>
+				</TableHeaderCell>
+			}
+
+			{ this._renderDummyCell && this._popinCells.length === 0 &&
+				<TableHeaderCell id="dummy-cell" role="none" aria-hidden={true}
+					data-excluded-from-navigation="nofocus">
 				</TableHeaderCell>
 			}
 

--- a/packages/main/src/TableHeaderRowTemplate.tsx
+++ b/packages/main/src/TableHeaderRowTemplate.tsx
@@ -54,7 +54,7 @@ export default function TableHeaderRowTemplate(this: TableHeaderRow, ariaColInde
 				return [<slot name={cell._individualSlot}></slot>];
 			})}
 
-			{ this._renderDummyCell && this._popinCells.length > 0 &&
+			{ this._renderDummyCell && this._hasPopin &&
 				<TableHeaderCell id="dummy-cell" role="none" aria-hidden={true}
 					data-excluded-from-navigation="">
 				</TableHeaderCell>
@@ -72,16 +72,17 @@ export default function TableHeaderRowTemplate(this: TableHeaderRow, ariaColInde
 					aria-hidden={true}
 					role="none"
 				>
+					<div id="navigated"></div>
 				</TableHeaderCell>
 			}
 
-			{ this._renderDummyCell && this._popinCells.length === 0 &&
+			{ this._renderDummyCell && !this._hasPopin &&
 				<TableHeaderCell id="dummy-cell" role="none" aria-hidden={true}
 					data-excluded-from-navigation="nofocus">
 				</TableHeaderCell>
 			}
 
-			{ this._popinCells.length > 0 &&
+			{ this._hasPopin &&
 				<TableHeaderCell id="popin-cell" aria-colindex={ariaColIndex++} data-excluded-from-navigation>
 					<div id="popin-cell-content">{this._i18nRowPopin}</div>
 				</TableHeaderCell>

--- a/packages/main/src/TableNavigation.ts
+++ b/packages/main/src/TableNavigation.ts
@@ -246,6 +246,9 @@ class TableNavigation extends TableExtension {
 		for (const target of e.composedPath() as any[]) {
 			if (target.nodeType === Node.ELEMENT_NODE) {
 				const element = target as HTMLElement;
+				if (element.getAttribute("data-excluded-from-navigation") === "nofocus") {
+					break;
+				}
 				if (element.matches(":focus-within")) {
 					focusableElement = element;
 					break;

--- a/packages/main/src/TableRow.ts
+++ b/packages/main/src/TableRow.ts
@@ -130,13 +130,6 @@ class TableRow extends TableRowBase<TableCell> {
 		toggleAttribute(this, "draggable", this.movable, "true");
 		toggleAttribute(this, "_interactive", this._isInteractive);
 		toggleAttribute(this, "_alternate", this._alternate);
-		toggleAttribute(this, "_haspopin", this._hasPopin);
-	}
-
-	async focus(focusOptions?: FocusOptions | undefined): Promise<void> {
-		this.setAttribute("tabindex", "-1");
-		HTMLElement.prototype.focus.call(this, focusOptions);
-		return Promise.resolve();
 	}
 
 	async _onpointerdown(e: PointerEvent) {
@@ -196,10 +189,6 @@ class TableRow extends TableRowBase<TableCell> {
 		return this._fixedActions.find(action => {
 			return action.hasAttribute("ui5-table-row-action-navigation") && !action.invisible && !action._isInteractive;
 		}) !== undefined;
-	}
-
-	get _hasPopin() {
-		return this.cells.some(c => c._popin && !c._popinHidden);
 	}
 
 	get _rowIndex() {

--- a/packages/main/src/TableRowBase.ts
+++ b/packages/main/src/TableRowBase.ts
@@ -40,6 +40,9 @@ abstract class TableRowBase<TCell extends TableCellBase = TableCellBase> extends
 	@property({ type: Boolean, noAttribute: true })
 	_alternate = false;
 
+	@property({ type: Boolean, noAttribute: true })
+	_renderDummyCell = false;
+
 	@query("#selection-cell")
 	_selectionCell?: HTMLElement;
 

--- a/packages/main/src/TableRowBase.ts
+++ b/packages/main/src/TableRowBase.ts
@@ -40,7 +40,7 @@ abstract class TableRowBase<TCell extends TableCellBase = TableCellBase> extends
 	@property({ type: Boolean, noAttribute: true })
 	_alternate = false;
 
-	@property({ type: Boolean, noAttribute: true })
+	@property({ type: Boolean })
 	_renderDummyCell = false;
 
 	@query("#selection-cell")
@@ -52,6 +52,10 @@ abstract class TableRowBase<TCell extends TableCellBase = TableCellBase> extends
 	@i18n("@ui5/webcomponents")
 	static i18nBundle: I18nBundle;
 
+	isHeaderRow(): boolean {
+		return false;
+	}
+
 	onEnterDOM() {
 		!this.role && this.setAttribute("role", "row");
 		this.toggleAttribute("ui5-table-row-base", true);
@@ -59,14 +63,40 @@ abstract class TableRowBase<TCell extends TableCellBase = TableCellBase> extends
 
 	onBeforeRendering() {
 		toggleAttribute(this, "aria-selected", this._isSelectable, `${this._isSelected}`);
+		toggleAttribute(this, "_has-popin", this._hasPopin);
+	}
+
+	onAfterRendering() {
+		this._handleCustomFocusOutline();
 	}
 
 	getFocusDomRef() {
 		return this;
 	}
 
-	isHeaderRow(): boolean {
-		return false;
+	async focus(focusOptions?: FocusOptions | undefined): Promise<void> {
+		this.setAttribute("tabindex", "-1");
+		HTMLElement.prototype.focus.call(this, focusOptions);
+		this._handleCustomFocusOutline();
+		return Promise.resolve();
+	}
+
+	_handleCustomFocusOutline() {
+		if (this._renderDummyCell && !this._hasPopin && document.activeElement === this) {
+			const cells = [...this.shadowRoot!.children].flatMap(element => {
+				return element.localName === "slot" ? (element as HTMLSlotElement).assignedElements() : [element];
+			});
+			const customOutlineAttribute = "data-ui5-custom-outline";
+			cells.forEach(cell => cell.removeAttribute(customOutlineAttribute));
+			const firstVisibleCell = cells.at(0);
+			const lastVisibleCell = cells.at(-2);
+			if (firstVisibleCell === lastVisibleCell) {
+				firstVisibleCell?.setAttribute(customOutlineAttribute, "startend");
+			} else {
+				firstVisibleCell?.setAttribute(customOutlineAttribute, "start");
+				lastVisibleCell?.setAttribute(customOutlineAttribute, "end");
+			}
+		}
 	}
 
 	_onSelectionChange() {
@@ -121,6 +151,10 @@ abstract class TableRowBase<TCell extends TableCellBase = TableCellBase> extends
 
 	get _popinCells() {
 		return this.cells.filter(c => c._popin && !c._popinHidden);
+	}
+
+	get _hasPopin() {
+		return (this._table?.rows.length ?? 0) > 0 && this.cells.some(c => c._popin && !c._popinHidden);
 	}
 
 	get _stickyCells() {

--- a/packages/main/src/TableRowTemplate.tsx
+++ b/packages/main/src/TableRowTemplate.tsx
@@ -47,6 +47,12 @@ export default function TableRowTemplate(this: TableRow, ariaColIndex: number = 
 				return [<slot name={cell._individualSlot}></slot>];
 			})}
 
+			{ this._renderDummyCell && this._hasPopin &&
+				<TableCell id="dummy-cell" role="none" aria-hidden={true} data-border-merged=""
+					data-excluded-from-navigation="">
+				</TableCell>
+			}
+
 			{ this._rowActionCount > 0 &&
 				<TableCell id="actions-cell"
 					aria-colindex={ariaColIndex++}
@@ -77,6 +83,12 @@ export default function TableRowTemplate(this: TableRow, ariaColIndex: number = 
 					role="none"
 				>
 					<div id="navigated"></div>
+				</TableCell>
+			}
+
+			{ this._renderDummyCell && !this._hasPopin &&
+				<TableCell id="dummy-cell" role="none" aria-hidden={true} data-border-merged=""
+					data-excluded-from-navigation="nofocus">
 				</TableCell>
 			}
 

--- a/packages/main/src/TableRowTemplate.tsx
+++ b/packages/main/src/TableRowTemplate.tsx
@@ -92,7 +92,7 @@ export default function TableRowTemplate(this: TableRow, ariaColIndex: number = 
 				</TableCell>
 			}
 
-			{ this._popinCells.length > 0 &&
+			{ this._hasPopin &&
 				<TableCell id="popin-cell"
 					data-ui5-table-popin-cell
 					aria-colindex={ariaColIndex++}

--- a/packages/main/src/themes/TableRow.css
+++ b/packages/main/src/themes/TableRow.css
@@ -6,6 +6,10 @@
 	background: var(--_ui5_table_row_alternating_background);
 }
 
+:host([position]) {
+	height: var(--row-height);
+}
+
 :host(:first-of-type) > [ui5-table-cell],
 :host(:first-of-type) > ::slotted([ui5-table-cell]) {
 	border-top: none;
@@ -18,18 +22,28 @@
 :host([aria-selected="true"]) {
 	background: var(--sapList_SelectionBackgroundColor);
 	box-shadow: inset 0 calc(-1 * var(--sapList_BorderWidth)) 0 0 var(--sapList_SelectionBorderColor);
+
+	#actions-cell,
+	#navigated-cell,
+	#selection-cell {
+		clip-path: inset(0px 0px 1px 0px); /* selection bottom border should not overlap with sticky cells */
+	}
 }
 
-:host(:not([_haspopin])) {
+:host(:not([_has-popin])) {
 	/* Use CSS Space Toggles until if() or container style queries are widely supported */
 	--_ui5_table_cell_border_merged: ;
 	--_ui5_table_cell_content_merged: ;
 }
 
-:host(:not([_haspopin]):active),
-:host(:not([_haspopin]):focus-within) {
+:host(:not([_has-popin]):active),
+:host(:not([_has-popin]):focus-within) {
 	/* Provide a valid CSS value to intentionally invalidate the TableCell variable-based rules and disable visual merging. */
 	--_ui5_table_cell_content_merged: initial;
+}
+
+:host([_interactive]) {
+	cursor: pointer;
 }
 
 @media (hover: hover) {
@@ -39,7 +53,7 @@
 	:host([_interactive][aria-selected=true]:hover) {
 		background: var(--sapList_Hover_SelectionBackground);
 	}
-	:host(:not([_haspopin]):hover) {
+	:host(:not([_has-popin]):hover) {
 		/* Provide a valid CSS value to intentionally invalidate the TableCell variable-based rules and disable visual merging. */
 		--_ui5_table_cell_content_merged: initial;
 	}
@@ -48,14 +62,6 @@
 :host([_interactive][_active]),
 :host([_interactive][aria-selected="true"][_active]) {
 	background: var(--sapList_Active_Background);
-}
-
-:host([_interactive]) {
-	cursor: pointer;
-}
-
-:host([position]) {
-	height: var(--row-height);
 }
 
 #popin-cell {
@@ -67,38 +73,25 @@
 }
 
 #navigated-cell {
- 	position: sticky;
-	inset-inline-end: 0;
-	z-index: 1;
-	background-color: inherit;
 	overflow: visible;
 	grid-row: span 2;
-	min-width: 0;
-	padding: 0;
 }
 
 :host([navigated]) #navigated {
 	position: absolute;
-	inset: -1px 0px 0px 1px;
+	inset: 0px 0px 0px 1px;
 	background: var(--sapList_SelectionBorderColor);
 }
 
-:host([tabindex]:focus) #navigated {
-	transform: translateX(calc(var(--_ui5_table_navigated_cell_width) * -1));
-	bottom: 3px;
-	top: 2px;
-}
-
-:host([tabindex]:focus) #navigated:dir(rtl) {
-	transform: translateX(var(--_ui5_table_navigated_cell_width));
-}
-
-:host([tabindex]:focus) #navigated-cell {
-	clip-path: inset(var(--sapContent_FocusWidth) var(--sapContent_FocusWidth) var(--sapContent_FocusWidth) calc(var(--_ui5_table_navigated_cell_width) * -1));
-}
-
-:host([tabindex]:focus) #navigated-cell:dir(rtl) {
-	clip-path: inset(var(--sapContent_FocusWidth) calc(var(--_ui5_table_navigated_cell_width) * -1) var(--sapContent_FocusWidth) var(--sapContent_FocusWidth));
+:host([navigated][tabindex]:focus) {
+	#navigated {
+		transform: translateX(calc(var(--_ui5_table_navigated_cell_width) * -1));
+		bottom: 3px;
+		top: 2px;
+	}
+	#navigated:dir(rtl) {
+		transform: translateX(var(--_ui5_table_navigated_cell_width));
+	}
 }
 
 :host([navigated]) #popin-cell {
@@ -112,8 +105,4 @@
 
 #actions-cell {
 	gap: var(--_ui5_table_row_actions_gap);
-}
-
-#actions-cell:has(+ #navigated-cell) {
-	inset-inline-end: var(--_ui5_table_navigated_cell_width);
 }

--- a/packages/main/src/themes/TableRowBase.css
+++ b/packages/main/src/themes/TableRowBase.css
@@ -7,14 +7,19 @@
 	overflow: clip;
 }
 
-:host([tabindex]:focus) {
-	outline: var(--sapContent_FocusWidth) var(--sapContent_FocusStyle) var(--sapContent_FocusColor);
-	outline-offset: calc(-1 * var(--sapContent_FocusWidth));
+#selection-cell,
+#actions-cell,
+#navigated-cell {
+	background-color: inherit;
+ 	position: sticky;
+	z-index: 1;
 }
 
-:host([tabindex]:focus) #selection-cell,
-:host([tabindex]:focus) #actions-cell {
-	clip-path: inset(var(--sapContent_FocusWidth)); /* focus outline should not overlap sticky cells */
+#selection-cell {
+	padding: 0;
+	inset-inline-start: 0;
+	min-width: auto;
+	justify-content: center;
 }
 
 ::slotted([ui5-table-cell-base]:first-of-type) {
@@ -25,33 +30,79 @@
 	padding-inline-start: var(--_ui5_table_cell_horizontal_padding);
 }
 
-#selection-cell,
-#actions-cell {
-	background-color: inherit;
-	clip-path: inset(0px 0px 1px 0px); /* selection border should not overlap with sticky cells */
- 	position: sticky;
-	z-index: 1;
-}
-
-#dummy-cell {
-	border-inline-start: var(--sapList_TableFixedColumnBorderWidth) solid var(--sapList_TableFixedBorderColor);
-}
-
-:host([_haspopin]) #dummy-cell {
-	border-inline-start: none;
-}
-
-#selection-cell {
-	padding: 0;
-	inset-inline-start: 0;
-	min-width: auto;
-}
-
 #actions-cell {
 	inset-inline-end: 0;
 }
 
-#selection-cell[tabindex]:focus,
-#actions-cell[tabindex]:focus {
-	clip-path: inset(0px);
+#actions-cell:has(+ #navigated-cell) {
+	inset-inline-end: var(--_ui5_table_navigated_cell_width);
+}
+
+#navigated-cell {
+	inset-inline-end: 0;
+	min-width: 0;
+	padding: 0;
+}
+
+#dummy-cell {
+	border-inline-start: 1px solid var(--sapList_TableFixedBorderColor);
+}
+
+:host([_has-popin]) #dummy-cell {
+	border-inline-start: none;
+}
+
+:host([tabindex]:focus) {
+	outline: var(--sapContent_FocusWidth) var(--sapContent_FocusStyle) var(--sapContent_FocusColor);
+	outline-offset: calc(-1 * var(--sapContent_FocusWidth));
+
+	#selection-cell,
+	#actions-cell{
+		clip-path: inset(var(--sapContent_FocusWidth)); /* focus outline should not overlap sticky cells */
+	}
+
+	#navigated-cell {
+		clip-path: inset(3px 4px 3px -4px);
+	}
+	#navigated-cell:dir(rtl) {
+		clip-path: inset(3px -4px 3px 4px);
+	}
+}
+
+:host([tabindex][_render-dummy-cell]:not([_has-popin]):focus) {
+	outline: none;
+
+	--_ui5_table_cell_custom_outline_block: inset 0 var(--sapContent_FocusWidth) 0 0 var(--sapContent_FocusColor), inset 0 calc(-1 * var(--sapContent_FocusWidth)) 0 0 var(--sapContent_FocusColor);
+	--_ui5_table_cell_custom_outline_inline-start: inset var(--sapContent_FocusWidth) 0 0 0 var(--sapContent_FocusColor);
+	--_ui5_table_cell_custom_outline_inline-end: inset calc(-1 * var(--sapContent_FocusWidth)) 0 0 0 var(--sapContent_FocusColor);
+	:dir(rtl) {
+		--_ui5_table_cell_custom_outline_inline-start: inset calc(-1 * var(--sapContent_FocusWidth)) 0 0 0 var(--sapContent_FocusColor);
+		--_ui5_table_cell_custom_outline_inline-end: inset var(--sapContent_FocusWidth) 0 0 0 var(--sapContent_FocusColor);
+	}
+
+	[ui5-table-cell-base], ::slotted([ui5-table-cell-base]) {
+		box-shadow: var(--_ui5_table_cell_custom_outline_block);
+	}
+	[data-ui5-custom-outline="start"], ::slotted([data-ui5-custom-outline="start"]) {
+		box-shadow: var(--_ui5_table_cell_custom_outline_block), var(--_ui5_table_cell_custom_outline_inline-start);
+	}
+	[data-ui5-custom-outline="end"], ::slotted([data-ui5-custom-outline="end"]) {
+		box-shadow: var(--_ui5_table_cell_custom_outline_block), var(--_ui5_table_cell_custom_outline_inline-end);
+	}
+	[data-ui5-custom-outline="startend"], ::slotted([data-ui5-custom-outline="startend"]) {
+		box-shadow: var(--_ui5_table_cell_custom_outline_block), var(--_ui5_table_cell_custom_outline_inline-start), var(--_ui5_table_cell_custom_outline_inline-end);
+	}
+	#dummy-cell {
+		box-shadow: none;
+	}
+
+	#selection-cell,
+	#actions-cell,
+	#navigated-cell {
+		clip-path: none;
+	}
+
+	#navigated {
+		top: 3px;
+	}
 }

--- a/packages/main/src/themes/TableRowBase.css
+++ b/packages/main/src/themes/TableRowBase.css
@@ -33,6 +33,14 @@
 	z-index: 1;
 }
 
+#dummy-cell {
+	border-inline-start: var(--sapList_TableFixedColumnBorderWidth) solid var(--sapList_TableFixedBorderColor);
+}
+
+:host([_haspopin]) #dummy-cell {
+	border-inline-start: none;
+}
+
 #selection-cell {
 	padding: 0;
 	inset-inline-start: 0;

--- a/packages/main/test/pages/TableNoData.html
+++ b/packages/main/test/pages/TableNoData.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+
+	<title>Table - No Data</title>
+	<meta name="viewport"
+		content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+	<meta charset="utf-8">
+
+	<script src="%VITE_BUNDLE_PATH%" type="module"></script>
+	<script type="module">
+		import "@ui5/webcomponents-fiori/dist/IllustratedMessage.js";
+		import "@ui5/webcomponents-fiori/dist/illustrations/NoData.js";
+		import "@ui5/webcomponents/dist/TableRowAction.js";
+		import "@ui5/webcomponents/dist/TableRowActionNavigation.js";
+	</script>
+
+	<style>
+		ui5-table {
+			margin: 1rem;
+		}
+	</style>
+</head>
+
+<body class="sapUiSizeCompact">
+	<h3>Single column - no data (column should cover full width)</h3>
+	<ui5-table id="table1">
+		<ui5-table-header-row slot="headerRow">
+			<ui5-table-header-cell width="200px">Product</ui5-table-header-cell>
+		</ui5-table-header-row>
+	</ui5-table>
+
+	<br>
+	<h3>Single column (width:40%) - no data with custom noData slot</h3>
+	<div style="display: flex; gap: 0.5rem;">
+		<ui5-button id="addRow2" icon="add">Add Row</ui5-button>
+		<ui5-button id="removeRow2" icon="delete" design="Negative">Remove Row</ui5-button>
+	</div>
+	<ui5-table id="table2">
+		<ui5-table-header-row slot="headerRow">
+			<ui5-table-header-cell width="40%">Product</ui5-table-header-cell>
+		</ui5-table-header-row>
+		<div slot="noData">
+			<ui5-illustrated-message name="NoData"></ui5-illustrated-message>
+		</div>
+	</ui5-table>
+
+	<script>
+		let rowCount2 = 0;
+		const table2 = document.getElementById("table2");
+
+		document.getElementById("addRow2").addEventListener("click", () => {
+			rowCount2++;
+			const row = document.createElement("ui5-table-row");
+			const cell = document.createElement("ui5-table-cell");
+			const text = document.createElement("ui5-text");
+			text.textContent = "Product " + rowCount2;
+			cell.appendChild(text);
+			row.appendChild(cell);
+			table2.appendChild(row);
+		});
+
+		document.getElementById("removeRow2").addEventListener("click", () => {
+			const rows = table2.querySelectorAll("[ui5-table-row]");
+			if (rows.length > 0) {
+				rows[rows.length - 1].remove();
+			}
+		});
+	</script>
+
+	<br>
+	<h3>Multiple columns (width:200px each) - no data</h3>
+	<div style="display: flex; gap: 0.5rem;">
+		<ui5-button id="addRow3" icon="add">Add Row</ui5-button>
+		<ui5-button id="removeRow3" icon="delete" design="Negative">Remove Row</ui5-button>
+	</div>
+	<ui5-table id="table3">
+		<ui5-table-header-row slot="headerRow">
+			<ui5-table-header-cell width="200px">Product</ui5-table-header-cell>
+			<ui5-table-header-cell width="200px">Supplier</ui5-table-header-cell>
+			<ui5-table-header-cell width="200px">Price</ui5-table-header-cell>
+		</ui5-table-header-row>
+	</ui5-table>
+
+	<script>
+		let rowCount3 = 0;
+		const table3 = document.getElementById("table3");
+
+		document.getElementById("addRow3").addEventListener("click", () => {
+			rowCount3++;
+			const row = document.createElement("ui5-table-row");
+			["Product " + rowCount3, "Supplier " + rowCount3, rowCount3 * 100 + " EUR"].forEach(value => {
+				const cell = document.createElement("ui5-table-cell");
+				const text = document.createElement("ui5-text");
+				text.textContent = value;
+				cell.appendChild(text);
+				row.appendChild(cell);
+			});
+			table3.appendChild(row);
+		});
+
+		document.getElementById("removeRow3").addEventListener("click", () => {
+			const rows = table3.querySelectorAll("[ui5-table-row]");
+			if (rows.length > 0) {
+				rows[rows.length - 1].remove();
+			}
+		});
+	</script>
+
+	<br>
+	<h3>Popin - 4 columns (shrink below 1000px to see popin columns)</h3>
+	<div style="display: flex; gap: 0.5rem;">
+		<ui5-button id="addRow4" icon="add">Add Row</ui5-button>
+		<ui5-button id="removeRow4" icon="delete" design="Negative">Remove Row</ui5-button>
+	</div>
+	<ui5-table id="table4" overflow-mode="Popin" row-action-count="3">
+		<ui5-table-header-row slot="headerRow">
+			<ui5-table-header-cell width="250px">Product</ui5-table-header-cell>
+			<ui5-table-header-cell width="250px">Supplier</ui5-table-header-cell>
+			<ui5-table-header-cell width="250px">Dimensions</ui5-table-header-cell>
+			<ui5-table-header-cell width="250px">Price</ui5-table-header-cell>
+		</ui5-table-header-row>
+		<div slot="noData">
+			<ui5-illustrated-message name="NoData"></ui5-illustrated-message>
+		</div>
+	</ui5-table>
+
+	<script>
+		let rowCount4 = 0;
+		const table4 = document.getElementById("table4");
+
+		document.getElementById("addRow4").addEventListener("click", () => {
+			rowCount4++;
+			const row = document.createElement("ui5-table-row");
+			["Product " + rowCount4, "Supplier " + rowCount4, "30 x 18 x 3 cm", rowCount4 * 100 + " EUR"].forEach(value => {
+				const cell = document.createElement("ui5-table-cell");
+				const text = document.createElement("ui5-text");
+				text.textContent = value;
+				cell.appendChild(text);
+				row.appendChild(cell);
+			});
+
+			const editAction = document.createElement("ui5-table-row-action");
+			editAction.setAttribute("slot", "actions");
+			editAction.setAttribute("icon", "edit");
+			editAction.setAttribute("text", "Edit");
+			row.appendChild(editAction);
+
+			const deleteAction = document.createElement("ui5-table-row-action");
+			deleteAction.setAttribute("slot", "actions");
+			deleteAction.setAttribute("icon", "delete");
+			deleteAction.setAttribute("text", "Delete");
+			row.appendChild(deleteAction);
+
+			const navAction = document.createElement("ui5-table-row-action-navigation");
+			navAction.setAttribute("slot", "actions");
+			navAction.setAttribute("interactive", "");
+			row.appendChild(navAction);
+
+			if (rowCount4 === 2) {
+				row.setAttribute("navigated", "");
+			}
+
+			table4.appendChild(row);
+		});
+
+		document.getElementById("removeRow4").addEventListener("click", () => {
+			const rows = table4.querySelectorAll("[ui5-table-row]");
+			if (rows.length > 0) {
+				rows[rows.length - 1].remove();
+			}
+		});
+	</script>
+</body>
+
+</html>

--- a/packages/main/test/pages/TableNoData.html
+++ b/packages/main/test/pages/TableNoData.html
@@ -14,6 +14,7 @@
 		import "@ui5/webcomponents-fiori/dist/illustrations/NoData.js";
 		import "@ui5/webcomponents/dist/TableRowAction.js";
 		import "@ui5/webcomponents/dist/TableRowActionNavigation.js";
+		import "@ui5/webcomponents/dist/TableSelectionMulti.js";
 	</script>
 
 	<style>
@@ -115,6 +116,7 @@
 		<ui5-button id="removeRow4" icon="delete" design="Negative">Remove Row</ui5-button>
 	</div>
 	<ui5-table id="table4" overflow-mode="Popin" row-action-count="3">
+		<ui5-table-selection-multi slot="features"></ui5-table-selection-multi>
 		<ui5-table-header-row slot="headerRow">
 			<ui5-table-header-cell width="250px">Product</ui5-table-header-cell>
 			<ui5-table-header-cell width="250px">Supplier</ui5-table-header-cell>

--- a/packages/main/test/pages/Table_Acc.html
+++ b/packages/main/test/pages/Table_Acc.html
@@ -27,6 +27,7 @@
 			<ui5-label id="selectionModeLabel">Selection Mode:</ui5-label>
 			<ui5-select id="selectionModeSelect" accessible-name-ref="selectionModeLabel">
 				<ui5-option selected>Multi</ui5-option>
+				<ui5-option>Multi ClearAll</ui5-option>
 				<ui5-option>Single</ui5-option>
 				<ui5-option>None</ui5-option>
 			</ui5-select>
@@ -223,6 +224,12 @@
 				selection = document.createElement("ui5-table-selection-multi");
 				selection.setAttribute("id", "selection");
 				selection.setAttribute("slot", "features");
+				table.insertBefore(selection, table.firstChild);
+			} else if (e.target.selectedOption.textContent === "Multi ClearAll") {
+				selection = document.createElement("ui5-table-selection-multi");
+				selection.setAttribute("id", "selection");
+				selection.setAttribute("slot", "features");
+				selection.setAttribute("header-selector", "ClearAll");
 				table.insertBefore(selection, table.firstChild);
 			}
 		});

--- a/packages/website/docs/_components_pages/main/Table/TableCell.mdx
+++ b/packages/website/docs/_components_pages/main/Table/TableCell.mdx
@@ -19,21 +19,21 @@ Please note that the behavior of `horizontalAlign` depends on where you set it:
    Changes the horizontal alignment of the `TableHeaderCell` and its corresponding `TableCell`.
 - `horizontalAlign` is set on `TableCell` level only<br />
    The horizontal alignment is only changed for this one `TableCell`
-- `horizontalAlign` is set on `TableHeaderCell` and `TableCell` level<br />
-   Changing the `horizontalAlign` property on `TableHeaderCell` level changes only the `TableHeaderCell` itself and those `TableCell` without a `horizontalAlign` property.
+- `horizontalAlign` is set at the `TableHeaderCell` and `TableCell` level<br />
+   Changing the `horizontalAlign` property at the `TableHeaderCell` level changes only the `TableHeaderCell` itself and those `TableCell` properties without a `horizontalAlign` property.
 
 <HAlign />
 
 ## Merged cells
 
-Set the `merged` property on a `TableCell` to visually merge it with the cell directly above it in the same column. When a cell is merged,
+Set the `merged` property on a `TableCell` to visually merge it with the cell directly above it in the same column. If a cell is merged,
 its content is hidden and the border becomes transparent, giving the appearance of a single spanning cell.
-This is useful when consecutive rows share the same value in a column.
+This is useful if consecutive rows share the same value in a column.
 
 To ensure usability, merged cell styling is automatically disabled in these cases:
-- **Popin mode:** When the table is narrow and cells are rendered in the popin area, merged styling is removed so each row's content remains visible.
+- **Popin mode:** If the table is narrow, and cells are rendered in the pop-in area, merged styling is removed so each row's content remains visible.
 - **Hover and focus:** When the user hovers over or focuses within the row, merged styling is temporarily removed, making the merged content visible.
 
-**Note:** Avoid using `merged` on cells that contain interactive content (e.g., buttons, or inputs).
+**Note:** Avoid using `merged` on cells that contain interactive content (for example, buttons, or inputs).
 
 <MergedCells />

--- a/packages/website/docs/_components_pages/main/Table/TableHeaderCell.mdx
+++ b/packages/website/docs/_components_pages/main/Table/TableHeaderCell.mdx
@@ -27,7 +27,7 @@ Please note that the behavior of `horizontalAlign` depends on where you set it:
 Changes the horizontal alignment of the `TableHeaderCell` and its corresponding `TableCell`.
 - `horizontalAlign` is set on `TableCell` level only<br />
 The horizontal alignment is only changed for this one `TableCell`
-- `horizontalAlign` is set on `TableHeaderCell` and `TableCell` level<br />
-Changing the `horizontalAlign` property on `TableHeaderCell` level changes only the `TableHeaderCell` itself and those `TableCell` without a `horizontalAlign` property.
+- `horizontalAlign` is set at the `TableHeaderCell` and `TableCell` level<br />
+Changing the `horizontalAlign` property at the `TableHeaderCell` level changes only the `TableHeaderCell` itself and those `TableCell` properties without a `horizontalAlign` property.
 
 <HAlign />


### PR DESCRIPTION
  Summary :
  - Renders a "dummy cell" (minmax(0, 1fr)) in tables where all columns have explicit widths, filling the remaining empty space to the right of the data columns
  - Implements a custom per-cell focus outline using box-shadow that excludes the empty area, with full RTL support                     
  - Moves shared row logic (focus(), _hasPopin, popin attribute management) from TableRow into TableRowBase so both data rows and header rows benefit                                                                                                                         
  - Hides the row actions column when the table has no rows                                                                             
  - Reorganizes sticky cell and navigated cell CSS from TableRow.css into TableRowBase.css for proper inheritance
  - Missing documentation review of https://github.com/UI5/webcomponents/pull/13297 is applied
 
  Dummy cell rendering:                                                                                                                 
  - Table.ts computes _hasFlexibleColumns and sets _renderDummyCell on all rows                                                       
  - Grid template columns include a minmax(0, 1fr) dummy column positioned before or after actions depending on popin state             
  - Dummy cell has a left border (fixed column separator) when not in popin mode                                                      
                                                                                                                                        
  Custom focus outline:                                                                                                                 
  - When a row with a dummy cell is focused (non-popin), the standard outline is replaced with per-cell box-shadow insets               
  - _handleCustomFocusOutline() marks first/last visible cells via data-ui5-custom-outline attribute (start, end, or startend for single-column tables)                                                                                                               
  - CSS variables --_ui5_table_cell_custom_outline_block, inline-start, inline-end define the shadow values, with :dir(rtl) overrides   
                                                                                                                                      
  Refactoring:                                                                                                                          
  - _hasPopin getter moved to TableRowBase with additional rows.length > 0 guard (prevents popin rendering in empty tables)             
  - Attribute renamed from _haspopin to _has-popin for consistency with kebab-case convention                                           
  - Navigated cell clip-path and focus rules consolidated using CSS nesting                                                             
  - Sticky cell styles (position: sticky, z-index, background-color) moved to TableRowBase.css 

                