### PR TITLE
docs: update Angular wrapper links to fundamental-ngx

### DIFF
--- a/docs/3-frameworks/02-Angular.md
+++ b/docs/3-frameworks/02-Angular.md
@@ -2,7 +2,7 @@
 
 In this tutorial, you will learn how to use `UI5 Web Components` in an Angular application. In the second part, we will introduce `UI5 Web Components for Angular` - wrapper library for UI5 Web Components, improving their integration with Angular.
 
-**Note:** To get the best development experience, we recommend using the [UI5 Web Components for Angular](https://ui5-webcomponents-ngx.netlify.app). The library removes the need for `CUSTOM_ELEMENTS_SCHEMA` and `NO_ERRORS_SCHEMA` schemas, and supports all Angular-specific features out-of-the-box.
+**Note:** To get the best development experience, we recommend using the [UI5 Web Components for Angular](https://sap.github.io/fundamental-ngx/). The library removes the need for `CUSTOM_ELEMENTS_SCHEMA` and `NO_ERRORS_SCHEMA` schemas, and supports all Angular-specific features out-of-the-box.
 
 ## UI5 Web Components
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,7 +37,7 @@ The UI5 Web Components for React library remains valuable for its additional fea
 
 ### UI5 Web Components for Angular
 
-[UI5 Web Components for Angular](https://github.com/SAP/ui5-webcomponents-ngx) is a wrapper implementation around UI5 Web Components which to make it work with Angular without needing to use the `CUSTOM_ELEMENTS_SCHEMA` or `NO_ERRORS_SCHEMA` schemas.
+[UI5 Web Components for Angular](https://sap.github.io/fundamental-ngx/) is a wrapper implementation around UI5 Web Components which to make it work with Angular without needing to use the `CUSTOM_ELEMENTS_SCHEMA` or `NO_ERRORS_SCHEMA` schemas.
 Moreover, all Angular-specific features, such as two-way data binding and Angular Form support, work out of the box.
 
 


### PR DESCRIPTION
## Summary

- Update outdated `ui5-webcomponents-ngx.netlify.app` link to `https://sap.github.io/fundamental-ngx/`
- Update GitHub repo link in Introduction docs to point to the new docs site

## Files changed
- `docs/3-frameworks/02-Angular.md`
- `docs/README.md`