### PR TITLE
feat(ui5-shellbar): align padding and logo styles with VD spec

### DIFF
--- a/packages/fiori/src/themes/ShellBarBranding.css
+++ b/packages/fiori/src/themes/ShellBarBranding.css
@@ -10,7 +10,7 @@
 	overflow: hidden;
 	display: flex;
 	align-items: center;
-	padding-block: 0.25rem;
+	padding-block: 0.125rem;
 	padding-inline: 0.25rem 0.5rem;
 	box-sizing: border-box;
 	cursor: pointer;
@@ -55,7 +55,7 @@
 	overflow: hidden;
 	display: flex;
 	align-items: center;
-	padding: .25rem .5rem .25rem .25rem;
+	padding: 0.125rem 0.5rem 0.125rem 0.25rem;
 	box-sizing: border-box;
 	cursor: pointer;
 	background: var(--sapButton_Lite_Background);
@@ -67,6 +67,7 @@
 
 ::slotted([slot="logo"]) {
 	max-height: 2rem;
+	width: auto;
 	padding-inline: 0.25rem;
 	vertical-align: middle;
 }

--- a/packages/fiori/src/themes/ShellBarBranding.css
+++ b/packages/fiori/src/themes/ShellBarBranding.css
@@ -10,6 +10,7 @@
 	overflow: hidden;
 	display: flex;
 	align-items: center;
+	height: 2.25rem;
 	padding-block: 0.125rem;
 	padding-inline: 0.25rem 0.5rem;
 	box-sizing: border-box;
@@ -19,7 +20,7 @@
 	color: var(--sapShell_TextColor);
 	/* fix cutting of the focus outline */
 	margin-inline-start: 0.125rem;
-	margin-inline-end: .5rem;
+	margin-inline-end: 0.5rem;
 }
 
 .ui5-shellbar-branding-root:focus {
@@ -55,7 +56,7 @@
 	overflow: hidden;
 	display: flex;
 	align-items: center;
-	padding: 0.125rem 0.5rem 0.125rem 0.25rem;
+	padding: 0.125rem 0.25rem 0.125rem 0.25rem;
 	box-sizing: border-box;
 	cursor: pointer;
 	background: var(--sapButton_Lite_Background);
@@ -66,8 +67,9 @@
 }
 
 ::slotted([slot="logo"]) {
-	max-height: 2rem;
+	max-height: 1.875rem;
 	width: auto;
+	padding-block: 0.0625rem;
 	padding-inline: 0.25rem;
 	vertical-align: middle;
 }


### PR DESCRIPTION
Aligns `ShellBarBranding.css` with the Shell Bar (Horizon) Visual Design specification.

## Changes

- **Container height**: added explicit `height: 2.25rem` (36px) to `.ui5-shellbar-branding-root` to cap the branding area at the correct size
- **Container padding-block**: reduced from `0.25rem` (4px) to `0.125rem` (2px) top and bottom, as specified
- **Container padding-inline**: kept at `0.25rem` left / `0.5rem` right (4px / 8px) — already correct
- **Standalone logo right spacing**: reduced `.ui5-shellbar-logo-area` right padding from `0.5rem` to `0.25rem` to avoid the double 8px gap that was appearing when no product identifier is present
- **Slotted logo max-height**: reduced from `2rem` (32px) to `1.875rem` (30px) with `1px` top/bottom `padding-block` breathing space, so the logo renders at the correct 30px height without being clipped
- **Slotted logo width**: added `width: auto` to ensure proportional scaling regardless of the logo's original dimensions

## Spec reference
Shell Bar (Horizon) — Branding section:
- Branding container: height `2.25rem`, padding top/bottom `2px`, padding left `0.25rem` (4px), padding right `0.5rem` (8px)
- Logo: max-height `2rem`, 1px top/bottom breathing space, padding left/right `0.25rem` (4px)
- Spacing between logo and product identifier: `0.25rem` (4px)

JIRA: BGSOFUIPIRIN-7065