### PR TITLE
fix(ui5-wizard): focus first visible element after pressing next/prev button

### DIFF
--- a/packages/fiori/cypress/specs/Wizard.cy.tsx
+++ b/packages/fiori/cypress/specs/Wizard.cy.tsx
@@ -633,6 +633,50 @@ describe("Wizard inside Dialog", () => {
             .find("[ui5-responsive-popover]")
             .should("be.visible");
     });
+
+    it("Tests focus management on step change", () => {
+        cy.mount(
+            <div>
+                <Dialog id="dialog" headerText="Wizard">
+                    <Wizard id="wizard">
+                        <WizardStep icon="sap-icon://home" selected titleText="Product type">
+                            <Button id="step1Button">Step 1 Button</Button>
+                        </WizardStep>
+                        <WizardStep titleText="Product Information" disabled>
+                            <Button id="step2Button">Step 2 Button</Button>
+                        </WizardStep>
+                    </Wizard>
+                    <Bar slot="footer" design="Footer">
+                        <Button id="nextButton" design="Emphasized">Next step</Button>
+                    </Bar>
+                </Dialog>
+                <Button id="openButton" style={{ display: "inline-block" }}>Open Dialog</Button>
+            </div>
+        );
+
+        cy.get("#openButton").then($button => {
+            $button[0].addEventListener("click", () => {
+                cy.get("#dialog").invoke("prop", "open", true);
+            });
+        });
+
+        cy.get("#openButton")
+            .realClick();
+
+        cy.get("#nextButton")
+            .then($button => {
+                $button[0].addEventListener("click", () => {
+                    goToWizardStep("wizard", 1);
+                });
+            });
+
+        cy.get("#nextButton")
+            .realClick();
+
+        // Verify that focus moves to the first element in the new step
+        cy.get("#step2Button")
+            .should("be.focused");
+    });
 });
 
 describe("Wizard - getFocusDomRef Method", () => {

--- a/packages/fiori/src/Wizard.ts
+++ b/packages/fiori/src/Wizard.ts
@@ -328,6 +328,7 @@ class Wizard extends UI5Element {
 
 		if (this.previouslySelectedStepIndex !== this.selectedStepIndex) {
 			this.scrollToSelectedStep();
+			this.announceStepChange();
 		}
 
 		this.attachStepsResizeObserver();
@@ -923,6 +924,24 @@ class Wizard extends UI5Element {
 			this.scrollToContentItem(this.selectedStepIndex);
 		}
 		this.selectionRequestedByScroll = false;
+	}
+
+	/**
+	 * Announces the current step change to screen readers by focusing the new step content.
+	 * @private
+	 */
+	async announceStepChange() {
+		const stepToSelect = this.slottedSteps[this.selectedStepIndex];
+		if (stepToSelect && !stepToSelect.disabled) {
+			// Focus the first focusable element in the new step to announce the change
+			// This matches the behavior when clicking wizard step headers
+			const firstElementChild = stepToSelect.firstElementChild as HTMLElement;
+			const firstFocusableElement = await getFirstFocusableElement(firstElementChild);
+
+			if (firstFocusableElement) {
+				firstFocusableElement.focus();
+			}
+		}
 	}
 
 	/**

--- a/packages/fiori/src/Wizard.ts
+++ b/packages/fiori/src/Wizard.ts
@@ -328,7 +328,7 @@ class Wizard extends UI5Element {
 
 		if (this.previouslySelectedStepIndex !== this.selectedStepIndex) {
 			this.scrollToSelectedStep();
-			this.announceStepChange();
+			this.focusFirstElementInCurrentStep();
 		}
 
 		this.attachStepsResizeObserver();
@@ -927,20 +927,21 @@ class Wizard extends UI5Element {
 	}
 
 	/**
-	 * Announces the current step change to screen readers by focusing the new step content.
+	 * Focuses the first focusable element in the currently selected step.
+	 * This helps screen readers announce the step change.
 	 * @private
 	 */
-	async announceStepChange() {
-		const stepToSelect = this.slottedSteps[this.selectedStepIndex];
-		if (stepToSelect && !stepToSelect.disabled) {
-			// Focus the first focusable element in the new step to announce the change
-			// This matches the behavior when clicking wizard step headers
-			const firstElementChild = stepToSelect.firstElementChild as HTMLElement;
-			const firstFocusableElement = await getFirstFocusableElement(firstElementChild);
+	async focusFirstElementInCurrentStep() {
+		const currentStep = this.slottedSteps[this.selectedStepIndex];
+		if (!currentStep || currentStep.disabled) {
+			return;
+		}
 
-			if (firstFocusableElement) {
-				firstFocusableElement.focus();
-			}
+		const firstElementChild = currentStep.firstElementChild as HTMLElement;
+		const firstFocusableElement = await getFirstFocusableElement(firstElementChild);
+
+		if (firstFocusableElement) {
+			firstFocusableElement.focus();
 		}
 	}
 


### PR DESCRIPTION
Fixes: #12460

Focus first focusable element (copy clicking on header title behaviour) on step change so it is announced.