### PR TITLE
fix(ui5-multi-input): fix arrow left key behavior

### DIFF
--- a/packages/main/cypress/specs/MultiInput.cy.tsx
+++ b/packages/main/cypress/specs/MultiInput.cy.tsx
@@ -1502,6 +1502,145 @@ describe("Keyboard handling", () => {
 		cy.get("@changeSpy")
 			.should("have.been.calledOnce");
 	});
+
+	it("should focus last token on ArrowLeft at start of input, keep suggestions open, and not fire change event", () => {
+		cy.mount(
+			<MultiInput showSuggestions>
+				<Token slot="tokens" text="Amet"></Token>
+				<SuggestionItem text="Bulgaria"></SuggestionItem>
+				<SuggestionItem text="Brazil"></SuggestionItem>
+			</MultiInput>
+		);
+
+		const changeSpy = cy.stub().as("changeSpy");
+
+		cy.get("[ui5-multi-input]")
+			.then(multiInput => {
+				multiInput[0].addEventListener("ui5-change", changeSpy);
+			});
+
+		cy.get("[ui5-multi-input]")
+			.shadow()
+			.find("input")
+			.as("input");
+
+		cy.get("@input")
+			.realClick();
+
+		cy.realType("a");
+
+		cy.get("[ui5-multi-input]")
+			.shadow()
+			.find<ResponsivePopover>("[ui5-responsive-popover]")
+			.ui5ResponsivePopoverOpened();
+
+		cy.realPress("ArrowLeft"); // cursor: pos 1 → pos 0
+		cy.realPress("ArrowLeft"); // cursor at pos 0 → focuses last token
+
+		cy.get("[ui5-token]")
+			.should("have.length", 1);
+
+		cy.get("[ui5-token]")
+			.should("be.focused");
+
+		cy.get("[ui5-multi-input]")
+			.shadow()
+			.find<ResponsivePopover>("[ui5-responsive-popover]")
+			.ui5ResponsivePopoverOpened();
+
+		cy.get("@changeSpy")
+			.should("not.have.been.called");
+	});
+
+	it("should fire change event when returning from tokenizer to input via ArrowRight and pressing Tab", () => {
+		cy.mount(
+			<MultiInput showSuggestions>
+				<Token slot="tokens" text="Amet"></Token>
+				<SuggestionItem text="Bulgaria"></SuggestionItem>
+				<SuggestionItem text="Brazil"></SuggestionItem>
+			</MultiInput>
+		);
+
+		const changeSpy = cy.stub().as("changeSpy");
+
+		cy.get("[ui5-multi-input]")
+			.then(multiInput => {
+				multiInput[0].addEventListener("ui5-change", changeSpy);
+			});
+
+		cy.get("[ui5-multi-input]")
+			.shadow()
+			.find("input")
+			.as("input");
+
+		cy.get("@input")
+			.realClick();
+
+		cy.realType("a");
+
+		// focus last token
+		cy.realPress("ArrowLeft");
+		cy.realPress("ArrowLeft");
+
+		cy.get("[ui5-token]")
+			.should("be.focused");
+
+		// return to input
+		cy.realPress("ArrowRight");
+
+		cy.get("[ui5-multi-input]")
+			.should("be.focused");
+
+		cy.realPress("Tab");
+
+		cy.get("@changeSpy")
+			.should("have.been.calledOnce");
+	});
+
+	it("should fire change event when returning from tokenizer to input via Tab and pressing Enter", () => {
+		cy.mount(
+			<MultiInput showSuggestions noTypeahead>
+				<Token slot="tokens" text="Amet"></Token>
+				<SuggestionItem text="Bulgaria"></SuggestionItem>
+				<SuggestionItem text="Brazil"></SuggestionItem>
+			</MultiInput>
+		);
+
+		const changeSpy = cy.stub().as("changeSpy");
+
+		cy.get("[ui5-multi-input]")
+			.then(multiInput => {
+				multiInput[0].addEventListener("ui5-change", changeSpy);
+			});
+
+		cy.get("[ui5-multi-input]")
+			.shadow()
+			.find("input")
+			.as("input");
+
+		cy.get("@input")
+			.realClick();
+
+		cy.realType("b");
+
+		// focus last token
+		cy.realPress("ArrowLeft");
+		cy.realPress("ArrowLeft");
+
+		cy.get("[ui5-token]")
+			.should("be.focused");
+
+		// return to input
+		cy.realPress("Tab");
+
+		cy.get("[ui5-multi-input]")
+			.should("be.focused");
+
+		cy.realPress("Enter");
+
+		cy.get("@changeSpy")
+			.should("have.been.calledOnce");
+	});
 });
 
 describe("MultiInput Composition", () => {

--- a/packages/main/cypress/specs/MultiInput.cy.tsx
+++ b/packages/main/cypress/specs/MultiInput.cy.tsx
@@ -31,8 +31,17 @@ const handleTokenDelete = (event) => {
 
 describe("MultiInput Web Component", () => {
 	it("creates only one token when typing 'ad' and pressing Enter", () => {
+		const fnOnKeyDown = (event: KeyboardEvent) => {
+			const inputElement =event.target as HTMLInputElement;
+			if (event.key === "Enter" && inputElement.value) {
+				const token = createTokenFromText(inputElement.value);
+				inputElement.appendChild(token);
+				inputElement.value = "";
+			}
+		}; 
+
 		cy.mount(
-			<MultiInput showSuggestions={true} showValueHelpIcon={true} id="suggestion-token">
+			<MultiInput showSuggestions={true} showValueHelpIcon={true} id="suggestion-token" onKeyDown={fnOnKeyDown}>
 				<SuggestionItem text="Aute"></SuggestionItem>
 				<SuggestionItem text="ad"></SuggestionItem>
 				<SuggestionItem text="exercitation"></SuggestionItem>
@@ -43,17 +52,6 @@ describe("MultiInput Web Component", () => {
 				<SuggestionItem text="excepteur"></SuggestionItem>
 			</MultiInput>
 		);
-
-		cy.get("#suggestion-token").then(multiInput => {
-			multiInput[0].addEventListener("keydown", (event: KeyboardEvent) => {
-				const inputElement = multiInput[0] as HTMLInputElement;
-				if (event.key === "Enter" && inputElement.value) {
-					const token = createTokenFromText(inputElement.value);
-					inputElement.appendChild(token);
-					inputElement.value = "";
-				}
-			});
-		});
 
 		cy.get("#suggestion-token")
 			.shadow()
@@ -212,16 +210,11 @@ describe("MultiInput Web Component", () => {
 
 	it("fires value-help-trigger with F4 and Alt/Option + ArrowUp/Down", () => {
 		cy.mount(
-			<MultiInput id="multi-with-value-help-icon" showValueHelpIcon={true}></MultiInput>
+			<MultiInput id="multi-with-value-help-icon" showValueHelpIcon={true} onValueHelpTrigger={cy.stub().as("valueHelpTrigger")}></MultiInput>
 		);
 
 		cy.get("[ui5-multi-input]")
 			.as("multiInput");
-
-		cy.get("@multiInput")
-			.then($multiInput => {
-				$multiInput[0].addEventListener("value-help-trigger", cy.stub().as("valueHelpTrigger"));
-			});
 
 		cy.get("@multiInput")
 			.shadow()
@@ -396,19 +389,14 @@ describe("MultiInput tokens", () => {
 	});
 
 	it("Should fire a change event", () => {
+		const changeSpy = cy.stub().as("changeSpy");
 		cy.mount(
-			<MultiInput showSuggestions={true} showValueHelpIcon={true}>
+			<MultiInput showSuggestions={true} showValueHelpIcon={true} onChange={changeSpy}>
 				<SuggestionItem text="Aute" />
 				<SuggestionItem text="ad" />
 				<SuggestionItem text="exercitation" />
 			</MultiInput>
 		);
-
-		const changeSpy = cy.stub().as("changeSpy");
-
-		cy.get("[ui5-multi-input]").then(multiInput => {
-			multiInput[0].addEventListener("ui5-change", changeSpy);
-		});
 
 		cy.get("[ui5-multi-input]")
 			.shadow()
@@ -538,23 +526,21 @@ describe("MultiInput tokens", () => {
 	});
 
 	it("should empty the field when value is cleared in the change handler", () => {
+		const fnOnChange = (evt: any) => {
+			(evt.target as HTMLElement).appendChild(createTokenFromText((evt.target as HTMLInputElement).value));
+			(evt.target as HTMLInputElement).value = "";
+		};
+
+		const fnValueHelpTrigger = (evt: any) => {
+			(evt.target as ResponsivePopover).open = true;
+		};
+
 		cy.mount(
-			<MultiInput showSuggestions id="token-unique" showValueHelpIcon>
+			<MultiInput showSuggestions id="token-unique" showValueHelpIcon onChange={fnOnChange} onValueHelpTrigger={fnValueHelpTrigger}>
 				<div slot="valueStateMessage" id="value-state-wrapper">Token is already in the list</div>
 				<SuggestionItem text="Argentina"></SuggestionItem>
 			</MultiInput>
 		);
-
-		cy.get("[ui5-multi-input]")
-			.then(multiInput => {
-				multiInput[0].addEventListener("ui5-value-help-trigger", function (event) {
-					(event.target as ResponsivePopover).open = true;
-				});
-				multiInput[0].addEventListener("ui5-change", (event) => {
-				(event.target as HTMLElement).appendChild(createTokenFromText((event.target as HTMLInputElement).value));
-				(event.target as HTMLInputElement).value = "";
-				});
-			});
 
 		cy.get("[ui5-multi-input]")
 			.shadow()
@@ -795,17 +781,12 @@ describe("MultiInput Truncated Token", () => {
 	});
 
 	it("should truncate token when a long token is added", () => {
-
 		cy.mount(
 			<>
-			<MultiInput id="truncated-token"></MultiInput>
+			<MultiInput id="truncated-token" onTokenDelete={handleTokenDelete}></MultiInput>
 			<Button>button</Button>
 			</>
 		);
-
-		cy.get("[ui5-multi-input]").then(multiInput => {
-			multiInput[0].addEventListener("ui5-token-delete", handleTokenDelete);
-		});
 
 		cy.get("[ui5-button]").then(button => {
 			button[0].addEventListener("click", () => {
@@ -986,25 +967,22 @@ describe("ARIA attributes", () => {
 	});
 
 	it("announces correct suggestion position when selecting a suggestion with Enter", () => {
+		const fnKeyDown =  (event: KeyboardEvent) => {
+			const inputElement = event.target as HTMLInputElement;
+			if (event.key === "Enter" && inputElement.value) {
+				const token = createTokenFromText(inputElement.value);
+				inputElement.appendChild(token);
+				inputElement.value = "";
+			}
+		};
+
 		cy.mount(
-			<MultiInput show-suggestions id="suggestion-token">
+			<MultiInput show-suggestions id="suggestion-token" onKeyDown={fnKeyDown}>
 				<SuggestionItem text="Aute"></SuggestionItem>
 				<SuggestionItem text="ad"></SuggestionItem>
 				<SuggestionItem text="exercitation"></SuggestionItem>
 			</MultiInput>
 		);
-
-		cy.get("[ui5-multi-input]")
-			.then(multiInput => {
-				multiInput[0].addEventListener("keydown", (event: KeyboardEvent) => {
-					const inputElement = multiInput[0] as HTMLInputElement;
-					if (event.key === "Enter" && inputElement.value) {
-						const token = createTokenFromText(inputElement.value);
-						inputElement.appendChild(token);
-						inputElement.value = "";
-					}
-				});
-			})
 
 		cy.get("[ui5-multi-input]")
 			.realClick();
@@ -1350,8 +1328,17 @@ describe("Keyboard handling", () => {
 	});
 
 	it("should change input's value when set in selection change event", () => {
+		const fnOnKeyDown = (event: KeyboardEvent) => {
+			const inputElement = event.target as HTMLInputElement;
+			if (event.key === "Enter" && inputElement.value) {
+				const token = createTokenFromText(inputElement.value);
+				inputElement.appendChild(token);
+				inputElement.value = "";
+			}
+		};
+
 		cy.mount(
-			<MultiInput showSuggestions showValueHelpIcon>
+			<MultiInput showSuggestions showValueHelpIcon onKeyDown={fnOnKeyDown}>
 				<SuggestionItem text="Aute"></SuggestionItem>
 				<SuggestionItem text="ad"></SuggestionItem>
 				<SuggestionItem text="exercitation"></SuggestionItem>
@@ -1362,18 +1349,6 @@ describe("Keyboard handling", () => {
 				<SuggestionItem text="excepteur"></SuggestionItem>
 			</MultiInput>
 		);
-
-		cy.get("[ui5-multi-input]")
-			.then(multiInput => {
-				multiInput[0].addEventListener("keydown", (event: KeyboardEvent) => {
-					const inputElement = multiInput[0] as HTMLInputElement;
-					if (event.key === "Enter" && inputElement.value) {
-						const token = createTokenFromText(inputElement.value);
-						inputElement.appendChild(token);
-						inputElement.value = "";
-					}
-				});
-			})
 
 		cy.get("[ui5-multi-input]")
 			.shadow()
@@ -1424,42 +1399,38 @@ describe("Keyboard handling", () => {
 	});
 
 	it("should trigger change event on enter", () => {
+		const fnOnChange = (event: any) => {
+			const target = event.target as HTMLInputElement;
+			if (!target.value) {
+				return;
+			}
+
+			var isDuplicate = (event.target as MultiInput).tokens.some(function(token) {
+				return token.text === (event.target as HTMLInputElement).value
+			});
+
+			if (isDuplicate) {
+				(event.target as Input).valueState = "Negative";
+
+				setTimeout(function () {
+					(event.target as Input).valueState = "None";
+				}, 200);
+
+				return;
+			}
+
+			(event.target as HTMLElement).appendChild(createTokenFromText((event.target as HTMLInputElement).value));
+			(event.target as HTMLInputElement).value = "";
+		};
+
 		cy.mount(
-			<MultiInput showSuggestions id="token-unique" showValueHelpIcon>
+			<MultiInput showSuggestions id="token-unique" showValueHelpIcon onChange={fnOnChange}>
 				<div slot="valueStateMessage" id="value-state-wrapper">Token is already in the list</div>
 				<SuggestionItem text="Argentina" />
 			</MultiInput>
 		);
 
 		cy.get("[ui5-multi-input]")
-		.then(multiInput => {
-
-			multiInput[0].addEventListener("ui5-change", function (event) {
-				const target = event.target as HTMLInputElement;
-				if (!target.value) {
-					return;
-				}
-
-				var isDuplicate = (event.target as MultiInput).tokens.some(function(token) {
-					return token.text === (event.target as HTMLInputElement).value
-				});
-
-				if (isDuplicate) {
-					(event.target as Input).valueState = "Negative";
-
-					setTimeout(function () {
-						(event.target as Input).valueState = "None";
-					}, 200);
-
-					return;
-				}
-
-				(event.target as HTMLElement).appendChild(createTokenFromText((event.target as HTMLInputElement).value));
-				(event.target as HTMLInputElement).value = "";
-			});
-		});
-
-		 cy.get("[ui5-multi-input]")
 		 	.shadow()
 			.find("input")
 			.as("innerInput");
@@ -1504,20 +1475,15 @@ describe("Keyboard handling", () => {
 	});
 
 	it("should focus last token on ArrowLeft at start of input, keep suggestions open, and not fire change event", () => {
+		const changeSpy = cy.stub().as("changeSpy");
+
 		cy.mount(
-			<MultiInput showSuggestions>
+			<MultiInput showSuggestions onChange={changeSpy}>
 				<Token slot="tokens" text="Amet"></Token>
 				<SuggestionItem text="Bulgaria"></SuggestionItem>
 				<SuggestionItem text="Brazil"></SuggestionItem>
 			</MultiInput>
 		);
-
-		const changeSpy = cy.stub().as("changeSpy");
-
-		cy.get("[ui5-multi-input]")
-			.then(multiInput => {
-				multiInput[0].addEventListener("ui5-change", changeSpy);
-			});
 
 		cy.get("[ui5-multi-input]")
 			.shadow()
@@ -1553,20 +1519,15 @@ describe("Keyboard handling", () => {
 	});
 
 	it("should fire change event when returning from tokenizer to input via ArrowRight and pressing Tab", () => {
+		const changeSpy = cy.stub().as("changeSpy");
+
 		cy.mount(
-			<MultiInput showSuggestions>
+			<MultiInput showSuggestions onChange={changeSpy}>
 				<Token slot="tokens" text="Amet"></Token>
 				<SuggestionItem text="Bulgaria"></SuggestionItem>
 				<SuggestionItem text="Brazil"></SuggestionItem>
 			</MultiInput>
 		);
-
-		const changeSpy = cy.stub().as("changeSpy");
-
-		cy.get("[ui5-multi-input]")
-			.then(multiInput => {
-				multiInput[0].addEventListener("ui5-change", changeSpy);
-			});
 
 		cy.get("[ui5-multi-input]")
 			.shadow()
@@ -1598,20 +1559,15 @@ describe("Keyboard handling", () => {
 	});
 
 	it("should fire change event when returning from tokenizer to input via Tab and pressing Enter", () => {
+		const changeSpy = cy.stub().as("changeSpy");
+
 		cy.mount(
-			<MultiInput showSuggestions noTypeahead>
+			<MultiInput showSuggestions noTypeahead onChange={changeSpy}>
 				<Token slot="tokens" text="Amet"></Token>
 				<SuggestionItem text="Bulgaria"></SuggestionItem>
 				<SuggestionItem text="Brazil"></SuggestionItem>
 			</MultiInput>
 		);
-
-		const changeSpy = cy.stub().as("changeSpy");
-
-		cy.get("[ui5-multi-input]")
-			.then(multiInput => {
-				multiInput[0].addEventListener("ui5-change", changeSpy);
-			});
 
 		cy.get("[ui5-multi-input]")
 			.shadow()

--- a/packages/main/src/Input.ts
+++ b/packages/main/src/Input.ts
@@ -631,8 +631,8 @@ class Input extends UI5Element implements SuggestionComponent, IFormInputElement
 	previousValue: string;
 	firstRendering: boolean;
 	typedInValue: string;
-	lastConfirmedValue: string
-	isTyping: boolean
+	lastConfirmedValue: string;
+	isTyping: boolean;
 	_handleResizeBound: ResizeObserverCallback;
 	_shouldAutocomplete?: boolean;
 	_enterKeyDown?: boolean;

--- a/packages/main/src/MultiInput.ts
+++ b/packages/main/src/MultiInput.ts
@@ -13,7 +13,8 @@ import {
 	isHome,
 	isEnd,
 	isDown,
-
+	isEnter,
+	isTabNext,
 } from "@ui5/webcomponents-base/dist/Keys.js";
 import { isPhone } from "@ui5/webcomponents-base/dist/Device.js";
 import type { ITabbable } from "@ui5/webcomponents-base/dist/delegate/ItemNavigation.js";
@@ -153,6 +154,8 @@ class MultiInput extends Input implements IFormInputElement {
 
 	_skipOpenSuggestions: boolean;
 	_valueHelpIconPressed: boolean;
+	_focusInTokenizer: boolean;
+	_returningFromTokenizer: boolean;
 
 	get formValidityMessage() {
 		return MultiInput.i18nBundle.getText(FORM_MIXED_TEXTFIELD_REQUIRED);
@@ -188,6 +191,8 @@ class MultiInput extends Input implements IFormInputElement {
 		// Prevent suggestions' opening.
 		this._skipOpenSuggestions = false;
 		this._valueHelpIconPressed = false;
+		this._focusInTokenizer = false;
+		this._returningFromTokenizer = false;
 	}
 
 	valueHelpPress() {
@@ -225,6 +230,10 @@ class MultiInput extends Input implements IFormInputElement {
 		if (!this.contains(e.relatedTarget as HTMLElement) && !this.shadowRoot!.contains(e.relatedTarget as HTMLElement)) {
 			this.tokenizer._tokens.forEach(token => { token.selected = false; });
 		}
+		if (this.shadowRoot!.contains(e.relatedTarget as HTMLElement)) {
+			this._returningFromTokenizer = true;
+		}
+		this._focusInTokenizer = false;
 	}
 
 	valueHelpMouseUp() {
@@ -248,6 +257,7 @@ class MultiInput extends Input implements IFormInputElement {
 
 	_onkeydown(e: KeyboardEvent) {
 		!this._isComposing && super._onkeydown(e);
+		this._isKeyNavigation = true;
 
 		const target = e.target as HTMLInputElement;
 		const isHomeInBeginning = isHome(e) && target.selectionStart === 0;
@@ -269,9 +279,16 @@ class MultiInput extends Input implements IFormInputElement {
 
 		this._skipOpenSuggestions = false;
 
+		if ((isEnter(e) || isTabNext(e)) && this.previousValue !== this.value) {
+			this._handleChange();
+			return;
+		}
+
 		if (isShow(e)) {
 			this.valueHelpPress();
 		}
+
+		this._isKeyNavigation = false;
 	}
 
 	_onTokenizerKeydown(e: KeyboardEvent) {
@@ -281,6 +298,7 @@ class MultiInput extends Input implements IFormInputElement {
 			const lastTokenIndex = this.tokens.length - 1;
 
 			if (e.target === this.tokens[lastTokenIndex] && this.tokens[lastTokenIndex] === document.activeElement) {
+				this._returningFromTokenizer = true;
 				setTimeout(() => {
 					this.focus();
 				}, 0);
@@ -296,9 +314,25 @@ class MultiInput extends Input implements IFormInputElement {
 		// selectionStart property applies only to inputs of types text, search, URL, tel, and password
 		if (((cursorPosition === null && !this.value) || cursorPosition === 0) && lastToken) {
 			e.preventDefault();
-			lastToken.focus();
-			this.tokenizer._itemNav.setCurrentItem(lastToken);
+			this._focusToken(lastToken);
 		}
+	}
+
+	_focusToken(tokenToFocus: IToken) {
+		this._focusInTokenizer = true;
+		tokenToFocus.focus();
+		this.tokenizer._itemNav.setCurrentItem(tokenToFocus);
+	}
+
+	/**
+	 * @override
+	 */
+	_handleChange() {
+		if (this._focusInTokenizer) {
+			return;
+		}
+
+		super._handleChange();
 	}
 
 	_handleBackspace(e: KeyboardEvent) {
@@ -308,8 +342,7 @@ class MultiInput extends Input implements IFormInputElement {
 		// Only move focus to the last token if the input is empty
 		if (!this.value && lastToken) {
 			e.preventDefault();
-			lastToken.focus();
-			this.tokenizer._itemNav.setCurrentItem(lastToken);
+			this._focusToken(lastToken);
 		}
 	}
 
@@ -319,9 +352,7 @@ class MultiInput extends Input implements IFormInputElement {
 
 		if (firstToken) {
 			e.preventDefault();
-
-			firstToken.focus();
-			this.tokenizer._itemNav.setCurrentItem(firstToken);
+			this._focusToken(firstToken);
 		}
 	}
 
@@ -347,7 +378,15 @@ class MultiInput extends Input implements IFormInputElement {
 		const inputDomRef = this.getInputDOMRef();
 
 		if (e.target === inputDomRef) {
-			super._onfocusin(e);
+			if (this._returningFromTokenizer) {
+				this._returningFromTokenizer = false;
+				this.focused = true;
+				this.open = true;
+				this._inputIconFocused = false;
+				this._focusedAfterClear = false;
+			} else {
+				super._onfocusin(e);
+			}
 		}
 	}
 

--- a/packages/main/src/MultiInput.ts
+++ b/packages/main/src/MultiInput.ts
@@ -155,7 +155,6 @@ class MultiInput extends Input implements IFormInputElement {
 	_skipOpenSuggestions: boolean;
 	_valueHelpIconPressed: boolean;
 	_focusInTokenizer: boolean;
-	_returningFromTokenizer: boolean;
 
 	get formValidityMessage() {
 		return MultiInput.i18nBundle.getText(FORM_MIXED_TEXTFIELD_REQUIRED);
@@ -192,7 +191,6 @@ class MultiInput extends Input implements IFormInputElement {
 		this._skipOpenSuggestions = false;
 		this._valueHelpIconPressed = false;
 		this._focusInTokenizer = false;
-		this._returningFromTokenizer = false;
 	}
 
 	valueHelpPress() {
@@ -229,9 +227,6 @@ class MultiInput extends Input implements IFormInputElement {
 	_tokenizerFocusOut(e: FocusEvent) {
 		if (!this.contains(e.relatedTarget as HTMLElement) && !this.shadowRoot!.contains(e.relatedTarget as HTMLElement)) {
 			this.tokenizer._tokens.forEach(token => { token.selected = false; });
-		}
-		if (this.shadowRoot!.contains(e.relatedTarget as HTMLElement)) {
-			this._returningFromTokenizer = true;
 		}
 		this._focusInTokenizer = false;
 	}
@@ -298,7 +293,6 @@ class MultiInput extends Input implements IFormInputElement {
 			const lastTokenIndex = this.tokens.length - 1;
 
 			if (e.target === this.tokens[lastTokenIndex] && this.tokens[lastTokenIndex] === document.activeElement) {
-				this._returningFromTokenizer = true;
 				setTimeout(() => {
 					this.focus();
 				}, 0);
@@ -376,10 +370,10 @@ class MultiInput extends Input implements IFormInputElement {
 	 */
 	_onfocusin(e: FocusEvent) {
 		const inputDomRef = this.getInputDOMRef();
+		const wasTokenFocused = e.relatedTarget instanceof HTMLElement && e.relatedTarget.hasAttribute("ui5-token");
 
 		if (e.target === inputDomRef) {
-			if (this._returningFromTokenizer) {
-				this._returningFromTokenizer = false;
+			if (wasTokenFocused) {
 				this.focused = true;
 				this.open = true;
 				this._inputIconFocused = false;


### PR DESCRIPTION
Fixes: #13357
Do not fire change event when user navigates inside the multi-input with the arrow left and right key between inner input and tokenizer. Change event should only be fired when the user leaves the multi-input.
