### PR TITLE
chore(ui5-date-picker, ui5-range-slider): use i18n bundle in tests instead of hardcoded strings

### DIFF
--- a/packages/main/cypress/specs/DatePicker.cy.tsx
+++ b/packages/main/cypress/specs/DatePicker.cy.tsx
@@ -2,6 +2,7 @@ import "../../src/Assets.js";
 import { setLanguage } from "@ui5/webcomponents-base/dist/config/Language.js";
 import DatePicker from "../../src/DatePicker.js";
 import Label from "../../src/Label.js";
+import { DATEPICKER_POPOVER_ACCESSIBLE_NAME } from "../../src/generated/i18n/i18n-defaults.js";
 
 describe("Date Picker Tests", () => {
 
@@ -1994,7 +1995,7 @@ describe("Accessibility", () => {
 		cy.get<DatePicker>("@datePicker")
 			.shadow()
 			.find("ui5-responsive-popover")
-			.should("have.attr", "accessible-name", `Choose Date for ${LABEL}`);
+			.should("have.attr", "accessible-name", DatePicker.i18nBundle.getText(DATEPICKER_POPOVER_ACCESSIBLE_NAME, LABEL));
 	});
 
 	it("picker popover accessible name", () => {
@@ -2010,7 +2011,7 @@ describe("Accessibility", () => {
 		cy.get<DatePicker>("@datePicker")
 			.shadow()
 			.find("ui5-responsive-popover")
-			.should("have.attr", "accessible-name", `Choose Date for ${LABEL}`);
+			.should("have.attr", "accessible-name", DatePicker.i18nBundle.getText(DATEPICKER_POPOVER_ACCESSIBLE_NAME, LABEL));
 	});
 
 	it("accessibleDescription property", () => {

--- a/packages/main/cypress/specs/RangeSlider.cy.tsx
+++ b/packages/main/cypress/specs/RangeSlider.cy.tsx
@@ -1,4 +1,5 @@
 import RangeSlider from "../../src/RangeSlider.js";
+import { RANGE_SLIDER_START_HANDLE_DESCRIPTION, RANGE_SLIDER_END_HANDLE_DESCRIPTION } from "../../src/generated/i18n/i18n-defaults.js";
 
 describe("Testing Range Slider interactions", () => {
 	it("Changing the current startValue is reflected", () => {
@@ -874,7 +875,7 @@ describe("Testing events", () => {
 			const startValue = rangeSlider.startValue;
 
 			cy.get("@startHandle")
-				.should("have.attr", "aria-label", "Left handle");
+				.should("have.attr", "aria-label", RangeSlider.i18nBundle.getText(RANGE_SLIDER_START_HANDLE_DESCRIPTION));
 
 			cy.get("@startHandle")
 				.should("have.attr", "aria-valuemin", `${minValue}`);
@@ -903,7 +904,7 @@ describe("Testing events", () => {
 			const endValue = rangeSlider.endValue;
 
 			cy.get("@endHandle")
-				.should("have.attr", "aria-label", "Right handle");
+				.should("have.attr", "aria-label", RangeSlider.i18nBundle.getText(RANGE_SLIDER_END_HANDLE_DESCRIPTION));
 
 			cy.get("@endHandle")
 				.should("have.attr", "aria-valuemin", `${minValue}`);
@@ -929,8 +930,8 @@ describe("Testing events", () => {
 			.find("[ui5-slider-handle][handle-type='End']")
 			.as("endHandle");
 
-		cy.get("@startHandle").should("have.attr", "aria-label", "Left handle");
-		cy.get("@endHandle").should("have.attr", "aria-label", "Right handle");
+		cy.get("@startHandle").should("have.attr", "aria-label", RangeSlider.i18nBundle.getText(RANGE_SLIDER_START_HANDLE_DESCRIPTION));
+		cy.get("@endHandle").should("have.attr", "aria-label", RangeSlider.i18nBundle.getText(RANGE_SLIDER_END_HANDLE_DESCRIPTION));
 
 		// Drag start handle past end handle to swap values using real events
 		cy.get("@startHandle")
@@ -938,8 +939,8 @@ describe("Testing events", () => {
 			.realMouseMove(100, 0)
 			.realMouseUp();
 
-		cy.get("@startHandle").should("have.attr", "aria-label", "Left handle");
-		cy.get("@endHandle").should("have.attr", "aria-label", "Right handle");
+		cy.get("@startHandle").should("have.attr", "aria-label", RangeSlider.i18nBundle.getText(RANGE_SLIDER_START_HANDLE_DESCRIPTION));
+		cy.get("@endHandle").should("have.attr", "aria-label", RangeSlider.i18nBundle.getText(RANGE_SLIDER_END_HANDLE_DESCRIPTION));
 	});
 
 	it("Click anywhere in the Range Slider should focus the closest handle", () => {
@@ -1811,12 +1812,12 @@ describe("Accessibility", () => {
 		cy.get("[ui5-range-slider]")
 			.shadow()
 			.find("[ui5-slider-handle][handle-type='Start']")
-			.should("have.attr", "aria-label", `${labelText} Left handle`);
+			.should("have.attr", "aria-label", `${labelText} ${RangeSlider.i18nBundle.getText(RANGE_SLIDER_START_HANDLE_DESCRIPTION)}`);
 
 		cy.get("[ui5-range-slider]")
 			.shadow()
 			.find("[ui5-slider-handle][handle-type='End']")
-			.should("have.attr", "aria-label", `${labelText} Right handle`);
+			.should("have.attr", "aria-label", `${labelText} ${RangeSlider.i18nBundle.getText(RANGE_SLIDER_END_HANDLE_DESCRIPTION)}`);
 	});
 
 	it("Aria attributes of the progress bar are set correctly", () => {


### PR DESCRIPTION
## Summary

- Replaces hardcoded accessible name strings in DatePicker and RangeSlider tests with `i18nBundle.getText()` calls
- Tests now dynamically resolve the expected text from the message bundle, making them resilient to translation updates

### Root cause

- `DatePicker.cy.tsx` asserted `"Choose Date for ..."` but the English source bundle was changed to `"Enter date for ..."` in #13100
- `RangeSlider.cy.tsx` asserted `"Left handle"/"Right handle"` but the English source bundle was changed to `"Minimum"/"Maximum"` in #13316

Both caused failures on the Translation Delivery PR #13427.

### Changes

| File | Fix |
|------|-----|
| `DatePicker.cy.tsx` | Use `DatePicker.i18nBundle.getText(DATEPICKER_POPOVER_ACCESSIBLE_NAME, label)` |
| `RangeSlider.cy.tsx` | Use `RangeSlider.i18nBundle.getText(RANGE_SLIDER_START_HANDLE_DESCRIPTION)` / `RANGE_SLIDER_END_HANDLE_DESCRIPTION` |

## Test plan

- [ ] `yarn test:cypress:single cypress/specs/DatePicker.cy.tsx` passes (suite-2)
- [ ] `yarn test:cypress:single cypress/specs/RangeSlider.cy.tsx` passes (suite-3)

Fixes CI failures in #13427.