### PR TITLE
feat(ui5-shellbar): align hover state colors for shell action buttons

### DIFF
--- a/packages/fiori/src/themes/ShellBar.css
+++ b/packages/fiori/src/themes/ShellBar.css
@@ -99,7 +99,9 @@
 }
 
 .ui5-shellbar-action-button:hover {
-	color: var(--sapShell_TextColor);
+	background: var(--sapShell_Hover_Background);
+	border-color: var(--sapButton_Lite_Hover_BorderColor);
+	color: var(--sapShell_InteractiveTextColor);
 }
 
 .ui5-shellbar-action-button[active] {

--- a/packages/fiori/src/themes/ShellBarItem.css
+++ b/packages/fiori/src/themes/ShellBarItem.css
@@ -9,7 +9,9 @@
 }
 
 .ui5-shellbar-action-button:hover {
-	color: var(--sapShell_TextColor);
+	background: var(--sapShell_Hover_Background);
+	border-color: var(--sapButton_Lite_Hover_BorderColor);
+	color: var(--sapShell_InteractiveTextColor);
 }
 
 .ui5-shellbar-action-button[active] {


### PR DESCRIPTION
Shell action buttons on hover were missing the shell-specific background and border-color, and used `--sapShell_TextColor` instead of the required `--sapShell_InteractiveTextColor` for the icon color.

Align hover state with the Shell Button Specification:                                                                                          
  - background: `--sapShell_Hover_Background`                                                                                                       
  - border-color: `--sapButton_Lite_Hover_BorderColor`                                                                                              
  - color: `--sapShell_InteractiveTextColor`
  
  JIRA: BGSOFUIPIRIN-7063