### PR TITLE
fix(ui5-multi-combobox): use clipboardData for paste functionality

### DIFF
--- a/packages/main/cypress/specs/MultiComboBox.cy.tsx
+++ b/packages/main/cypress/specs/MultiComboBox.cy.tsx
@@ -4422,13 +4422,20 @@ describe("Keyboard Handling", () => {
 	});
 
 	describe("Copy/Cut/Paste keyboard shortcuts", () => {
-		const dispatchPasteEvent = () => {
+		const dispatchPasteEvent = (pastedText?: string) => {
 			cy.get("@input").then($input => {
 				const input = $input.get(0) as HTMLInputElement;
+
+				// Create clipboardData with the pasted text
+				const dataTransfer = new DataTransfer();
+				if (pastedText) {
+					dataTransfer.setData("text/plain", pastedText);
+				}
 
 				const pasteEvent = new ClipboardEvent("paste", {
 					bubbles: true,
 					cancelable: true,
+					clipboardData: dataTransfer,
 				});
 
 				input.dispatchEvent(pasteEvent);
@@ -4472,28 +4479,18 @@ describe("Keyboard Handling", () => {
 				</MultiComboBox>
 			</>)
 
-			cy.window().then(win => {
-				cy.stub(win.navigator.clipboard, "readText")
-					.as("clipboardRead")
-					.returns("22222");
-			});
-
 			cy.get("[ui5-multi-combobox]").as("mcb2");
 			cy.get("@mcb2").shadow().find("input").as("input");
 
 			cy.get("@input").realClick();
 			cy.get("@input").should("be.focused");
 
-			dispatchPasteEvent();
-
-			cy.get("@clipboardRead").should("have.been.calledOnce");
+			dispatchPasteEvent("22222");
 
 			cy.get("@input").should("have.value", "22222");
 			cy.get("@mcb2").should("have.prop", "open", true);
 
-			dispatchPasteEvent();
-
-			cy.get("@clipboardRead").should("have.been.calledTwice");
+			dispatchPasteEvent("22222");
 
 			cy.get("@input").should("have.value", "2222222222");
 		});

--- a/packages/main/src/MultiComboBox.ts
+++ b/packages/main/src/MultiComboBox.ts
@@ -995,7 +995,7 @@ class MultiComboBox extends UI5Element implements IFormInputElement {
 		});
 	}
 
-	async _handlePaste(e: ClipboardEvent) {
+	_handlePaste(e: ClipboardEvent) {
 		if (this.readonly) {
 			return;
 		}

--- a/packages/main/src/MultiComboBox.ts
+++ b/packages/main/src/MultiComboBox.ts
@@ -1002,21 +1002,22 @@ class MultiComboBox extends UI5Element implements IFormInputElement {
 
 		e.preventDefault();
 
-		const pastedText = await navigator.clipboard.readText();
-		document.execCommand("insertText", true, pastedText ?? "");
-		const inputEvent = new Event("input", {
-			bubbles: true,
-			cancelable: true,
-		});
+		// Get pasted text from clipboardData - more reliable than navigator.clipboard
+		const pastedText = e.clipboardData?.getData("text/plain") || "";
 
-		// Dispatch it
-		this._innerInput.dispatchEvent(inputEvent);
+		if (pastedText) {
+			// Use deprecated but still functional document.execCommand for cursor handling
+			document.execCommand("insertText", true, pastedText);
 
-		if (!pastedText) {
-			return;
+			// Dispatch input event to ensure the component updates
+			const inputEvent = new Event("input", {
+				bubbles: true,
+				cancelable: true,
+			});
+			this._innerInput.dispatchEvent(inputEvent);
+
+			this._handleTokenCreationUponPaste(pastedText, e);
 		}
-
-		this._handleTokenCreationUponPaste(pastedText, e);
 	}
 
 	_handleTokenCreationUponPaste(pastedText: string, e: KeyboardEvent | ClipboardEvent) {
@@ -1033,23 +1034,30 @@ class MultiComboBox extends UI5Element implements IFormInputElement {
 		if (this.readonly || isFirefox()) {
 			return;
 		}
-		e.preventDefault();
 
-		const pastedText = await navigator.clipboard.readText();
-		document.execCommand("insertText", true, pastedText ?? "");
-		const inputEvent = new Event("input", {
-			bubbles: true,
-			cancelable: true,
-		});
+		// For Shift+Insert, try to use navigator.clipboard API
+		// If it fails due to permissions, the browser's native paste will be blocked
+		try {
+			e.preventDefault();
+			const pastedText = await navigator.clipboard.readText();
 
-		// Dispatch it
-		this._innerInput.dispatchEvent(inputEvent);
+			if (pastedText) {
+				// Use deprecated but still functional document.execCommand for cursor handling
+				document.execCommand("insertText", true, pastedText);
 
-		if (!pastedText) {
-			return;
+				// Dispatch input event to ensure the component updates
+				const inputEvent = new Event("input", {
+					bubbles: true,
+					cancelable: true,
+				});
+				this._innerInput.dispatchEvent(inputEvent);
+
+				this._handleTokenCreationUponPaste(pastedText, e);
+			}
+		} catch (err) {
+			// If clipboard API fails, silently ignore
+			// Native paste won't work since we already prevented default
 		}
-
-		this._handleTokenCreationUponPaste(pastedText, e);
 	}
 
 	_handleShow(e: KeyboardEvent) {


### PR DESCRIPTION
Fixes: #13448 

Changed from navigator.clipboard.readText() to e.clipboardData.getData()
to avoid permission policy errors when pasting with Ctrl+V/CMD+V.