### PR TITLE
fix: run version bump before build in v1 release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -364,9 +364,6 @@ jobs:
       - name: Install Dependencies
         run: yarn --immutable
 
-      - name: Build
-        run: yarn ci:releasebuild
-        
       - name: Version Bump
         env:
           GH_TOKEN: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
@@ -379,6 +376,9 @@ jobs:
                 --yes \
                 --exact \
                 --create-release github
+
+      - name: Build
+        run: yarn ci:releasebuild
 
       - name: Publish
         run: |


### PR DESCRIPTION
The v1 release job was running the build step before the version bump, causing the build to produce generated files with the old version. Reordered to match the flow used by all other release types.