### PR TITLE
chore: update repository URL for npm provenance

### DIFF
--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -44,7 +44,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/SAP/ui5-webcomponents.git",
+    "url": "https://github.com/UI5/webcomponents.git",
     "directory": "packages/ai"
   },
   "dependencies": {

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -13,7 +13,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/SAP/ui5-webcomponents.git",
+    "url": "https://github.com/UI5/webcomponents.git",
     "directory": "packages/base"
   },
   "exports": {

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -44,7 +44,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/SAP/ui5-webcomponents.git",
+    "url": "https://github.com/UI5/webcomponents.git",
     "directory": "packages/compat"
   },
   "dependencies": {

--- a/packages/create-package/package.json
+++ b/packages/create-package/package.json
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/SAP/ui5-webcomponents.git",
+    "url": "https://github.com/UI5/webcomponents.git",
     "directory": "packages/create-package"
   },
   "dependencies": {

--- a/packages/fiori/package.json
+++ b/packages/fiori/package.json
@@ -50,7 +50,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/SAP/ui5-webcomponents.git",
+    "url": "https://github.com/UI5/webcomponents.git",
     "directory": "packages/fiori"
   },
   "dependencies": {

--- a/packages/icons-business-suite/package.json
+++ b/packages/icons-business-suite/package.json
@@ -24,7 +24,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/SAP/ui5-webcomponents.git",
+    "url": "https://github.com/UI5/webcomponents.git",
     "directory": "packages/icons-business-suite"
   },
   "dependencies": {

--- a/packages/icons-tnt/package.json
+++ b/packages/icons-tnt/package.json
@@ -24,7 +24,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/SAP/ui5-webcomponents.git",
+    "url": "https://github.com/UI5/webcomponents.git",
     "directory": "packages/icons-tnt"
   },
   "dependencies": {

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -24,7 +24,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/SAP/ui5-webcomponents.git",
+    "url": "https://github.com/UI5/webcomponents.git",
     "directory": "packages/icons"
   },
   "dependencies": {

--- a/packages/localization/package.json
+++ b/packages/localization/package.json
@@ -12,7 +12,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/SAP/ui5-webcomponents.git",
+    "url": "https://github.com/UI5/webcomponents.git",
     "directory": "packages/localization"
   },
   "exports": {

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -50,7 +50,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/SAP/ui5-webcomponents.git",
+    "url": "https://github.com/UI5/webcomponents.git",
     "directory": "packages/main"
   },
   "dependencies": {

--- a/packages/theming/package.json
+++ b/packages/theming/package.json
@@ -26,7 +26,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/SAP/ui5-webcomponents.git",
+    "url": "https://github.com/UI5/webcomponents.git",
     "directory": "packages/theming"
   },
   "dependencies": {

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/SAP/ui5-webcomponents.git",
+    "url": "https://github.com/UI5/webcomponents.git",
     "directory": "packages/tools"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

Fix npm publish provenance failure by updating `repository.url` in all package.json files from `SAP/ui5-webcomponents` to `UI5/webcomponents`.

The v2.10.1 release version bump succeeded but publish failed with:
> E422 Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "git+https://github.com/SAP/ui5-webcomponents.git", expected to match "https://github.com/UI5/webcomponents" from provenance

After merging, re-run publish: `lerna publish from-git --yes --dist-tag "hotfix-2.10"`