### PR TITLE
fix(ui5-carousel): clamp page index when items per page changes on resize

### DIFF
--- a/packages/main/cypress/specs/Carousel.cy.tsx
+++ b/packages/main/cypress/specs/Carousel.cy.tsx
@@ -799,4 +799,44 @@ describe("Carousel general interaction", () => {
 				expect(indices.every(i => i >= 0), "visibleItemsIndices should not contain negative values").to.be.true;
 			});
 	});
+
+	it("items should remain reachable after resizing increases items per page", () => {
+		const navigateStub = cy.stub().as("navigateStub");
+
+		cy.viewport(800, 500);
+
+		cy.mount(
+			<Carousel id="resizeCarousel" itemsPerPage="S2 M2 L3 XL3" onNavigate={navigateStub}>
+				<Button>Button 1</Button>
+				<Button>Button 2</Button>
+				<Button>Button 3</Button>
+			</Carousel>
+		);
+
+		// At M breakpoint (800px): 2 items per page, navigate right to show items 2 and 3
+		cy.get("#resizeCarousel")
+			.trigger("mouseover")
+			.shadow()
+			.find(".ui5-carousel-navigation-arrows .ui5-carousel-navigation-button:not(.ui5-carousel-navigation-button--hidden)")
+			.last()
+			.realClick();
+
+		cy.get("#resizeCarousel").should("have.prop", "_currentPageIndex", 1);
+		cy.get("@navigateStub").should("have.been.calledOnce");
+
+		// Resize to L breakpoint (1200px): 3 items per page, all items should fit
+		cy.viewport(1200, 500);
+
+		// Page index should be clamped to 0 since all 3 items fit on one page
+		cy.get("#resizeCarousel").should("have.prop", "_currentPageIndex", 0);
+
+		// Navigate event should fire when page index changes due to resize
+		cy.get("@navigateStub").should("have.been.calledTwice");
+
+		// All items should be visible
+		cy.get("#resizeCarousel")
+			.shadow()
+			.find(".ui5-carousel-item:not(.ui5-carousel-item--hidden)")
+			.should("have.length", 3);
+	});
 });

--- a/packages/main/src/Carousel.ts
+++ b/packages/main/src/Carousel.ts
@@ -406,15 +406,27 @@ class Carousel extends UI5Element {
 		// Change transitively effectiveItemsPerPage by modifying _width
 		this._width = this.offsetWidth;
 		this._itemWidth = Math.floor(this._width / this.effectiveItemsPerPage);
-		this._updateVisibleItems(this._currentPageIndex);
 
-		// Items per page did not change or the current,
+		// Items per page did not change,
 		// therefore page index does not need to be re-adjusted
 		if (this.effectiveItemsPerPage === previousItemsPerPage) {
+			this._updateVisibleItems(this._currentPageIndex);
 			return;
 		}
 
-		this._focusedItemIndex = clamp(this._focusedItemIndex, this._currentPageIndex, this.items.length - this.effectiveItemsPerPage);
+		// When items per page changes, clamp page index to the valid range
+		// to prevent items from becoming unreachable (e.g. when resizing
+		// from showing 2 to 3 items while on page 1 with only 3 items total).
+		const maxPageIndex = Math.max(0, this.items.length - this.effectiveItemsPerPage);
+		const newPageIndex = clamp(this._currentPageIndex, 0, maxPageIndex);
+
+		if (this._currentPageIndex !== newPageIndex) {
+			this._currentPageIndex = newPageIndex;
+			this.fireDecoratorEvent("navigate", { selectedIndex: newPageIndex });
+		}
+
+		this._updateVisibleItems(this._currentPageIndex);
+		this._focusedItemIndex = clamp(this._focusedItemIndex, this._currentPageIndex, this._currentPageIndex + this.effectiveItemsPerPage - 1);
 	}
 
 	_updateScrolling(e: ScrollEnablementEventListenerParam) {


### PR DESCRIPTION
When a user navigates forward in a Carousel and then resizes the browser so that effectiveItemsPerPage( increases to fit all items), the _currentPageIndex was not being re-adjusted. This caused earlier items to be shifted off-screen via the CSS translate3d transform, with no navigation arrows shown to scroll back — making those items permanently unreachable.

Root Cause
In _onResize(), when effectiveItemsPerPage changed, there was no clamping of _currentPageIndex to the new valid range [0, items.length - effectiveItemsPerPage]

Fix
Clamp _currentPageIndexto the valid range when effectiveItemsPerPage changes during resize
Fire the navigate event when the page index is adjusted (consistent with the event's documentation: "Fired whenever the page changes...while resizing")
Clamp _focusedItemIndex relative to the corrected page range
Testing
Added a Cypress test that:

Starts at M breakpoint (800px, 2 items/page) with 3 items
Navigates right to page index 1
Resizes to L breakpoint (1200px, 3 items/page)
Asserts page index is clamped to 0, all 3 items are visible, and the navigate event fires.

Fixes #13443
