### PR TITLE
fix(OpenUI5Support): add shared registry for patched functions

### DIFF
--- a/packages/base/src/Runtimes.ts
+++ b/packages/base/src/Runtimes.ts
@@ -56,6 +56,33 @@ const getCurrentRuntimeIndex = () => {
 };
 
 /**
+ * Compares two VersionInfo objects and returns 1 if the first is bigger, -1 if the second is bigger, and 0 if equal.
+ */
+const compareVersions = (v1: VersionInfo, v2: VersionInfo): number => {
+	if (v1.isNext || v2.isNext) {
+		return v1.buildTime - v2.buildTime;
+	}
+
+	const majorDiff = v1.major - v2.major;
+	if (majorDiff) {
+		return majorDiff;
+	}
+
+	const minorDiff = v1.minor - v2.minor;
+	if (minorDiff) {
+		return minorDiff;
+	}
+
+	const patchDiff = v1.patch - v2.patch;
+	if (patchDiff) {
+		return patchDiff;
+	}
+
+	const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: "base" });
+	return collator.compare(v1.suffix, v2.suffix);
+};
+
+/**
  * Compares two runtimes and returns 1 if the first is of a bigger version, -1 if the second is of a bigger version, and 0 if equal
  * @param index1 The index of the first runtime to compare
  * @param index2 The index of the second runtime to compare
@@ -74,33 +101,7 @@ const compareRuntimes = (index1: number, index2: number) => {
 		throw new Error("Invalid runtime index supplied");
 	}
 
-	// If any of the two is a next version, bigger buildTime wins
-	if (runtime1.isNext || runtime2.isNext) {
-		return runtime1.buildTime - runtime2.buildTime;
-	}
-
-	// If major versions differ, bigger one wins
-	const majorDiff = runtime1.major - runtime2.major;
-	if (majorDiff) {
-		return majorDiff;
-	}
-
-	// If minor versions differ, bigger one wins
-	const minorDiff = runtime1.minor - runtime2.minor;
-	if (minorDiff) {
-		return minorDiff;
-	}
-
-	// If patch versions differ, bigger one wins
-	const patchDiff = runtime1.patch - runtime2.patch;
-	if (patchDiff) {
-		return patchDiff;
-	}
-
-	// Bigger suffix wins, f.e. rc10 > rc9
-	// Important: suffix is alphanumeric, must use natural compare
-	const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: "base" });
-	const result = collator.compare(runtime1.suffix, runtime2.suffix);
+	const result = compareVersions(runtime1, runtime2);
 
 	compareCache.set(cacheIndex, result);
 	return result;
@@ -122,6 +123,7 @@ export {
 	getCurrentRuntimeIndex,
 	registerCurrentRuntime,
 	compareRuntimes,
+	compareVersions,
 	setRuntimeAlias,
 	getAllRuntimes,
 };

--- a/packages/base/src/features/patchPopup.ts
+++ b/packages/base/src/features/patchPopup.ts
@@ -1,6 +1,29 @@
 // OpenUI5's Control.js subset
 import getSharedResource from "../getSharedResource.js";
 import insertOpenUI5PopupStyles from "./insertOpenUI5PopupStyles.js";
+import VersionInfo from "../generated/VersionInfo.js";
+import { compareVersions } from "../Runtimes.js";
+
+type PatchedFunctionRecord = {
+	version: VersionInfo | undefined;
+	originalFn: (...args: any[]) => any;
+};
+
+type PatchedFunctionsRegistry = Record<string, PatchedFunctionRecord>;
+
+const PatchedFunctions = getSharedResource<PatchedFunctionsRegistry>("PatchedFunctions", {});
+
+const shouldRepatch = (key: string): boolean => {
+	const existing = PatchedFunctions[key];
+	if (!existing) {
+		return true;
+	}
+
+	if (!existing.version) {
+		return true;
+	}
+	return compareVersions(VersionInfo, existing.version) > 0;
+};
 
 type Control = {
 	getDomRef: () => HTMLElement | null,
@@ -173,7 +196,11 @@ const isNativePopoverOpen = (root: Document | ShadowRoot = document): boolean =>
 };
 
 const patchDialog = (Dialog: OpenUI5DialogClass) => {
-	const origOnsapescape = Dialog.prototype.onsapescape;
+	const key = "Dialog.prototype.onsapescape";
+	if (shouldRepatch(key)) {
+		PatchedFunctions[key] = { version: VersionInfo, originalFn: PatchedFunctions[key]?.originalFn ?? Dialog.prototype.onsapescape };
+	}
+	const origOnsapescape = PatchedFunctions[key].originalFn;
 	Dialog.prototype.onsapescape = function onsapescape(...args: any[]) {
 		if (hasWebComponentPopupAbove(this.oPopup)) {
 			return;
@@ -184,7 +211,11 @@ const patchDialog = (Dialog: OpenUI5DialogClass) => {
 };
 
 const patchOpen = (Popup: OpenUI5PopupClass) => {
-	const origOpen = Popup.prototype.open;
+	const key = "Popup.prototype.open";
+	if (shouldRepatch(key)) {
+		PatchedFunctions[key] = { version: VersionInfo, originalFn: PatchedFunctions[key]?.originalFn ?? Popup.prototype.open };
+	}
+	const origOpen = PatchedFunctions[key].originalFn;
 	Popup.prototype.open = function open(...args: any[]) {
 		origOpen.apply(this, args); // call open first to initiate opening
 		openNativePopoverForOpenUI5(this);
@@ -197,7 +228,11 @@ const patchOpen = (Popup: OpenUI5PopupClass) => {
 };
 
 const patchClosed = (Popup: OpenUI5PopupClass) => {
-	const _origClosed = Popup.prototype._closed;
+	const key = "Popup.prototype._closed";
+	if (shouldRepatch(key)) {
+		PatchedFunctions[key] = { version: VersionInfo, originalFn: PatchedFunctions[key]?.originalFn ?? Popup.prototype._closed };
+	}
+	const _origClosed = PatchedFunctions[key].originalFn;
 	Popup.prototype._closed = function _closed(...args: any[]) {
 		closeNativePopoverForOpenUI5(this);
 		_origClosed.apply(this, args); // only then call _close
@@ -206,7 +241,11 @@ const patchClosed = (Popup: OpenUI5PopupClass) => {
 };
 
 const patchFocusEvent = (Popup: OpenUI5PopupClass) => {
-	const origFocusEvent = Popup.prototype.onFocusEvent;
+	const key = "Popup.prototype.onFocusEvent";
+	if (shouldRepatch(key)) {
+		PatchedFunctions[key] = { version: VersionInfo, originalFn: PatchedFunctions[key]?.originalFn ?? Popup.prototype.onFocusEvent };
+	}
+	const origFocusEvent = PatchedFunctions[key].originalFn;
 	Popup.prototype.onFocusEvent = function onFocusEvent(...args: any[]) {
 		if (!hasWebComponentPopupAbove(this)) {
 			origFocusEvent.apply(this, args);


### PR DESCRIPTION
Store patched OpenUI5 prototype functions in a shared resource (PatchedFunctions) that persists across runtime instances. Each entry records the original (unwrapped) function and the runtime version that installed the patch.

On each init, the patch is skipped if an equal or newer version already owns it, and force-applied if no version is recorded (pre-existing patch from older runtimes). This prevents double-wrapping the prototype chain while ensuring the newest loaded runtime always owns the active wrapper.

Extract compareVersions from compareRuntimes in Runtimes.ts to enable direct VersionInfo comparisons without requiring registered runtime indices.

Isolated example:
https://stackblitz.com/edit/vitejs-vite-gwkgpaa6?file=index.html

Fixes: https://github.com/UI5/webcomponents/issues/13406