### PR TITLE
chore(ci): add GitHub environment for OIDC token protection

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,6 +29,7 @@ jobs:
   # ✅ Job 1: Stable Release Flow
   stable-release:
     if: ${{ github.event.inputs.release_type == 'stable' }}
+    environment: "npmjs:@ui5/webcomponents"
     permissions:
       contents: write
       id-token: write
@@ -135,6 +136,7 @@ jobs:
   # ✅ Job 2: RC Release Flow
   rc-release:
     if: ${{ github.event.inputs.release_type == 'rc' || github.event_name == 'schedule' }}
+    environment: "npmjs:@ui5/webcomponents"
     permissions:
       contents: write
       id-token: write
@@ -228,6 +230,7 @@ jobs:
   # ✅ Job 3: Hotfix Release Flow
   hotfix-release:
     if: ${{ github.event.inputs.release_type == 'hotfix' && github.event.inputs.new_version != '' }}
+    environment: "npmjs:@ui5/webcomponents"
     permissions:
       contents: write
       id-token: write
@@ -298,6 +301,7 @@ jobs:
   # ✅ Job 4: Experimental Release Flow
   experimental-release:
     if: ${{ github.event.inputs.release_type == 'experimental' }}
+    environment: "npmjs:@ui5/webcomponents"
     permissions:
       contents: write
       id-token: write
@@ -344,6 +348,7 @@ jobs:
   # ✅ Job 5: V1 Release Flow
   v1-release:
     if: ${{ github.event.inputs.release_type == 'v1' && github.event.inputs.new_version != '' }}
+    environment: "npmjs:@ui5/webcomponents"
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
## Summary

Per OSPO recommendation, adds the `npmjs:@ui5/webcomponents` GitHub Actions environment to all 5 publish jobs in the release workflow. This protects the OIDC token used for npm trusted publishing by gating deploys through an environment with required reviewers.

- Adds `environment: "npmjs:@ui5/webcomponents"` to stable, rc, hotfix, experimental, and v1 release jobs
- The environment is already created in repo settings with required reviewers enabled

## What this means in practice

- **Manual releases (stable, hotfix, experimental, v1):** The job will pause for environment approval. If the person who triggered the workflow is on the required reviewers list, they can self-approve (since "Prevent self-review" is unchecked).
- **Scheduled RC release (Thursday 8 AM UTC):** Since there's no human trigger for cron events, it will always pause waiting for a required reviewer to approve manually in the Actions UI. If nobody approves, it times out.

## Remaining steps (outside this PR)

On npmjs.com, the trusted publisher configuration for each published package needs to be updated to include the environment name. Per package, the trusted publisher config should be:

| Field | Value |
|-------|-------|
| Repository owner | `SAP` |
| Repository | `ui5-webcomponents` |
| Workflow filename | `release.yaml` |
| Environment | `npmjs:@ui5/webcomponents` |

This needs to be done via the `sap-ospo-admin` user for all published packages (`@ui5/webcomponents`, `@ui5/webcomponents-base`, `@ui5/webcomponents-fiori`, `@ui5/webcomponents-theming`, `@ui5/webcomponents-localization`, `@ui5/webcomponents-icons`, `@ui5/webcomponents-icons-tnt`, `@ui5/webcomponents-icons-business-suite`, `@ui5/webcomponents-ai`, `@ui5/webcomponents-compat`, `@ui5/webcomponents-tools`).

> **Note:** Without the npm-side change, publishing still works (npm doesn't reject the extra environment claim). But the full security benefit — npm validating that the token originated from a protected environment — only applies once both sides are configured.