### PR TITLE
fix(ui5-shellbar): correct icon color in overflow popover

### DIFF
--- a/packages/fiori/src/themes/ShellBarItem.css
+++ b/packages/fiori/src/themes/ShellBarItem.css
@@ -21,6 +21,10 @@
 	margin: var(--_ui5-shellbar-badge-margin, -0.5rem);
 }
 
+[ui5-li]::part(icon) {
+	color: var(--sapList_TextColor);
+}
+
 [ui5-li]:after {
 	position: relative;
 	width: fit-content;

--- a/packages/fiori/src/themes/ShellBarPopover.css
+++ b/packages/fiori/src/themes/ShellBarPopover.css
@@ -7,6 +7,11 @@
 	color: var(--sapList_TextColor);
 }
 
+.ui5-shellbar-overflow-popover ::slotted([ui5-toggle-button]),
+.ui5-shellbar-overflow-popover ::slotted([ui5-button]) {
+	color: var(--sapList_TextColor);
+}
+
 .ui5-shellbar-overflow-popover [ui5-li]::part(title) {
 	font-size: var(--sapFontSize);
 }


### PR DESCRIPTION
Problem:
 - Icons in the overflow popover were retaining `--sapShell_TextColor` from the shell header, causing them to appear in the wrong color against the popover's light background.

Solution: 
 - Set the button color to `--sapList_TextColor` inside the overflow popover, consistent with the existing `[ui5-li]::part(icon)` rule and aligned with the VD spec requirement that overflow icons match the list text color.
 
 JIRA: BGSOFUIPIRIN-7069