### PR TITLE
fix(CEM): generation for 3rd party packages

### DIFF
--- a/packages/ai/package-scripts.cjs
+++ b/packages/ai/package-scripts.cjs
@@ -5,6 +5,7 @@ const options = {
 	portStep: 2,
 	aiPackage: true,
 	noWatchTS: true,
+	standalone: false,
 	cssVariablesTarget: "host",
 	dev: true,
 	internal: {

--- a/packages/compat/package-scripts.cjs
+++ b/packages/compat/package-scripts.cjs
@@ -5,6 +5,7 @@ const options = {
 	portStep: 2,
 	compatPackage: true,
 	noWatchTS: true,
+	standalone: false,
 	cssVariablesTarget: "host",
 	dev: true,
 	internal: {

--- a/packages/create-package/template/package-scripts.cjs
+++ b/packages/create-package/template/package-scripts.cjs
@@ -2,6 +2,7 @@ const getScripts = require("@ui5/webcomponents-tools/components-package/nps.js")
 
 const options = {
 	port: 8080,
+	standalone: false,
 };
 
 const scripts = getScripts(options);

--- a/packages/fiori/package-scripts.cjs
+++ b/packages/fiori/package-scripts.cjs
@@ -18,6 +18,7 @@ const options = {
 	dev: true,
 	fioriPackage: true,
 	noWatchTS: true,
+	standalone: false,
 	internal: {
 		cypress_code_coverage: false,
 	},

--- a/packages/main/package-scripts.cjs
+++ b/packages/main/package-scripts.cjs
@@ -5,6 +5,7 @@ const options = {
 	portStep: 2,
 	noWatchTS: true,
 	dev: true,
+	standalone: false,
 	cssVariablesTarget: "host",
 	internal: {
 		cypress_code_coverage: false,

--- a/packages/tools/components-package/nps.js
+++ b/packages/tools/components-package/nps.js
@@ -36,7 +36,7 @@ const getScripts = (options) => {
 		createIllustrationsLoadersScript[`generate-${illustrations.set}-${illustrations.collection}`] = `ui5nps-script ${LIB}generate-js-imports/illustrations.js ${illustrations.path} ${illustrations.dynamicImports.outputFile} ${illustrations.set} ${illustrations.collection} ${illustrations.dynamicImports.location} ${illustrations.dynamicImports.filterOut.join(",")}`
 	});
 
-
+	const standalone = options.standalone ?? true;
 	const tsOption = !!(!options.legacy || options.jsx);
 	const tsCommandOld = tsOption ? "tsc" : "";
 	let tsWatchCommandStandalone = tsOption ? "tsc --watch" : "";
@@ -66,6 +66,17 @@ const getScripts = (options) => {
 		viteConfig = `-c "${require.resolve("@ui5/webcomponents-tools/components-package/vite.config.js")}"`;
 	}
 
+
+	const getPrepareDefault = () => {
+		let result = `ui5nps clean prepare.all copy copyProps prepare.typescript`
+
+		if (standalone) {
+			result = `${result} generateAPI`;
+		}
+
+		return result;
+	}
+
 	const scripts = {
 		__ui5envs: {
 			UI5_CEM_MODE: typeof options.dev === "boolean" ? (options.dev ? "dev" : undefined) : options.dev,
@@ -86,7 +97,7 @@ const getScripts = (options) => {
 			styleRelated: "ui5nps build.styles build.jsonImports build.jsImports",
 		},
 		prepare: {
-			default: `ui5nps clean prepare.all copy copyProps prepare.typescript`,
+			default: getPrepareDefault(),
 			all: `ui5nps-p build.templates build.i18n prepare.styleRelated build.illustrations`, // concurently
 			styleRelated: "ui5nps build.styles build.jsonImports build.jsImports",
 			typescript: tsCommandOld,
@@ -165,6 +176,7 @@ const getScripts = (options) => {
 			bundle: `ui5nps-script ${LIB}dev-server/dev-server.mjs ${viteConfig}`,
 		},
 		generateAPI: {
+			"default": tsOption ? "ui5nps generateAPI.generateCEM generateAPI.validateCEM generateAPI.mergeCEM" : "",
 			generateCEM: `ui5nps-script "${LIB}cem/cem.js" analyze --config "${LIB}cem/custom-elements-manifest.config.mjs"`,
 			validateCEM: `ui5nps-script "${LIB}cem/validate.js"`,
 			mergeCEM: `ui5nps-script "${LIB}cem/merge.mjs"`,


### PR DESCRIPTION
  In the monorepo, CEM generation is split into three sequential steps (generate, validate, merge) that must complete across all packages before proceeding to the next.

For third-party packages this separation is unnecessary since each package has all the information needed to generate its own CEM independently. Standalone mode (default) appends all three steps directly to prepare as a single per-package operation.

This monorepo packages opt out via standalone: false.

Fixes: https://github.com/UI5/webcomponents/issues/13453