### PR TITLE
refactor(ui5-table): warn at runtime for non-interactive navigation

### DIFF
--- a/packages/main/cypress/specs/Table.cy.tsx
+++ b/packages/main/cypress/specs/Table.cy.tsx
@@ -756,6 +756,18 @@ describe("Table - Fixed Header", () => {
 
 		check(50, "#row-100");
 	});
+
+	it("creates a stacking context on the table host", () => {
+		cy.mount(
+			<Table id="table" accessibleNameRef="title" noDataText="No data found">
+				<TableHeaderRow slot="headerRow">
+					<TableHeaderCell><span>ColumnA</span></TableHeaderCell>
+				</TableHeaderRow>
+			</Table>,
+		);
+
+		cy.get("#table").should("have.css", "z-index", "0");
+	});
 });
 
 describe("Table - Horizontal Scrolling", () => {

--- a/packages/main/cypress/specs/TableCustomAnnouncement.cy.tsx
+++ b/packages/main/cypress/specs/TableCustomAnnouncement.cy.tsx
@@ -32,7 +32,6 @@ const {
 	TABLE_SELECTION: { defaultText: SELECTION },
 	TABLE_COLUMN_HEADER_ROW: { defaultText: COLUMN_HEADER_ROW },
 	TABLE_ROW_SELECTED: { defaultText: SELECTED },
-	TABLE_ROW_NAVIGABLE: { defaultText: NAVIGABLE },
 	TABLE_ROW_NAVIGATED: { defaultText: NAVIGATED },
 	TABLE_ROW_ACTIVE: { defaultText: ACTIVE },
 } = Translations;
@@ -59,7 +58,7 @@ describe("Cell Custom Announcement - More details", () => {
 					<TableCell><input id="row1-input1" value="Row1Input1"/><input id="row1-input2" value="Row1Input2" hidden/></TableCell>
 					<TableCell><div id="row1-div"><b></b></div></TableCell>
 					<TableCell><Button id="row1-button">Row1Cell3</Button></TableCell>
-					<TableRowActionNavigation slot="actions" id="row1-nav-action"></TableRowActionNavigation>
+					<TableRowActionNavigation slot="actions" id="row1-nav-action" interactive={true}></TableRowActionNavigation>
 					<TableRowAction slot="actions" id="row1-add-action" icon={add} text="Add"></TableRowAction>
 					<TableRowAction slot="actions" id="row1-edit-action" icon={edit} text="Edit"></TableRowAction>
 				</TableRow>
@@ -146,22 +145,25 @@ describe("Cell Custom Announcement - More details", () => {
 		checkAnnouncement(`Button with custom accessibility text . ${CONTAINS_CONTROL}`, true);
 
 		cy.realPress("ArrowRight"); // Row actions cell
-		checkAnnouncement(Table.i18nBundle.getText(MULTIPLE_ACTIONS, 2));
+		checkAnnouncement(Table.i18nBundle.getText(MULTIPLE_ACTIONS, 3));
 		cy.focused().should("have.attr", "aria-colindex", "6")
 					.should("have.attr", "role", "gridcell")
 					.then($rowActionsCell => {
 						const rowActionsCell = $rowActionsCell[0];
 						const invisibleText = document.getElementById("ui5-invisible-text");
-						expect(rowActionsCell.ariaLabelledByElements[0]).to.equal(invisibleText);
+						expect(rowActionsCell.ariaLabelledByElements![0]).to.equal(invisibleText);
 						rowActionsCell.blur();
 						expect(rowActionsCell.ariaLabelledByElements).to.equal(null);
 						rowActionsCell.focus();
 					});
 
 		cy.get("#row1-edit-action").invoke("remove");
-		checkAnnouncement(ONE_ROW_ACTION, true);
+		checkAnnouncement(Table.i18nBundle.getText(MULTIPLE_ACTIONS, 2), true);
 
 		cy.get("#row1-add-action").invoke("remove");
+		checkAnnouncement(ONE_ROW_ACTION, true);
+
+		cy.get("#row1-nav-action").invoke("remove");
 		checkAnnouncement(EMPTY, true);
 
 		cy.get("@row1NavigatedCell").should("have.attr", "role", "none")
@@ -251,7 +253,7 @@ describe("Row Custom Announcement - Less details", () => {
 						C4
 						<Button id="row1-button">C4Button</Button>
 					</TableCell>
-					<TableRowActionNavigation slot="actions" id="row1-nav-action"></TableRowActionNavigation>
+					<TableRowActionNavigation slot="actions" id="row1-nav-action" interactive={true}></TableRowActionNavigation>
 					<TableRowAction slot="actions" id="row1-add-action" icon={add} text="Add"></TableRowAction>
 				</TableRow>
 			</Table>
@@ -283,7 +285,7 @@ describe("Row Custom Announcement - Less details", () => {
 		});
 	});
 
-	function checkAnnouncement(expectedText: string, focusAgain = false, check = "contains") {
+	function checkAnnouncement(expectedText: string, focusAgain = false, check: "contains" | "equal" = "contains") {
 		focusAgain && cy.focused().then($el => {
 			if ($el.attr("ui5-table-header-row") !== undefined) {
 				cy.realPress("ArrowDown");
@@ -301,14 +303,14 @@ describe("Row Custom Announcement - Less details", () => {
 
 	it("should announce table rows", () => {
 		cy.get("@row1").realClick();
-		checkAnnouncement(`Row . 2 of 2 . ${SELECTED} . ${NAVIGABLE} . H1`);
+		checkAnnouncement(`Row . 2 of 2 . ${SELECTED} . ${ACTIVE} . H1`);
 		checkAnnouncement(`H1 . R1C1 . H2 . ${CONTAINS_CONTROLS} . H3 . ${EMPTY} . H4 . C4 Button C4Button`);
-		checkAnnouncement(ONE_ROW_ACTION);
+		checkAnnouncement(Table.i18nBundle.getText(MULTIPLE_ACTIONS, 2));
 		cy.focused().should("have.attr", "aria-rowindex", "2")
 					.should("have.attr", "role", "row");
 
 		cy.get("#selection").invoke("attr", "selected", "");
-		checkAnnouncement(`Row . 2 of 2 . ${NAVIGABLE}`, true);
+		checkAnnouncement(`Row . 2 of 2 . ${ACTIVE}`, true);
 
 		cy.get("#row1-nav-action").invoke("prop", "interactive", true);
 		checkAnnouncement(`Row . 2 of 2 . ${ACTIVE} . H1`, true);

--- a/packages/main/cypress/specs/TableRowActions.cy.tsx
+++ b/packages/main/cypress/specs/TableRowActions.cy.tsx
@@ -59,7 +59,7 @@ describe("TableRowActions", () => {
 					<TableRowAction slot="actions" icon={add} text="Add" invisible={true}></TableRowAction>
 				</TableRow>
 				<TableRow>
-					<TableRowActionNavigation slot="actions"></TableRowActionNavigation>
+					<TableRowActionNavigation slot="actions" interactive={true}></TableRowActionNavigation>
 				</TableRow>
 				<TableRow id="navigationRow">
 					<TableRowActionNavigation slot="actions" id="navigationAction" interactive={true}></TableRowActionNavigation>
@@ -71,7 +71,7 @@ describe("TableRowActions", () => {
 			checkTemplateColumn(`${8 + 36 + 8}px`);
 			cy.get("@row1").find("[icon=add]").shadow().find("ui5-button").should("exist");
 			cy.get("@row2").find("[icon=add]").should("have.css", "display", "block");
-			cy.get("@row3").find("ui5-table-row-action-navigation").shadow().find("ui5-icon").should("have.attr", "name", "navigation-right-arrow");
+			cy.get("@row3").find("ui5-table-row-action-navigation").shadow().find("ui5-button").should("have.attr", "icon", "navigation-right-arrow");
 			cy.get("@row4").find("ui5-table-row-action-navigation").shadow().find("ui5-button").should("have.attr", "icon", "navigation-right-arrow");
 
 			cy.get("#addAction").invoke("on", "click", cy.stub().as("addActionClick"));
@@ -213,7 +213,7 @@ describe("TableRowActions", () => {
 		it("tests that the aligment of navigation is more important than avoiding overflow", () => {
 			mountTable(3, () => <>
 				<TableRow>
-					<TableRowActionNavigation slot="actions" invisible={true}></TableRowActionNavigation>
+					<TableRowActionNavigation slot="actions" invisible={true} interactive={true}></TableRowActionNavigation>
 					<TableRowAction slot="actions" icon={add} text="Add"></TableRowAction>
 					<TableRowAction slot="actions" icon={edit} text="Edit"></TableRowAction>
 					<TableRowAction slot="actions" icon={deleteIcon} text="Delete"></TableRowAction>

--- a/packages/main/src/TableRowActionBase.ts
+++ b/packages/main/src/TableRowActionBase.ts
@@ -125,7 +125,7 @@ abstract class TableRowActionBase extends UI5Element {
 	}
 
 	get _isInteractive() {
-		return this.getRenderInfo().interactive;
+		return this.getRenderInfo().interactive !== false;
 	}
 }
 

--- a/packages/main/src/TableRowActionNavigation.ts
+++ b/packages/main/src/TableRowActionNavigation.ts
@@ -31,7 +31,7 @@ class TableRowActionNavigation extends TableRowActionBase {
 	 * @deprecated As of version 2.20.0, the navigation icon is deprecated.
 	 * For better accessibility, the interactive mode which renders a button, must be used instead. To handle the action, attach a listener to the `click` event.
 	 * If the navigation should be triggered when a row is pressed, set the row's `interactive` property and use the `row-click` event of the `ui5-table`.
-	 * This property will be removed in a future release.
+	 * This property will be removed in the next major version.
 	 */
 	@property({ type: Boolean })
 	interactive = false;
@@ -41,6 +41,19 @@ class TableRowActionNavigation extends TableRowActionBase {
 
 	isFixedAction() {
 		return true;
+	}
+
+	onEnterDOM(): void {
+		super.onEnterDOM();
+		if (!this.interactive) {
+			// eslint-disable-next-line no-console
+			console.warn(
+				"[ui5-table-row-action-navigation] The non-interactive (icon) rendering mode is deprecated and will be removed in the next major version. "
+				+ "Set the `interactive` property to render the navigation action as an accessible button and handle the action via the `click` event. "
+				+ "If the navigation should be triggered when a row is pressed, set the row's `interactive` property and use the `row-click` event of `ui5-table`. "
+				+ "Button rendering will become the only supported behavior, and the `interactive` property will then be removed.",
+			);
+		}
 	}
 
 	getRenderInfo() {

--- a/packages/main/src/themes/Table.css
+++ b/packages/main/src/themes/Table.css
@@ -1,6 +1,7 @@
 :host {
 	display: block;
 	position: relative;
+	z-index: 0; /* create a stacking context for the sticky elements */
 	color: var(--sapList_TextColor);
 	font: var(--sapFontSize) var(--sapFontFamily);
 }
@@ -36,8 +37,4 @@
 	inset: 0;
 	height: 100%;
 	z-index: 2;
-}
-
-:host([loading]) #table:has(#loading[_is-busy]) ::slotted(*) {
-	opacity: var(--sapContent_DisabledOpacity);
 }

--- a/packages/website/docs/_samples/main/Table/Basic/main.js
+++ b/packages/website/docs/_samples/main/Table/Basic/main.js
@@ -1,4 +1,4 @@
 import "@ui5/webcomponents/dist/Table.js";
 import "@ui5/webcomponents/dist/TableHeaderRow.js";
 import "@ui5/webcomponents/dist/TableHeaderCell.js";
-import "@ui5/webcomponents/dist/Label.js";
+import "@ui5/webcomponents/dist/Text.js";

--- a/packages/website/docs/_samples/main/Table/Basic/sample.html
+++ b/packages/website/docs/_samples/main/Table/Basic/sample.html
@@ -20,25 +20,25 @@
 				<ui5-table-header-cell id="priceCol" width="220px">Price</ui5-table-header-cell>
 			</ui5-table-header-row>
 			<ui5-table-row>
-				<ui5-table-cell><ui5-label><b>Notebook Basic 15</b><br>HT-1000</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>Very Best Screens</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>30 x 18 x 3 cm</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>4.2</b> KG</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label><b>956</b> EUR</ui5-label></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>Notebook Basic 15</b><br>HT-1000</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>Very Best Screens</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>30 x 18 x 3 cm</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text style="color: #2b7c2b"><b>4.2</b> KG</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>956</b> EUR</ui5-text></ui5-table-cell>
 			</ui5-table-row>
 			<ui5-table-row>
-				<ui5-table-cell><ui5-label><b>Notebook Basic 17</b><br>HT-1001</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>Smartcards</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>29 x 17 x 3.1 cm</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>4.5</b> KG</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label><b>1249</b> EUR</ui5-label></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>Notebook Basic 17</b><br>HT-1001</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>Smartcards</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>29 x 17 x 3.1 cm</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text style="color: #2b7c2b"><b>4.5</b> KG</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>1249</b> EUR</ui5-text></ui5-table-cell>
 			</ui5-table-row>
 			<ui5-table-row>
-				<ui5-table-cell><ui5-label><b>Notebook Basic 18</b><br>HT-1002</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>Technocom</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>32 x 21 x 4 cm</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>3.7</b> KG</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label><b>29</b> EUR</ui5-label></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>Notebook Basic 18</b><br>HT-1002</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>Technocom</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>32 x 21 x 4 cm</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text style="color: #2b7c2b"><b>3.7</b> KG</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>29</b> EUR</ui5-text></ui5-table-cell>
 			</ui5-table-row>
 		</ui5-table>
 <!-- playground-fold -->

--- a/packages/website/docs/_samples/main/Table/Basic/sample.tsx
+++ b/packages/website/docs/_samples/main/Table/Basic/sample.tsx
@@ -1,17 +1,17 @@
 import createReactComponent from "@ui5/webcomponents-base/dist/createReactComponent.js";
-import LabelClass from "@ui5/webcomponents/dist/Label.js";
 import TableClass from "@ui5/webcomponents/dist/Table.js";
 import TableCellClass from "@ui5/webcomponents/dist/TableCell.js";
 import TableHeaderCellClass from "@ui5/webcomponents/dist/TableHeaderCell.js";
 import TableHeaderRowClass from "@ui5/webcomponents/dist/TableHeaderRow.js";
 import TableRowClass from "@ui5/webcomponents/dist/TableRow.js";
+import TextClass from "@ui5/webcomponents/dist/Text.js";
 
-const Label = createReactComponent(LabelClass);
 const Table = createReactComponent(TableClass);
 const TableCell = createReactComponent(TableCellClass);
 const TableHeaderCell = createReactComponent(TableHeaderCellClass);
 const TableHeaderRow = createReactComponent(TableHeaderRowClass);
 const TableRow = createReactComponent(TableRowClass);
+const Text = createReactComponent(TextClass);
 
 function App() {
   return (
@@ -36,77 +36,77 @@ function App() {
         </TableHeaderRow>
         <TableRow>
           <TableCell>
-            <Label>
+            <Text>
               <b>Notebook Basic 15</b>
               <br />
               HT-1000
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Very Best Screens</Label>
+            <Text>Very Best Screens</Text>
           </TableCell>
           <TableCell>
-            <Label>30 x 18 x 3 cm</Label>
+            <Text>30 x 18 x 3 cm</Text>
           </TableCell>
           <TableCell>
-            <Label style={{ color: "#2b7c2b" }}>
+            <Text style={{ color: "#2b7c2b" }}>
               <b>4.2</b> KG
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>
+            <Text>
               <b>956</b> EUR
-            </Label>
+            </Text>
           </TableCell>
         </TableRow>
         <TableRow>
           <TableCell>
-            <Label>
+            <Text>
               <b>Notebook Basic 17</b>
               <br />
               HT-1001
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Smartcards</Label>
+            <Text>Smartcards</Text>
           </TableCell>
           <TableCell>
-            <Label>29 x 17 x 3.1 cm</Label>
+            <Text>29 x 17 x 3.1 cm</Text>
           </TableCell>
           <TableCell>
-            <Label style={{ color: "#2b7c2b" }}>
+            <Text style={{ color: "#2b7c2b" }}>
               <b>4.5</b> KG
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>
+            <Text>
               <b>1249</b> EUR
-            </Label>
+            </Text>
           </TableCell>
         </TableRow>
         <TableRow>
           <TableCell>
-            <Label>
+            <Text>
               <b>Notebook Basic 18</b>
               <br />
               HT-1002
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Technocom</Label>
+            <Text>Technocom</Text>
           </TableCell>
           <TableCell>
-            <Label>32 x 21 x 4 cm</Label>
+            <Text>32 x 21 x 4 cm</Text>
           </TableCell>
           <TableCell>
-            <Label style={{ color: "#2b7c2b" }}>
+            <Text style={{ color: "#2b7c2b" }}>
               <b>3.7</b> KG
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>
+            <Text>
               <b>29</b> EUR
-            </Label>
+            </Text>
           </TableCell>
         </TableRow>
       </Table>

--- a/packages/website/docs/_samples/main/Table/ColumnWidths/main.js
+++ b/packages/website/docs/_samples/main/Table/ColumnWidths/main.js
@@ -1,8 +1,8 @@
 import "@ui5/webcomponents/dist/Table.js";
 import "@ui5/webcomponents/dist/TableHeaderRow.js";
 import "@ui5/webcomponents/dist/TableHeaderCell.js";
-import "@ui5/webcomponents/dist/Label.js";
 import "@ui5/webcomponents/dist/Slider.js";
+import "@ui5/webcomponents/dist/Text.js";
 
 const slider = document.getElementById("slider");
 const table = document.getElementById("table");

--- a/packages/website/docs/_samples/main/Table/ColumnWidths/sample.html
+++ b/packages/website/docs/_samples/main/Table/ColumnWidths/sample.html
@@ -21,22 +21,22 @@
 			</ui5-table-header-row>
 <!-- playground-fold -->
 			<ui5-table-row>
-				<ui5-table-cell><ui5-label><b>Notebook Basic 15</b><br>HT-1000</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>Very Best Screens</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>30 x 18 x 3 cm</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>4.2</b> KG</ui5-label></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>Notebook Basic 15</b><br>HT-1000</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>Very Best Screens</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>30 x 18 x 3 cm</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text style="color: #2b7c2b"><b>4.2</b> KG</ui5-text></ui5-table-cell>
 			</ui5-table-row>
 			<ui5-table-row>
-				<ui5-table-cell><ui5-label><b>Notebook Basic 17</b><br>HT-1001</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>Smartcards</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>29 x 17 x 3.1 cm</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>4.5</b> KG</ui5-label></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>Notebook Basic 17</b><br>HT-1001</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>Smartcards</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>29 x 17 x 3.1 cm</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text style="color: #2b7c2b"><b>4.5</b> KG</ui5-text></ui5-table-cell>
 			</ui5-table-row>
 			<ui5-table-row>
-				<ui5-table-cell><ui5-label><b>Notebook Basic 18</b><br>HT-1002</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>Technocom</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>32 x 21 x 4 cm</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>3.1</b> KG</ui5-label></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>Notebook Basic 18</b><br>HT-1002</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>Technocom</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>32 x 21 x 4 cm</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text style="color: #2b7c2b"><b>3.1</b> KG</ui5-text></ui5-table-cell>
 			</ui5-table-row>
 <!-- playground-fold-end -->
 		</ui5-table>

--- a/packages/website/docs/_samples/main/Table/ColumnWidths/sample.tsx
+++ b/packages/website/docs/_samples/main/Table/ColumnWidths/sample.tsx
@@ -1,21 +1,21 @@
 import { useRef } from "react";
 import createReactComponent from "@ui5/webcomponents-base/dist/createReactComponent.js";
 import { type UI5CustomEvent } from "@ui5/webcomponents-base";
-import LabelClass from "@ui5/webcomponents/dist/Label.js";
 import SliderClass from "@ui5/webcomponents/dist/Slider.js";
 import TableClass from "@ui5/webcomponents/dist/Table.js";
 import TableCellClass from "@ui5/webcomponents/dist/TableCell.js";
 import TableHeaderCellClass from "@ui5/webcomponents/dist/TableHeaderCell.js";
 import TableHeaderRowClass from "@ui5/webcomponents/dist/TableHeaderRow.js";
 import TableRowClass from "@ui5/webcomponents/dist/TableRow.js";
+import TextClass from "@ui5/webcomponents/dist/Text.js";
 
-const Label = createReactComponent(LabelClass);
 const Slider = createReactComponent(SliderClass);
 const Table = createReactComponent(TableClass);
 const TableCell = createReactComponent(TableCellClass);
 const TableHeaderCell = createReactComponent(TableHeaderCellClass);
 const TableHeaderRow = createReactComponent(TableHeaderRowClass);
 const TableRow = createReactComponent(TableRowClass);
+const Text = createReactComponent(TextClass);
 
 function App() {
   const tableRef = useRef(null);
@@ -53,62 +53,62 @@ function App() {
         {/* playground-fold */}
         <TableRow>
           <TableCell>
-            <Label>
+            <Text>
               <b>Notebook Basic 15</b>
               <br />
               HT-1000
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Very Best Screens</Label>
+            <Text>Very Best Screens</Text>
           </TableCell>
           <TableCell>
-            <Label>30 x 18 x 3 cm</Label>
+            <Text>30 x 18 x 3 cm</Text>
           </TableCell>
           <TableCell>
-            <Label style={{ color: "#2b7c2b" }}>
+            <Text style={{ color: "#2b7c2b" }}>
               <b>4.2</b> KG
-            </Label>
+            </Text>
           </TableCell>
         </TableRow>
         <TableRow>
           <TableCell>
-            <Label>
+            <Text>
               <b>Notebook Basic 17</b>
               <br />
               HT-1001
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Smartcards</Label>
+            <Text>Smartcards</Text>
           </TableCell>
           <TableCell>
-            <Label>29 x 17 x 3.1 cm</Label>
+            <Text>29 x 17 x 3.1 cm</Text>
           </TableCell>
           <TableCell>
-            <Label style={{ color: "#2b7c2b" }}>
+            <Text style={{ color: "#2b7c2b" }}>
               <b>4.5</b> KG
-            </Label>
+            </Text>
           </TableCell>
         </TableRow>
         <TableRow>
           <TableCell>
-            <Label>
+            <Text>
               <b>Notebook Basic 18</b>
               <br />
               HT-1002
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Technocom</Label>
+            <Text>Technocom</Text>
           </TableCell>
           <TableCell>
-            <Label>32 x 21 x 4 cm</Label>
+            <Text>32 x 21 x 4 cm</Text>
           </TableCell>
           <TableCell>
-            <Label style={{ color: "#2b7c2b" }}>
+            <Text style={{ color: "#2b7c2b" }}>
               <b>3.1</b> KG
-            </Label>
+            </Text>
           </TableCell>
         </TableRow>
         {/* playground-fold-end */}

--- a/packages/website/docs/_samples/main/Table/DragAndDrop/main.js
+++ b/packages/website/docs/_samples/main/Table/DragAndDrop/main.js
@@ -1,7 +1,7 @@
 import "@ui5/webcomponents/dist/Table.js";
 import "@ui5/webcomponents/dist/TableHeaderRow.js";
 import "@ui5/webcomponents/dist/TableHeaderCell.js";
-import "@ui5/webcomponents/dist/Label.js";
+import "@ui5/webcomponents/dist/Text.js";
 
 function tableMoveOver(e) {
 	const { source, destination } = e.detail;

--- a/packages/website/docs/_samples/main/Table/DragAndDrop/sample.html
+++ b/packages/website/docs/_samples/main/Table/DragAndDrop/sample.html
@@ -19,22 +19,22 @@
 				<ui5-table-header-cell id="priceCol">Price</ui5-table-header-cell>
 			</ui5-table-header-row>
 			<ui5-table-row movable>
-				<ui5-table-cell><ui5-label><b>Notebook Basic 15</b><br>HT-1000</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>Very Best Screens</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>30 x 18 x 3 cm</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label><b>956</b> EUR</ui5-label></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>Notebook Basic 15</b><br>HT-1000</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>Very Best Screens</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>30 x 18 x 3 cm</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>956</b> EUR</ui5-text></ui5-table-cell>
 			</ui5-table-row>
 			<ui5-table-row movable>
-				<ui5-table-cell><ui5-label><b>Notebook Basic 17</b><br>HT-1001</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>Smartcards</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>29 x 17 x 3.1 cm</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label><b>1249</b> EUR</ui5-label></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>Notebook Basic 17</b><br>HT-1001</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>Smartcards</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>29 x 17 x 3.1 cm</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>1249</b> EUR</ui5-text></ui5-table-cell>
 			</ui5-table-row>
 			<ui5-table-row movable>
-				<ui5-table-cell><ui5-label><b>Notebook Basic 18</b><br>HT-1002</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>Technocom</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>32 x 21 x 4 cm</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label><b>29</b> EUR</ui5-label></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>Notebook Basic 18</b><br>HT-1002</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>Technocom</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>32 x 21 x 4 cm</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>29</b> EUR</ui5-text></ui5-table-cell>
 			</ui5-table-row>
 		</ui5-table>
 <!-- playground-fold -->

--- a/packages/website/docs/_samples/main/Table/DragAndDrop/sample.tsx
+++ b/packages/website/docs/_samples/main/Table/DragAndDrop/sample.tsx
@@ -1,18 +1,18 @@
 import { useRef, useEffect } from "react";
 import createReactComponent from "@ui5/webcomponents-base/dist/createReactComponent.js";
-import LabelClass from "@ui5/webcomponents/dist/Label.js";
 import TableClass from "@ui5/webcomponents/dist/Table.js";
 import TableCellClass from "@ui5/webcomponents/dist/TableCell.js";
 import TableHeaderCellClass from "@ui5/webcomponents/dist/TableHeaderCell.js";
 import TableHeaderRowClass from "@ui5/webcomponents/dist/TableHeaderRow.js";
 import TableRowClass from "@ui5/webcomponents/dist/TableRow.js";
+import TextClass from "@ui5/webcomponents/dist/Text.js";
 
-const Label = createReactComponent(LabelClass);
 const Table = createReactComponent(TableClass);
 const TableCell = createReactComponent(TableCellClass);
 const TableHeaderCell = createReactComponent(TableHeaderCellClass);
 const TableHeaderRow = createReactComponent(TableHeaderRowClass);
 const TableRow = createReactComponent(TableRowClass);
+const Text = createReactComponent(TextClass);
 
 function App() {
   const tableRef = useRef(null);
@@ -86,62 +86,62 @@ function App() {
         </TableHeaderRow>
         <TableRow movable={true}>
           <TableCell>
-            <Label>
+            <Text>
               <b>Notebook Basic 15</b>
               <br />
               HT-1000
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Very Best Screens</Label>
+            <Text>Very Best Screens</Text>
           </TableCell>
           <TableCell>
-            <Label>30 x 18 x 3 cm</Label>
+            <Text>30 x 18 x 3 cm</Text>
           </TableCell>
           <TableCell>
-            <Label>
+            <Text>
               <b>956</b> EUR
-            </Label>
+            </Text>
           </TableCell>
         </TableRow>
         <TableRow movable={true}>
           <TableCell>
-            <Label>
+            <Text>
               <b>Notebook Basic 17</b>
               <br />
               HT-1001
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Smartcards</Label>
+            <Text>Smartcards</Text>
           </TableCell>
           <TableCell>
-            <Label>29 x 17 x 3.1 cm</Label>
+            <Text>29 x 17 x 3.1 cm</Text>
           </TableCell>
           <TableCell>
-            <Label>
+            <Text>
               <b>1249</b> EUR
-            </Label>
+            </Text>
           </TableCell>
         </TableRow>
         <TableRow movable={true}>
           <TableCell>
-            <Label>
+            <Text>
               <b>Notebook Basic 18</b>
               <br />
               HT-1002
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Technocom</Label>
+            <Text>Technocom</Text>
           </TableCell>
           <TableCell>
-            <Label>32 x 21 x 4 cm</Label>
+            <Text>32 x 21 x 4 cm</Text>
           </TableCell>
           <TableCell>
-            <Label>
+            <Text>
               <b>29</b> EUR
-            </Label>
+            </Text>
           </TableCell>
         </TableRow>
       </Table>

--- a/packages/website/docs/_samples/main/Table/Growing/main.js
+++ b/packages/website/docs/_samples/main/Table/Growing/main.js
@@ -2,8 +2,8 @@ import "@ui5/webcomponents/dist/Table.js";
 import "@ui5/webcomponents/dist/TableGrowing.js";
 import "@ui5/webcomponents/dist/TableHeaderRow.js";
 import "@ui5/webcomponents/dist/TableHeaderCell.js";
-import "@ui5/webcomponents/dist/Label.js";
 import "@ui5/webcomponents/dist/Input.js";
+import "@ui5/webcomponents/dist/Text.js";
 
 const MAX_GROW = 3;
 

--- a/packages/website/docs/_samples/main/Table/Growing/sample.html
+++ b/packages/website/docs/_samples/main/Table/Growing/sample.html
@@ -22,25 +22,25 @@
 				<ui5-table-header-cell id="priceCol">Price</ui5-table-header-cell>
 			</ui5-table-header-row>
 			<ui5-table-row row-key="0">
-				<ui5-table-cell><ui5-label><b>Notebook Basic 15</b><br>HT-1000</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>Very Best Screens</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>30 x 18 x 3 cm</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>4.2</b> KG</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label><b>956</b> EUR</ui5-label></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>Notebook Basic 15</b><br>HT-1000</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>Very Best Screens</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>30 x 18 x 3 cm</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text style="color: #2b7c2b"><b>4.2</b> KG</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>956</b> EUR</ui5-text></ui5-table-cell>
 			</ui5-table-row>
 			<ui5-table-row row-key="1">
-				<ui5-table-cell><ui5-label><b>Notebook Basic 17</b><br>HT-1001</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>Smartcards</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>29 x 17 x 3.1 cm</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>4.5</b> KG</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label><b>1249</b> EUR</ui5-label></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>Notebook Basic 17</b><br>HT-1001</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>Smartcards</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>29 x 17 x 3.1 cm</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text style="color: #2b7c2b"><b>4.5</b> KG</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>1249</b> EUR</ui5-text></ui5-table-cell>
 			</ui5-table-row>
 			<ui5-table-row row-key="2">
-				<ui5-table-cell><ui5-label><b>Notebook Basic 18</b><br>HT-1002</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>Technocom</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>32 x 21 x 4 cm</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>3.7</b> KG</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label><b>29</b> EUR</ui5-label></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>Notebook Basic 18</b><br>HT-1002</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>Technocom</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>32 x 21 x 4 cm</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text style="color: #2b7c2b"><b>3.7</b> KG</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>29</b> EUR</ui5-text></ui5-table-cell>
 			</ui5-table-row>
 <!-- playground-fold-end -->
 		</ui5-table>

--- a/packages/website/docs/_samples/main/Table/Growing/sample.tsx
+++ b/packages/website/docs/_samples/main/Table/Growing/sample.tsx
@@ -1,20 +1,20 @@
 import { useState, useRef } from "react";
 import createReactComponent from "@ui5/webcomponents-base/dist/createReactComponent.js";
-import LabelClass from "@ui5/webcomponents/dist/Label.js";
 import TableClass from "@ui5/webcomponents/dist/Table.js";
 import TableCellClass from "@ui5/webcomponents/dist/TableCell.js";
 import TableGrowingClass from "@ui5/webcomponents/dist/TableGrowing.js";
 import TableHeaderCellClass from "@ui5/webcomponents/dist/TableHeaderCell.js";
 import TableHeaderRowClass from "@ui5/webcomponents/dist/TableHeaderRow.js";
 import TableRowClass from "@ui5/webcomponents/dist/TableRow.js";
+import TextClass from "@ui5/webcomponents/dist/Text.js";
 
-const Label = createReactComponent(LabelClass);
 const Table = createReactComponent(TableClass);
 const TableCell = createReactComponent(TableCellClass);
 const TableGrowing = createReactComponent(TableGrowingClass);
 const TableHeaderCell = createReactComponent(TableHeaderCellClass);
 const TableHeaderRow = createReactComponent(TableHeaderRowClass);
 const TableRow = createReactComponent(TableRowClass);
+const Text = createReactComponent(TextClass);
 
 const MAX_GROW = 3;
 
@@ -66,103 +66,103 @@ function App() {
         </TableHeaderRow>
         <TableRow rowKey="0">
           <TableCell>
-            <Label>
+            <Text>
               <b>Notebook Basic 15</b>
               <br />
               HT-1000
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Very Best Screens</Label>
+            <Text>Very Best Screens</Text>
           </TableCell>
           <TableCell>
-            <Label>30 x 18 x 3 cm</Label>
+            <Text>30 x 18 x 3 cm</Text>
           </TableCell>
           <TableCell>
-            <Label style={{ color: "#2b7c2b" }}>
+            <Text style={{ color: "#2b7c2b" }}>
               <b>4.2</b> KG
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>
+            <Text>
               <b>956</b> EUR
-            </Label>
+            </Text>
           </TableCell>
         </TableRow>
         <TableRow rowKey="1">
           <TableCell>
-            <Label>
+            <Text>
               <b>Notebook Basic 17</b>
               <br />
               HT-1001
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Smartcards</Label>
+            <Text>Smartcards</Text>
           </TableCell>
           <TableCell>
-            <Label>29 x 17 x 3.1 cm</Label>
+            <Text>29 x 17 x 3.1 cm</Text>
           </TableCell>
           <TableCell>
-            <Label style={{ color: "#2b7c2b" }}>
+            <Text style={{ color: "#2b7c2b" }}>
               <b>4.5</b> KG
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>
+            <Text>
               <b>1249</b> EUR
-            </Label>
+            </Text>
           </TableCell>
         </TableRow>
         <TableRow rowKey="2">
           <TableCell>
-            <Label>
+            <Text>
               <b>Notebook Basic 18</b>
               <br />
               HT-1002
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Technocom</Label>
+            <Text>Technocom</Text>
           </TableCell>
           <TableCell>
-            <Label>32 x 21 x 4 cm</Label>
+            <Text>32 x 21 x 4 cm</Text>
           </TableCell>
           <TableCell>
-            <Label style={{ color: "#2b7c2b" }}>
+            <Text style={{ color: "#2b7c2b" }}>
               <b>3.7</b> KG
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>
+            <Text>
               <b>29</b> EUR
-            </Label>
+            </Text>
           </TableCell>
         </TableRow>
         {extraRows.map((row) => (
           <TableRow rowKey={row.key.toString()} key={row.key}>
             <TableCell>
-              <Label>
+              <Text>
                 <b>{row.name}</b>
                 <br />
                 {row.code}
-              </Label>
+              </Text>
             </TableCell>
             <TableCell>
-              <Label>Technocom</Label>
+              <Text>Technocom</Text>
             </TableCell>
             <TableCell>
-              <Label>32 x 21 x 4 cm</Label>
+              <Text>32 x 21 x 4 cm</Text>
             </TableCell>
             <TableCell>
-              <Label style={{ color: "#2b7c2b" }}>
+              <Text style={{ color: "#2b7c2b" }}>
                 <b>3.7</b> KG
-              </Label>
+              </Text>
             </TableCell>
             <TableCell>
-              <Label>
+              <Text>
                 <b>29</b> EUR
-              </Label>
+              </Text>
             </TableCell>
           </TableRow>
         ))}

--- a/packages/website/docs/_samples/main/Table/HAlign/main.js
+++ b/packages/website/docs/_samples/main/Table/HAlign/main.js
@@ -1,4 +1,4 @@
 import "@ui5/webcomponents/dist/Table.js";
 import "@ui5/webcomponents/dist/TableHeaderRow.js";
 import "@ui5/webcomponents/dist/TableHeaderCell.js";
-import "@ui5/webcomponents/dist/Label.js";
+import "@ui5/webcomponents/dist/Text.js";

--- a/packages/website/docs/_samples/main/Table/HAlign/sample.html
+++ b/packages/website/docs/_samples/main/Table/HAlign/sample.html
@@ -20,25 +20,25 @@
 				<ui5-table-header-cell id="priceCol" width="220px">Price</ui5-table-header-cell>
 			</ui5-table-header-row>
 			<ui5-table-row>
-				<ui5-table-cell><ui5-label><b>Notebook Basic 15</b><br>HT-1000</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>Very Best Screens</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>30 x 18 x 3 cm</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>4.2</b> KG</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label><b>956</b> EUR</ui5-label></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>Notebook Basic 15</b><br>HT-1000</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>Very Best Screens</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>30 x 18 x 3 cm</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text style="color: #2b7c2b"><b>4.2</b> KG</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>956</b> EUR</ui5-text></ui5-table-cell>
 			</ui5-table-row>
 			<ui5-table-row>
-				<ui5-table-cell><ui5-label><b>Notebook Basic 17</b><br>HT-1001</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>Smartcards</ui5-label></ui5-table-cell>
-				<ui5-table-cell horizontal-align="Left"><ui5-label>29 x 17 x 3.1 cm</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>4.5</b> KG</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label><b>1249</b> EUR</ui5-label></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>Notebook Basic 17</b><br>HT-1001</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>Smartcards</ui5-text></ui5-table-cell>
+				<ui5-table-cell horizontal-align="Left"><ui5-text>29 x 17 x 3.1 cm</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text style="color: #2b7c2b"><b>4.5</b> KG</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>1249</b> EUR</ui5-text></ui5-table-cell>
 			</ui5-table-row>
 			<ui5-table-row>
-				<ui5-table-cell><ui5-label><b>Notebook Basic 18</b><br>HT-1002</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>Technocom</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>32 x 21 x 4 cm</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>3.7</b> KG</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label><b>29</b> EUR</ui5-label></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>Notebook Basic 18</b><br>HT-1002</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>Technocom</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>32 x 21 x 4 cm</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text style="color: #2b7c2b"><b>3.7</b> KG</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>29</b> EUR</ui5-text></ui5-table-cell>
 			</ui5-table-row>
 		</ui5-table>
 <!-- playground-fold -->

--- a/packages/website/docs/_samples/main/Table/HAlign/sample.tsx
+++ b/packages/website/docs/_samples/main/Table/HAlign/sample.tsx
@@ -1,17 +1,17 @@
 import createReactComponent from "@ui5/webcomponents-base/dist/createReactComponent.js";
-import LabelClass from "@ui5/webcomponents/dist/Label.js";
 import TableClass from "@ui5/webcomponents/dist/Table.js";
 import TableCellClass from "@ui5/webcomponents/dist/TableCell.js";
 import TableHeaderCellClass from "@ui5/webcomponents/dist/TableHeaderCell.js";
 import TableHeaderRowClass from "@ui5/webcomponents/dist/TableHeaderRow.js";
 import TableRowClass from "@ui5/webcomponents/dist/TableRow.js";
+import TextClass from "@ui5/webcomponents/dist/Text.js";
 
-const Label = createReactComponent(LabelClass);
 const Table = createReactComponent(TableClass);
 const TableCell = createReactComponent(TableCellClass);
 const TableHeaderCell = createReactComponent(TableHeaderCellClass);
 const TableHeaderRow = createReactComponent(TableHeaderRowClass);
 const TableRow = createReactComponent(TableRowClass);
+const Text = createReactComponent(TextClass);
 
 function App() {
   return (
@@ -44,77 +44,77 @@ function App() {
         </TableHeaderRow>
         <TableRow>
           <TableCell>
-            <Label>
+            <Text>
               <b>Notebook Basic 15</b>
               <br />
               HT-1000
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Very Best Screens</Label>
+            <Text>Very Best Screens</Text>
           </TableCell>
           <TableCell>
-            <Label>30 x 18 x 3 cm</Label>
+            <Text>30 x 18 x 3 cm</Text>
           </TableCell>
           <TableCell>
-            <Label style={{ color: "#2b7c2b" }}>
+            <Text style={{ color: "#2b7c2b" }}>
               <b>4.2</b> KG
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>
+            <Text>
               <b>956</b> EUR
-            </Label>
+            </Text>
           </TableCell>
         </TableRow>
         <TableRow>
           <TableCell>
-            <Label>
+            <Text>
               <b>Notebook Basic 17</b>
               <br />
               HT-1001
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Smartcards</Label>
+            <Text>Smartcards</Text>
           </TableCell>
           <TableCell horizontalAlign="Left">
-            <Label>29 x 17 x 3.1 cm</Label>
+            <Text>29 x 17 x 3.1 cm</Text>
           </TableCell>
           <TableCell>
-            <Label style={{ color: "#2b7c2b" }}>
+            <Text style={{ color: "#2b7c2b" }}>
               <b>4.5</b> KG
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>
+            <Text>
               <b>1249</b> EUR
-            </Label>
+            </Text>
           </TableCell>
         </TableRow>
         <TableRow>
           <TableCell>
-            <Label>
+            <Text>
               <b>Notebook Basic 18</b>
               <br />
               HT-1002
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Technocom</Label>
+            <Text>Technocom</Text>
           </TableCell>
           <TableCell>
-            <Label>32 x 21 x 4 cm</Label>
+            <Text>32 x 21 x 4 cm</Text>
           </TableCell>
           <TableCell>
-            <Label style={{ color: "#2b7c2b" }}>
+            <Text style={{ color: "#2b7c2b" }}>
               <b>3.7</b> KG
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>
+            <Text>
               <b>29</b> EUR
-            </Label>
+            </Text>
           </TableCell>
         </TableRow>
       </Table>

--- a/packages/website/docs/_samples/main/Table/HeaderCellActionAI/sample.html
+++ b/packages/website/docs/_samples/main/Table/HeaderCellActionAI/sample.html
@@ -29,25 +29,25 @@
 <!-- playground-fold -->
 			</ui5-table-header-row>
 			<ui5-table-row row-key="0">
-				<ui5-table-cell><ui5-label><b>Notebook Basic 17</b><br>HT-1001</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>Smartcards</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>29 x 17 x 3.1 cm</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>4.5</b> KG</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label><b>1249</b> EUR</ui5-label></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>Notebook Basic 17</b><br>HT-1001</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>Smartcards</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>29 x 17 x 3.1 cm</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text style="color: #2b7c2b"><b>4.5</b> KG</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>1249</b> EUR</ui5-text></ui5-table-cell>
 			</ui5-table-row>
 			<ui5-table-row row-key="1">
-				<ui5-table-cell><ui5-label><b>Notebook Basic 15</b><br>HT-1000</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>Very Best Screens</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>30 x 18 x 3 cm</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>4.2</b> KG</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label><b>956</b> EUR</ui5-label></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>Notebook Basic 15</b><br>HT-1000</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>Very Best Screens</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>30 x 18 x 3 cm</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text style="color: #2b7c2b"><b>4.2</b> KG</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>956</b> EUR</ui5-text></ui5-table-cell>
 			</ui5-table-row>
 			<ui5-table-row row-key="2">
-				<ui5-table-cell><ui5-label><b>Notebook Basic 18</b><br>HT-1002</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>Technocom</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>32 x 21 x 4 cm</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>3.7</b> KG</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label><b>290</b> EUR</ui5-label></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>Notebook Basic 18</b><br>HT-1002</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>Technocom</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>32 x 21 x 4 cm</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text style="color: #2b7c2b"><b>3.7</b> KG</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>290</b> EUR</ui5-text></ui5-table-cell>
 			</ui5-table-row>
 		</ui5-table>
 		<!-- playground-fold-end -->

--- a/packages/website/docs/_samples/main/Table/HeaderCellActionAI/sample.tsx
+++ b/packages/website/docs/_samples/main/Table/HeaderCellActionAI/sample.tsx
@@ -91,77 +91,77 @@ function App() {
         </TableHeaderRow>
         <TableRow rowKey="0">
           <TableCell>
-            <Label>
+            <Text>
               <b>Notebook Basic 17</b>
               <br />
               HT-1001
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Smartcards</Label>
+            <Text>Smartcards</Text>
           </TableCell>
           <TableCell>
-            <Label>29 x 17 x 3.1 cm</Label>
+            <Text>29 x 17 x 3.1 cm</Text>
           </TableCell>
           <TableCell>
-            <Label style={{ color: "#2b7c2b" }}>
+            <Text style={{ color: "#2b7c2b" }}>
               <b>4.5</b> KG
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>
+            <Text>
               <b>1249</b> EUR
-            </Label>
+            </Text>
           </TableCell>
         </TableRow>
         <TableRow rowKey="1">
           <TableCell>
-            <Label>
+            <Text>
               <b>Notebook Basic 15</b>
               <br />
               HT-1000
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Very Best Screens</Label>
+            <Text>Very Best Screens</Text>
           </TableCell>
           <TableCell>
-            <Label>30 x 18 x 3 cm</Label>
+            <Text>30 x 18 x 3 cm</Text>
           </TableCell>
           <TableCell>
-            <Label style={{ color: "#2b7c2b" }}>
+            <Text style={{ color: "#2b7c2b" }}>
               <b>4.2</b> KG
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>
+            <Text>
               <b>956</b> EUR
-            </Label>
+            </Text>
           </TableCell>
         </TableRow>
         <TableRow rowKey="2">
           <TableCell>
-            <Label>
+            <Text>
               <b>Notebook Basic 18</b>
               <br />
               HT-1002
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Technocom</Label>
+            <Text>Technocom</Text>
           </TableCell>
           <TableCell>
-            <Label>32 x 21 x 4 cm</Label>
+            <Text>32 x 21 x 4 cm</Text>
           </TableCell>
           <TableCell>
-            <Label style={{ color: "#2b7c2b" }}>
+            <Text style={{ color: "#2b7c2b" }}>
               <b>3.7</b> KG
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>
+            <Text>
               <b>290</b> EUR
-            </Label>
+            </Text>
           </TableCell>
         </TableRow>
       </Table>

--- a/packages/website/docs/_samples/main/Table/Interactive/main.js
+++ b/packages/website/docs/_samples/main/Table/Interactive/main.js
@@ -1,8 +1,8 @@
 import "@ui5/webcomponents/dist/Table.js";
 import "@ui5/webcomponents/dist/TableHeaderRow.js";
 import "@ui5/webcomponents/dist/TableHeaderCell.js";
-import "@ui5/webcomponents/dist/Label.js";
 import "@ui5/webcomponents/dist/Toast.js";
+import "@ui5/webcomponents/dist/Text.js";
 
 const table = document.getElementById("table");
 const toast = document.getElementById("message");

--- a/packages/website/docs/_samples/main/Table/Interactive/sample.html
+++ b/packages/website/docs/_samples/main/Table/Interactive/sample.html
@@ -21,22 +21,22 @@
 		</ui5-table-header-row>
 <!-- playground-fold-end -->
 		<ui5-table-row row-key="a" interactive>
-			<ui5-table-cell><ui5-label><b>Notebook Basic 15</b><br>HT-1000</ui5-label></ui5-table-cell>
-			<ui5-table-cell><ui5-label>Very Best Screens</ui5-label></ui5-table-cell>
-			<ui5-table-cell><ui5-label>30 x 18 x 3 cm</ui5-label></ui5-table-cell>
-			<ui5-table-cell><ui5-label><b>956</b> EUR</ui5-label></ui5-table-cell>
+			<ui5-table-cell><ui5-text><b>Notebook Basic 15</b><br>HT-1000</ui5-text></ui5-table-cell>
+			<ui5-table-cell><ui5-text>Very Best Screens</ui5-text></ui5-table-cell>
+			<ui5-table-cell><ui5-text>30 x 18 x 3 cm</ui5-text></ui5-table-cell>
+			<ui5-table-cell><ui5-text><b>956</b> EUR</ui5-text></ui5-table-cell>
 		</ui5-table-row>
 		<ui5-table-row row-key="b">
-			<ui5-table-cell><ui5-label><b>Notebook Basic 17</b><br>HT-1001</ui5-label></ui5-table-cell>
-			<ui5-table-cell><ui5-label>Smartcards</ui5-label></ui5-table-cell>
-			<ui5-table-cell><ui5-label>29 x 17 x 3.1 cm</ui5-label></ui5-table-cell>
-			<ui5-table-cell><ui5-label><b>1249</b> EUR</ui5-label></ui5-table-cell>
+			<ui5-table-cell><ui5-text><b>Notebook Basic 17</b><br>HT-1001</ui5-text></ui5-table-cell>
+			<ui5-table-cell><ui5-text>Smartcards</ui5-text></ui5-table-cell>
+			<ui5-table-cell><ui5-text>29 x 17 x 3.1 cm</ui5-text></ui5-table-cell>
+			<ui5-table-cell><ui5-text><b>1249</b> EUR</ui5-text></ui5-table-cell>
 		</ui5-table-row>
 		<ui5-table-row row-key="c" interactive>
-			<ui5-table-cell><ui5-label><b>Notebook Basic 18</b><br>HT-1002</ui5-label></ui5-table-cell>
-			<ui5-table-cell><ui5-label>Technocom</ui5-label></ui5-table-cell>
-			<ui5-table-cell><ui5-label>32 x 21 x 4 cm</ui5-label></ui5-table-cell>
-			<ui5-table-cell><ui5-label><b>29</b> EUR</ui5-label></ui5-table-cell>
+			<ui5-table-cell><ui5-text><b>Notebook Basic 18</b><br>HT-1002</ui5-text></ui5-table-cell>
+			<ui5-table-cell><ui5-text>Technocom</ui5-text></ui5-table-cell>
+			<ui5-table-cell><ui5-text>32 x 21 x 4 cm</ui5-text></ui5-table-cell>
+			<ui5-table-cell><ui5-text><b>29</b> EUR</ui5-text></ui5-table-cell>
 		</ui5-table-row>
 	</ui5-table>
 <!-- playground-fold -->

--- a/packages/website/docs/_samples/main/Table/Interactive/sample.tsx
+++ b/packages/website/docs/_samples/main/Table/Interactive/sample.tsx
@@ -1,21 +1,21 @@
 import { useRef } from "react";
 import createReactComponent from "@ui5/webcomponents-base/dist/createReactComponent.js";
 import { type UI5CustomEvent } from "@ui5/webcomponents-base";
-import LabelClass from "@ui5/webcomponents/dist/Label.js";
 import TableClass from "@ui5/webcomponents/dist/Table.js";
 import TableCellClass from "@ui5/webcomponents/dist/TableCell.js";
 import TableHeaderCellClass from "@ui5/webcomponents/dist/TableHeaderCell.js";
 import TableHeaderRowClass from "@ui5/webcomponents/dist/TableHeaderRow.js";
 import TableRowClass from "@ui5/webcomponents/dist/TableRow.js";
 import ToastClass from "@ui5/webcomponents/dist/Toast.js";
+import TextClass from "@ui5/webcomponents/dist/Text.js";
 
-const Label = createReactComponent(LabelClass);
 const Table = createReactComponent(TableClass);
 const TableCell = createReactComponent(TableCellClass);
 const TableHeaderCell = createReactComponent(TableHeaderCellClass);
 const TableHeaderRow = createReactComponent(TableHeaderRowClass);
 const TableRow = createReactComponent(TableRowClass);
 const Toast = createReactComponent(ToastClass);
+const Text = createReactComponent(TextClass);
 
 function App() {
   const toastRef = useRef(null);
@@ -49,62 +49,62 @@ function App() {
         {/* playground-fold-end */}
         <TableRow rowKey="a" interactive={true}>
           <TableCell>
-            <Label>
+            <Text>
               <b>Notebook Basic 15</b>
               <br />
               HT-1000
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Very Best Screens</Label>
+            <Text>Very Best Screens</Text>
           </TableCell>
           <TableCell>
-            <Label>30 x 18 x 3 cm</Label>
+            <Text>30 x 18 x 3 cm</Text>
           </TableCell>
           <TableCell>
-            <Label>
+            <Text>
               <b>956</b> EUR
-            </Label>
+            </Text>
           </TableCell>
         </TableRow>
         <TableRow rowKey="b">
           <TableCell>
-            <Label>
+            <Text>
               <b>Notebook Basic 17</b>
               <br />
               HT-1001
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Smartcards</Label>
+            <Text>Smartcards</Text>
           </TableCell>
           <TableCell>
-            <Label>29 x 17 x 3.1 cm</Label>
+            <Text>29 x 17 x 3.1 cm</Text>
           </TableCell>
           <TableCell>
-            <Label>
+            <Text>
               <b>1249</b> EUR
-            </Label>
+            </Text>
           </TableCell>
         </TableRow>
         <TableRow rowKey="c" interactive={true}>
           <TableCell>
-            <Label>
+            <Text>
               <b>Notebook Basic 18</b>
               <br />
               HT-1002
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Technocom</Label>
+            <Text>Technocom</Text>
           </TableCell>
           <TableCell>
-            <Label>32 x 21 x 4 cm</Label>
+            <Text>32 x 21 x 4 cm</Text>
           </TableCell>
           <TableCell>
-            <Label>
+            <Text>
               <b>29</b> EUR
-            </Label>
+            </Text>
           </TableCell>
         </TableRow>
       </Table>

--- a/packages/website/docs/_samples/main/Table/MergedCells/main.js
+++ b/packages/website/docs/_samples/main/Table/MergedCells/main.js
@@ -2,7 +2,6 @@ import "@ui5/webcomponents/dist/Table.js";
 import "@ui5/webcomponents/dist/TableHeaderRow.js";
 import "@ui5/webcomponents/dist/TableHeaderCell.js";
 import "@ui5/webcomponents/dist/TableSelectionMulti.js";
-import "@ui5/webcomponents/dist/Label.js";
 import "@ui5/webcomponents/dist/Text.js";
 import "@ui5/webcomponents/dist/Bar.js";
 import "@ui5/webcomponents/dist/SegmentedButton.js";

--- a/packages/website/docs/_samples/main/Table/NoDataSlot/main.js
+++ b/packages/website/docs/_samples/main/Table/NoDataSlot/main.js
@@ -1,6 +1,5 @@
 import "@ui5/webcomponents/dist/Table.js";
 import "@ui5/webcomponents/dist/TableHeaderRow.js";
 import "@ui5/webcomponents/dist/TableHeaderCell.js";
-import "@ui5/webcomponents/dist/Label.js";
 import "@ui5/webcomponents-fiori/dist/IllustratedMessage.js";
 import "@ui5/webcomponents-fiori/dist/illustrations/NoData.js";

--- a/packages/website/docs/_samples/main/Table/NoDataSlot/sample.html
+++ b/packages/website/docs/_samples/main/Table/NoDataSlot/sample.html
@@ -14,7 +14,7 @@
 		<ui5-illustrated-message slot="noData" name="NoData" design="Medium"></ui5-illustrated-message>
 <!-- playground-fold -->
 		<ui5-table-header-row slot="headerRow">
-			<ui5-table-header-cell id="produtCol" width="300px"><span>Product</span></ui5-table-header-cell>
+			<ui5-table-header-cell id="productCol" width="300px"><span>Product</span></ui5-table-header-cell>
 			<ui5-table-header-cell id="supplierCol" width="200px">Supplier</ui5-table-header-cell>
 			<ui5-table-header-cell id="dimensionsCol" width="300px">Dimensions</ui5-table-header-cell>
 			<ui5-table-header-cell id="weightCol" width="100px">Weight</ui5-table-header-cell>

--- a/packages/website/docs/_samples/main/Table/NoDataSlot/sample.tsx
+++ b/packages/website/docs/_samples/main/Table/NoDataSlot/sample.tsx
@@ -16,7 +16,7 @@ function App() {
         <IllustratedMessage slot="noData" name="NoData" design="Medium" />
         {/* playground-fold */}
         <TableHeaderRow slot="headerRow">
-          <TableHeaderCell id="produtCol" width="300px">
+          <TableHeaderCell id="productCol" width="300px">
             <span>Product</span>
           </TableHeaderCell>
           <TableHeaderCell id="supplierCol" width="200px">

--- a/packages/website/docs/_samples/main/Table/Popin/main.js
+++ b/packages/website/docs/_samples/main/Table/Popin/main.js
@@ -1,11 +1,11 @@
 import "@ui5/webcomponents/dist/Table.js";
 import "@ui5/webcomponents/dist/TableHeaderRow.js";
 import "@ui5/webcomponents/dist/TableHeaderCell.js";
-import "@ui5/webcomponents/dist/Label.js";
 import "@ui5/webcomponents/dist/Input.js";
 import "@ui5/webcomponents/dist/Slider.js";
 import "@ui5/webcomponents/dist/Bar.js";
 import "@ui5/webcomponents/dist/SegmentedButton.js";
+import "@ui5/webcomponents/dist/Text.js";
 import "@ui5/webcomponents-icons/dist/detail-more.js";
 import "@ui5/webcomponents-icons/dist/detail-less.js";
 

--- a/packages/website/docs/_samples/main/Table/Popin/sample.html
+++ b/packages/website/docs/_samples/main/Table/Popin/sample.html
@@ -33,25 +33,25 @@
 	</ui5-table-header-row>
 <!-- playground-fold -->
 			<ui5-table-row>
-				<ui5-table-cell><ui5-label><b>Notebook Basic 15</b><br>HT-1000</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>Very Best Screens</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>30 x 18 x 3 cm</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>4.2</b> KG</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label><b>956</b> EUR</ui5-label></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>Notebook Basic 15</b><br>HT-1000</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>Very Best Screens</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>30 x 18 x 3 cm</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text style="color: #2b7c2b"><b>4.2</b> KG</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>956</b> EUR</ui5-text></ui5-table-cell>
 			</ui5-table-row>
 			<ui5-table-row>
-				<ui5-table-cell><ui5-label><b>Notebook Basic 17</b><br>HT-1001</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>Smartcards</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>29 x 17 x 3.1 cm</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>4.5</b> KG</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label><b>1249</b> EUR</ui5-label></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>Notebook Basic 17</b><br>HT-1001</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>Smartcards</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>29 x 17 x 3.1 cm</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text style="color: #2b7c2b"><b>4.5</b> KG</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>1249</b> EUR</ui5-text></ui5-table-cell>
 			</ui5-table-row>
 			<ui5-table-row>
-				<ui5-table-cell><ui5-label><b>Notebook Basic 18</b><br>HT-1002</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>Technocom</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>32 x 21 x 4 cm</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>3.7</b> KG</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label><b>29</b> EUR</ui5-label></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>Notebook Basic 18</b><br>HT-1002</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>Technocom</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>32 x 21 x 4 cm</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text style="color: #2b7c2b"><b>3.7</b> KG</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>29</b> EUR</ui5-text></ui5-table-cell>
 			</ui5-table-row>
 <!-- playground-fold-end -->
 </ui5-table>

--- a/packages/website/docs/_samples/main/Table/Popin/sample.tsx
+++ b/packages/website/docs/_samples/main/Table/Popin/sample.tsx
@@ -2,7 +2,6 @@ import { useRef } from "react";
 import createReactComponent from "@ui5/webcomponents-base/dist/createReactComponent.js";
 import { type UI5CustomEvent } from "@ui5/webcomponents-base";
 import BarClass from "@ui5/webcomponents/dist/Bar.js";
-import LabelClass from "@ui5/webcomponents/dist/Label.js";
 import SegmentedButtonClass from "@ui5/webcomponents/dist/SegmentedButton.js";
 import SegmentedButtonItemClass from "@ui5/webcomponents/dist/SegmentedButtonItem.js";
 import TableClass from "@ui5/webcomponents/dist/Table.js";
@@ -10,11 +9,11 @@ import TableCellClass from "@ui5/webcomponents/dist/TableCell.js";
 import TableHeaderCellClass from "@ui5/webcomponents/dist/TableHeaderCell.js";
 import TableHeaderRowClass from "@ui5/webcomponents/dist/TableHeaderRow.js";
 import TableRowClass from "@ui5/webcomponents/dist/TableRow.js";
+import TextClass from "@ui5/webcomponents/dist/Text.js";
 import "@ui5/webcomponents-icons/dist/detail-more.js";
 import "@ui5/webcomponents-icons/dist/detail-less.js";
 
 const Bar = createReactComponent(BarClass);
-const Label = createReactComponent(LabelClass);
 const SegmentedButton = createReactComponent(SegmentedButtonClass);
 const SegmentedButtonItem = createReactComponent(SegmentedButtonItemClass);
 const Table = createReactComponent(TableClass);
@@ -22,6 +21,7 @@ const TableCell = createReactComponent(TableCellClass);
 const TableHeaderCell = createReactComponent(TableHeaderCellClass);
 const TableHeaderRow = createReactComponent(TableHeaderRowClass);
 const TableRow = createReactComponent(TableRowClass);
+const Text = createReactComponent(TextClass);
 
 const HIDDEN_COLUMNS = ["dimensionsCol", "weightCol"];
 
@@ -111,77 +111,77 @@ function App() {
         {/* playground-fold */}
         <TableRow>
           <TableCell>
-            <Label>
+            <Text>
               <b>Notebook Basic 15</b>
               <br />
               HT-1000
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Very Best Screens</Label>
+            <Text>Very Best Screens</Text>
           </TableCell>
           <TableCell>
-            <Label>30 x 18 x 3 cm</Label>
+            <Text>30 x 18 x 3 cm</Text>
           </TableCell>
           <TableCell>
-            <Label style={{ color: "#2b7c2b" }}>
+            <Text style={{ color: "#2b7c2b" }}>
               <b>4.2</b> KG
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>
+            <Text>
               <b>956</b> EUR
-            </Label>
+            </Text>
           </TableCell>
         </TableRow>
         <TableRow>
           <TableCell>
-            <Label>
+            <Text>
               <b>Notebook Basic 17</b>
               <br />
               HT-1001
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Smartcards</Label>
+            <Text>Smartcards</Text>
           </TableCell>
           <TableCell>
-            <Label>29 x 17 x 3.1 cm</Label>
+            <Text>29 x 17 x 3.1 cm</Text>
           </TableCell>
           <TableCell>
-            <Label style={{ color: "#2b7c2b" }}>
+            <Text style={{ color: "#2b7c2b" }}>
               <b>4.5</b> KG
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>
+            <Text>
               <b>1249</b> EUR
-            </Label>
+            </Text>
           </TableCell>
         </TableRow>
         <TableRow>
           <TableCell>
-            <Label>
+            <Text>
               <b>Notebook Basic 18</b>
               <br />
               HT-1002
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Technocom</Label>
+            <Text>Technocom</Text>
           </TableCell>
           <TableCell>
-            <Label>32 x 21 x 4 cm</Label>
+            <Text>32 x 21 x 4 cm</Text>
           </TableCell>
           <TableCell>
-            <Label style={{ color: "#2b7c2b" }}>
+            <Text style={{ color: "#2b7c2b" }}>
               <b>3.7</b> KG
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>
+            <Text>
               <b>29</b> EUR
-            </Label>
+            </Text>
           </TableCell>
         </TableRow>
         {/* playground-fold-end */}

--- a/packages/website/docs/_samples/main/Table/RowAction/main.js
+++ b/packages/website/docs/_samples/main/Table/RowAction/main.js
@@ -5,7 +5,7 @@ import "@ui5/webcomponents/dist/TableRow.js";
 import "@ui5/webcomponents/dist/TableCell.js";
 import "@ui5/webcomponents/dist/TableRowAction.js";
 import "@ui5/webcomponents/dist/TableRowActionNavigation.js";
-import "@ui5/webcomponents/dist/Label.js";
+import "@ui5/webcomponents/dist/Text.js";
 import "@ui5/webcomponents-icons/dist/add.js";
 import "@ui5/webcomponents-icons/dist/edit.js";
 import "@ui5/webcomponents-icons/dist/share.js";

--- a/packages/website/docs/_samples/main/Table/RowAction/sample.html
+++ b/packages/website/docs/_samples/main/Table/RowAction/sample.html
@@ -20,16 +20,16 @@
 		<ui5-table-header-cell horizontal-align="End">Price</ui5-table-header-cell>
 	</ui5-table-header-row>
 	<ui5-table-row row-key="1" interactive>
-		<ui5-table-cell><ui5-label><b>Notebook Basic 15</b><br><a href="#">HT-1000</a></ui5-label></ui5-table-cell>
-		<ui5-table-cell><ui5-label>Very Best Screens</ui5-label></ui5-table-cell>
-		<ui5-table-cell><ui5-label><b>899.99</b> EUR</ui5-label></ui5-table-cell>
-		<ui5-table-row-action-navigation slot="actions"></ui5-table-row-action-navigation>
+		<ui5-table-cell><ui5-text><b>Notebook Basic 15</b><br><a href="#">HT-1000</a></ui5-text></ui5-table-cell>
+		<ui5-table-cell><ui5-text>Very Best Screens</ui5-text></ui5-table-cell>
+		<ui5-table-cell><ui5-text><b>899.99</b> EUR</ui5-text></ui5-table-cell>
+		<ui5-table-row-action-navigation slot="actions" interactive></ui5-table-row-action-navigation>
 	</ui5-table-row>
 <!-- playground-fold-end -->
 	<ui5-table-row row-key="2">
-		<ui5-table-cell><ui5-label><b>Astro Laptop 216</b><br><a href="#">HT-1251</a></ui5-label></ui5-table-cell>
-		<ui5-table-cell><ui5-label>Technocom</ui5-label></ui5-table-cell>
-		<ui5-table-cell><ui5-label><b>679.99</b> EUR</ui5-label></ui5-table-cell>
+		<ui5-table-cell><ui5-text><b>Astro Laptop 216</b><br><a href="#">HT-1251</a></ui5-text></ui5-table-cell>
+		<ui5-table-cell><ui5-text>Technocom</ui5-text></ui5-table-cell>
+		<ui5-table-cell><ui5-text><b>679.99</b> EUR</ui5-text></ui5-table-cell>
 		<ui5-table-row-action slot="actions" icon="delete" text="Delete" handler="onDelete"></ui5-table-row-action>
 		<ui5-table-row-action slot="actions" icon="add" text="Add" handler="onAdd"></ui5-table-row-action>
 		<ui5-table-row-action slot="actions" icon="edit" text="Edit" handler="onEdit"></ui5-table-row-action>
@@ -39,17 +39,17 @@
 	</ui5-table-row>
 <!-- playground-fold -->
 	<ui5-table-row row-key="3" navigated>
-		<ui5-table-cell><ui5-label><b>Benda Laptop 1408</b><br><a href="#">HT-6102</a></ui5-label></ui5-table-cell>
-		<ui5-table-cell><ui5-label>Ultrasonic United</ui5-label></ui5-table-cell>
-		<ui5-table-cell><ui5-label><b>699.99</b> EUR</ui5-label></ui5-table-cell>
+		<ui5-table-cell><ui5-text><b>Benda Laptop 1408</b><br><a href="#">HT-6102</a></ui5-text></ui5-table-cell>
+		<ui5-table-cell><ui5-text>Ultrasonic United</ui5-text></ui5-table-cell>
+		<ui5-table-cell><ui5-text><b>699.99</b> EUR</ui5-text></ui5-table-cell>
 		<ui5-table-row-action slot="actions" icon="share" text="Share" handler="onShare"></ui5-table-row-action>
 		<ui5-table-row-action slot="actions" icon="edit" text="Edit" handler="onEdit" invisible></ui5-table-row-action>
 		<ui5-table-row-action slot="actions" icon="heart" text="Like" handler="onLike"></ui5-table-row-action>
 	</ui5-table-row>
 	<ui5-table-row row-key="4">
-		<ui5-table-cell><ui5-label><b>Broad Screen 22HD</b><br><a href="#">HT-1255</a></ui5-label></ui5-table-cell>
-		<ui5-table-cell><ui5-label>Speaker Experts</ui5-label></ui5-table-cell>
-		<ui5-table-cell><ui5-label><b>399.99</b> EUR</ui5-label></ui5-table-cell>
+		<ui5-table-cell><ui5-text><b>Broad Screen 22HD</b><br><a href="#">HT-1255</a></ui5-text></ui5-table-cell>
+		<ui5-table-cell><ui5-text>Speaker Experts</ui5-text></ui5-table-cell>
+		<ui5-table-cell><ui5-text><b>399.99</b> EUR</ui5-text></ui5-table-cell>
 		<ui5-table-row-action slot="actions" icon="share" text="Share" handler="onShare"></ui5-table-row-action>
 		<ui5-table-row-action slot="actions" icon="add" text="Add" handler="onAdd"></ui5-table-row-action>
 	</ui5-table-row>

--- a/packages/website/docs/_samples/main/Table/RowAction/sample.tsx
+++ b/packages/website/docs/_samples/main/Table/RowAction/sample.tsx
@@ -1,6 +1,5 @@
 import createReactComponent from "@ui5/webcomponents-base/dist/createReactComponent.js";
 import { type UI5CustomEvent } from "@ui5/webcomponents-base";
-import LabelClass from "@ui5/webcomponents/dist/Label.js";
 import TableClass from "@ui5/webcomponents/dist/Table.js";
 import TableCellClass from "@ui5/webcomponents/dist/TableCell.js";
 import TableHeaderCellClass from "@ui5/webcomponents/dist/TableHeaderCell.js";
@@ -15,8 +14,8 @@ import "@ui5/webcomponents-icons/dist/heart.js";
 import "@ui5/webcomponents-icons/dist/delete.js";
 import TableRowActionClass from "@ui5/webcomponents/dist/TableRowAction.js";
 import TableRowActionNavigationClass from "@ui5/webcomponents/dist/TableRowActionNavigation.js";
+import TextClass from "@ui5/webcomponents/dist/Text.js";
 
-const Label = createReactComponent(LabelClass);
 const Table = createReactComponent(TableClass);
 const TableCell = createReactComponent(TableCellClass);
 const TableHeaderCell = createReactComponent(TableHeaderCellClass);
@@ -24,6 +23,7 @@ const TableHeaderRow = createReactComponent(TableHeaderRowClass);
 const TableRow = createReactComponent(TableRowClass);
 const TableRowAction = createReactComponent(TableRowActionClass);
 const TableRowActionNavigation = createReactComponent(TableRowActionNavigationClass);
+const Text = createReactComponent(TextClass);
 
 const handlers: Record<string, (row: any) => void> = {
   onAdd: (row) => {
@@ -73,38 +73,38 @@ function App() {
         </TableHeaderRow>
         <TableRow rowKey="1" interactive={true}>
           <TableCell>
-            <Label>
+            <Text>
               <b>Notebook Basic 15</b>
               <br />
               <a href="#">HT-1000</a>
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Very Best Screens</Label>
+            <Text>Very Best Screens</Text>
           </TableCell>
           <TableCell>
-            <Label>
+            <Text>
               <b>899.99</b> EUR
-            </Label>
+            </Text>
           </TableCell>
-          <TableRowActionNavigation slot="actions"></TableRowActionNavigation>
+          <TableRowActionNavigation slot="actions" interactive></TableRowActionNavigation>
         </TableRow>
         {/* playground-fold-end */}
         <TableRow rowKey="2">
           <TableCell>
-            <Label>
+            <Text>
               <b>Astro Laptop 216</b>
               <br />
               <a href="#">HT-1251</a>
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Technocom</Label>
+            <Text>Technocom</Text>
           </TableCell>
           <TableCell>
-            <Label>
+            <Text>
               <b>679.99</b> EUR
-            </Label>
+            </Text>
           </TableCell>
           <TableRowAction
             slot="actions"
@@ -139,19 +139,19 @@ function App() {
         {/* playground-fold */}
         <TableRow rowKey="3" navigated={true}>
           <TableCell>
-            <Label>
+            <Text>
               <b>Benda Laptop 1408</b>
               <br />
               <a href="#">HT-6102</a>
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Ultrasonic United</Label>
+            <Text>Ultrasonic United</Text>
           </TableCell>
           <TableCell>
-            <Label>
+            <Text>
               <b>699.99</b> EUR
-            </Label>
+            </Text>
           </TableCell>
           <TableRowAction
             slot="actions"
@@ -172,19 +172,19 @@ function App() {
         </TableRow>
         <TableRow rowKey="4">
           <TableCell>
-            <Label>
+            <Text>
               <b>Broad Screen 22HD</b>
               <br />
               <a href="#">HT-1255</a>
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Speaker Experts</Label>
+            <Text>Speaker Experts</Text>
           </TableCell>
           <TableCell>
-            <Label>
+            <Text>
               <b>399.99</b> EUR
-            </Label>
+            </Text>
           </TableCell>
           <TableRowAction
             slot="actions"

--- a/packages/website/docs/_samples/main/Table/RowActionNavigation/RowActionNavigation.md
+++ b/packages/website/docs/_samples/main/Table/RowActionNavigation/RowActionNavigation.md
@@ -2,9 +2,7 @@ import html from '!!raw-loader!./sample.html';
 import js from '!!raw-loader!./main.js';
 import react from '!!raw-loader!./sample.tsx';
 
-By default, the `ui5-table-row-action-navigation` component displays a dedicated navigation icon to indicate that a row is navigable. The icon appears on the right side of the row and is the last item to move into the overflow menu. Therefore, if you want to show additional row actions along with the `ui5-table-row-action-navigation`, the `row-action-count` property of the `ui5-table` must be set to at least `2`. This ensures that the `ui5-table-row-action-navigation` component never appears in the overflow menu.
-
-If the `interactive` property is set to `true`, the navigation icon appears as a button, and clicking it triggers the table’s `row-action-click` event.
+By default, the `ui5-table-row-action-navigation` component displays a navigation button to indicate that a row is navigable. The button appears on the right side of the row and is the last item to move into the overflow menu. Therefore, if you want to show additional row actions along with the `ui5-table-row-action-navigation`, the `row-action-count` property of the `ui5-table` must be set to at least `2`. This ensures that the `ui5-table-row-action-navigation` component never appears in the overflow menu.
 
 The `invisible` property allows you to hide specific navigation actions. This property is useful for ensuring a consistent layout by displaying the navigation column.
 

--- a/packages/website/docs/_samples/main/Table/RowActionNavigation/main.js
+++ b/packages/website/docs/_samples/main/Table/RowActionNavigation/main.js
@@ -4,7 +4,7 @@ import "@ui5/webcomponents/dist/TableHeaderCell.js";
 import "@ui5/webcomponents/dist/TableRow.js";
 import "@ui5/webcomponents/dist/TableCell.js";
 import "@ui5/webcomponents/dist/TableRowActionNavigation.js";
-import "@ui5/webcomponents/dist/Label.js";
+import "@ui5/webcomponents/dist/Text.js";
 
 const table = document.getElementById("table");
 table.addEventListener("row-action-click", (e) => {

--- a/packages/website/docs/_samples/main/Table/RowActionNavigation/sample.html
+++ b/packages/website/docs/_samples/main/Table/RowActionNavigation/sample.html
@@ -20,29 +20,29 @@
 		<ui5-table-header-cell horizontal-align="End">Price</ui5-table-header-cell>
 	</ui5-table-header-row>
 	<ui5-table-row row-key="1">
-		<ui5-table-cell><ui5-label><b>Notebook Basic 15</b><br><a href="#">HT-1000</a></ui5-label></ui5-table-cell>
-		<ui5-table-cell><ui5-label>Very Best Screens</ui5-label></ui5-table-cell>
-		<ui5-table-cell><ui5-label><b>899.99</b> EUR</ui5-label></ui5-table-cell>
+		<ui5-table-cell><ui5-text><b>Notebook Basic 15</b><br><a href="#">HT-1000</a></ui5-text></ui5-table-cell>
+		<ui5-table-cell><ui5-text>Very Best Screens</ui5-text></ui5-table-cell>
+		<ui5-table-cell><ui5-text><b>899.99</b> EUR</ui5-text></ui5-table-cell>
 		<ui5-table-row-action-navigation slot="actions" interactive></ui5-table-row-action-navigation>
 	</ui5-table-row>
 <!-- playground-fold-end -->
 	<ui5-table-row row-key="2" interactive>
-		<ui5-table-cell><ui5-label><b>Astro Laptop 216</b><br><a href="#">HT-1251</a></ui5-label></ui5-table-cell>
-		<ui5-table-cell><ui5-label>Technocom</ui5-label></ui5-table-cell>
-		<ui5-table-cell><ui5-label><b>679.99</b> EUR</ui5-label></ui5-table-cell>
-		<ui5-table-row-action-navigation slot="actions"></ui5-table-row-action-navigation>
+		<ui5-table-cell><ui5-text><b>Astro Laptop 216</b><br><a href="#">HT-1251</a></ui5-text></ui5-table-cell>
+		<ui5-table-cell><ui5-text>Technocom</ui5-text></ui5-table-cell>
+		<ui5-table-cell><ui5-text><b>679.99</b> EUR</ui5-text></ui5-table-cell>
+		<ui5-table-row-action-navigation slot="actions" interactive></ui5-table-row-action-navigation>
 	</ui5-table-row>
 <!-- playground-fold -->
 	<ui5-table-row row-key="3" navigated>
-		<ui5-table-cell><ui5-label><b>Benda Laptop 1408</b><br><a href="#">HT-6102</a></ui5-label></ui5-table-cell>
-		<ui5-table-cell><ui5-label>Ultrasonic United</ui5-label></ui5-table-cell>
-		<ui5-table-cell><ui5-label><b>699.99</b> EUR</ui5-label></ui5-table-cell>
-		<ui5-table-row-action-navigation slot="actions" invisible></ui5-table-row-action-navigation>
+		<ui5-table-cell><ui5-text><b>Benda Laptop 1408</b><br><a href="#">HT-6102</a></ui5-text></ui5-table-cell>
+		<ui5-table-cell><ui5-text>Ultrasonic United</ui5-text></ui5-table-cell>
+		<ui5-table-cell><ui5-text><b>699.99</b> EUR</ui5-text></ui5-table-cell>
+		<ui5-table-row-action-navigation slot="actions" invisible interactive></ui5-table-row-action-navigation>
 	</ui5-table-row>
 	<ui5-table-row row-key="4">
-		<ui5-table-cell><ui5-label><b>Broad Screen 22HD</b><br><a href="#">HT-1255</a></ui5-label></ui5-table-cell>
-		<ui5-table-cell><ui5-label>Speaker Experts</ui5-label></ui5-table-cell>
-		<ui5-table-cell><ui5-label><b>399.99</b> EUR</ui5-label></ui5-table-cell>
+		<ui5-table-cell><ui5-text><b>Broad Screen 22HD</b><br><a href="#">HT-1255</a></ui5-text></ui5-table-cell>
+		<ui5-table-cell><ui5-text>Speaker Experts</ui5-text></ui5-table-cell>
+		<ui5-table-cell><ui5-text><b>399.99</b> EUR</ui5-text></ui5-table-cell>
 		<ui5-table-row-action-navigation slot="actions" interactive></ui5-table-row-action-navigation>
 	</ui5-table-row>
 <!-- playground-fold-end -->

--- a/packages/website/docs/_samples/main/Table/RowActionNavigation/sample.tsx
+++ b/packages/website/docs/_samples/main/Table/RowActionNavigation/sample.tsx
@@ -1,6 +1,5 @@
 import createReactComponent from "@ui5/webcomponents-base/dist/createReactComponent.js";
 import { type UI5CustomEvent } from "@ui5/webcomponents-base";
-import LabelClass from "@ui5/webcomponents/dist/Label.js";
 import TableClass from "@ui5/webcomponents/dist/Table.js";
 import TableCellClass from "@ui5/webcomponents/dist/TableCell.js";
 import TableHeaderCellClass from "@ui5/webcomponents/dist/TableHeaderCell.js";
@@ -8,14 +7,15 @@ import TableHeaderRowClass from "@ui5/webcomponents/dist/TableHeaderRow.js";
 import TableRowClass from "@ui5/webcomponents/dist/TableRow.js";
 import "@ui5/webcomponents/dist/TableRowActionNavigation.js";
 import TableRowActionNavigationClass from "@ui5/webcomponents/dist/TableRowActionNavigation.js";
+import TextClass from "@ui5/webcomponents/dist/Text.js";
 
-const Label = createReactComponent(LabelClass);
 const Table = createReactComponent(TableClass);
 const TableCell = createReactComponent(TableCellClass);
 const TableHeaderCell = createReactComponent(TableHeaderCellClass);
 const TableHeaderRow = createReactComponent(TableHeaderRowClass);
 const TableRow = createReactComponent(TableRowClass);
 const TableRowActionNavigation = createReactComponent(TableRowActionNavigationClass);
+const Text = createReactComponent(TextClass);
 
 function App() {
   const handleTableRowActionClick = (
@@ -40,19 +40,19 @@ function App() {
         </TableHeaderRow>
         <TableRow rowKey="1">
           <TableCell>
-            <Label>
+            <Text>
               <b>Notebook Basic 15</b>
               <br />
               <a href="#">HT-1000</a>
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Very Best Screens</Label>
+            <Text>Very Best Screens</Text>
           </TableCell>
           <TableCell>
-            <Label>
+            <Text>
               <b>899.99</b> EUR
-            </Label>
+            </Text>
           </TableCell>
           <TableRowActionNavigation
             slot="actions"
@@ -62,59 +62,60 @@ function App() {
         {/* playground-fold-end */}
         <TableRow rowKey="2" interactive={true}>
           <TableCell>
-            <Label>
+            <Text>
               <b>Astro Laptop 216</b>
               <br />
               <a href="#">HT-1251</a>
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Technocom</Label>
+            <Text>Technocom</Text>
           </TableCell>
           <TableCell>
-            <Label>
+            <Text>
               <b>679.99</b> EUR
-            </Label>
+            </Text>
           </TableCell>
-          <TableRowActionNavigation slot="actions"></TableRowActionNavigation>
+          <TableRowActionNavigation slot="actions" interactive></TableRowActionNavigation>
         </TableRow>
         {/* playground-fold */}
         <TableRow rowKey="3" navigated={true}>
           <TableCell>
-            <Label>
+            <Text>
               <b>Benda Laptop 1408</b>
               <br />
               <a href="#">HT-6102</a>
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Ultrasonic United</Label>
+            <Text>Ultrasonic United</Text>
           </TableCell>
           <TableCell>
-            <Label>
+            <Text>
               <b>699.99</b> EUR
-            </Label>
+            </Text>
           </TableCell>
           <TableRowActionNavigation
             slot="actions"
             invisible
+            interactive
           ></TableRowActionNavigation>
         </TableRow>
         <TableRow rowKey="4">
           <TableCell>
-            <Label>
+            <Text>
               <b>Broad Screen 22HD</b>
               <br />
               <a href="#">HT-1255</a>
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Speaker Experts</Label>
+            <Text>Speaker Experts</Text>
           </TableCell>
           <TableCell>
-            <Label>
+            <Text>
               <b>399.99</b> EUR
-            </Label>
+            </Text>
           </TableCell>
           <TableRowActionNavigation
             slot="actions"

--- a/packages/website/docs/_samples/main/Table/ScrollMode/main.js
+++ b/packages/website/docs/_samples/main/Table/ScrollMode/main.js
@@ -1,4 +1,4 @@
 import "@ui5/webcomponents/dist/Table.js";
 import "@ui5/webcomponents/dist/TableHeaderRow.js";
 import "@ui5/webcomponents/dist/TableHeaderCell.js";
-import "@ui5/webcomponents/dist/Label.js";
+import "@ui5/webcomponents/dist/Text.js";

--- a/packages/website/docs/_samples/main/Table/ScrollMode/sample.html
+++ b/packages/website/docs/_samples/main/Table/ScrollMode/sample.html
@@ -21,25 +21,25 @@
 			</ui5-table-header-row>
 <!-- playground-fold -->
 			<ui5-table-row>
-				<ui5-table-cell><ui5-label><b>Notebook Basic 15</b><br>HT-1000</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>Very Best Screens</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>30 x 18 x 3 cm</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>4.2</b> KG</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label><b>956</b> EUR</ui5-label></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>Notebook Basic 15</b><br>HT-1000</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>Very Best Screens</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>30 x 18 x 3 cm</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text style="color: #2b7c2b"><b>4.2</b> KG</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>956</b> EUR</ui5-text></ui5-table-cell>
 			</ui5-table-row>
 			<ui5-table-row>
-				<ui5-table-cell><ui5-label><b>Notebook Basic 17</b><br>HT-1001</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>Smartcards</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>29 x 17 x 3.1 cm</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>4.5</b> KG</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label><b>1249</b> EUR</ui5-label></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>Notebook Basic 17</b><br>HT-1001</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>Smartcards</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>29 x 17 x 3.1 cm</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text style="color: #2b7c2b"><b>4.5</b> KG</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>1249</b> EUR</ui5-text></ui5-table-cell>
 			</ui5-table-row>
 			<ui5-table-row>
-				<ui5-table-cell><ui5-label><b>Notebook Basic 18</b><br>HT-1002</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>Technocom</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>32 x 21 x 4 cm</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>3.7</b> KG</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label><b>29</b> EUR</ui5-label></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>Notebook Basic 18</b><br>HT-1002</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>Technocom</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>32 x 21 x 4 cm</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text style="color: #2b7c2b"><b>3.7</b> KG</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>29</b> EUR</ui5-text></ui5-table-cell>
 			</ui5-table-row>
 <!-- playground-fold-end -->
 		</ui5-table>

--- a/packages/website/docs/_samples/main/Table/ScrollMode/sample.tsx
+++ b/packages/website/docs/_samples/main/Table/ScrollMode/sample.tsx
@@ -1,17 +1,17 @@
 import createReactComponent from "@ui5/webcomponents-base/dist/createReactComponent.js";
-import LabelClass from "@ui5/webcomponents/dist/Label.js";
 import TableClass from "@ui5/webcomponents/dist/Table.js";
 import TableCellClass from "@ui5/webcomponents/dist/TableCell.js";
 import TableHeaderCellClass from "@ui5/webcomponents/dist/TableHeaderCell.js";
 import TableHeaderRowClass from "@ui5/webcomponents/dist/TableHeaderRow.js";
 import TableRowClass from "@ui5/webcomponents/dist/TableRow.js";
+import TextClass from "@ui5/webcomponents/dist/Text.js";
 
-const Label = createReactComponent(LabelClass);
 const Table = createReactComponent(TableClass);
 const TableCell = createReactComponent(TableCellClass);
 const TableHeaderCell = createReactComponent(TableHeaderCellClass);
 const TableHeaderRow = createReactComponent(TableHeaderRowClass);
 const TableRow = createReactComponent(TableRowClass);
+const Text = createReactComponent(TextClass);
 
 function App() {
   return (
@@ -37,77 +37,77 @@ function App() {
         {/* playground-fold */}
         <TableRow>
           <TableCell>
-            <Label>
+            <Text>
               <b>Notebook Basic 15</b>
               <br />
               HT-1000
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Very Best Screens</Label>
+            <Text>Very Best Screens</Text>
           </TableCell>
           <TableCell>
-            <Label>30 x 18 x 3 cm</Label>
+            <Text>30 x 18 x 3 cm</Text>
           </TableCell>
           <TableCell>
-            <Label style={{ color: "#2b7c2b" }}>
+            <Text style={{ color: "#2b7c2b" }}>
               <b>4.2</b> KG
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>
+            <Text>
               <b>956</b> EUR
-            </Label>
+            </Text>
           </TableCell>
         </TableRow>
         <TableRow>
           <TableCell>
-            <Label>
+            <Text>
               <b>Notebook Basic 17</b>
               <br />
               HT-1001
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Smartcards</Label>
+            <Text>Smartcards</Text>
           </TableCell>
           <TableCell>
-            <Label>29 x 17 x 3.1 cm</Label>
+            <Text>29 x 17 x 3.1 cm</Text>
           </TableCell>
           <TableCell>
-            <Label style={{ color: "#2b7c2b" }}>
+            <Text style={{ color: "#2b7c2b" }}>
               <b>4.5</b> KG
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>
+            <Text>
               <b>1249</b> EUR
-            </Label>
+            </Text>
           </TableCell>
         </TableRow>
         <TableRow>
           <TableCell>
-            <Label>
+            <Text>
               <b>Notebook Basic 18</b>
               <br />
               HT-1002
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Technocom</Label>
+            <Text>Technocom</Text>
           </TableCell>
           <TableCell>
-            <Label>32 x 21 x 4 cm</Label>
+            <Text>32 x 21 x 4 cm</Text>
           </TableCell>
           <TableCell>
-            <Label style={{ color: "#2b7c2b" }}>
+            <Text style={{ color: "#2b7c2b" }}>
               <b>3.7</b> KG
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>
+            <Text>
               <b>29</b> EUR
-            </Label>
+            </Text>
           </TableCell>
         </TableRow>
         {/* playground-fold-end */}

--- a/packages/website/docs/_samples/main/Table/ScrollToLoad/main.js
+++ b/packages/website/docs/_samples/main/Table/ScrollToLoad/main.js
@@ -2,8 +2,8 @@ import "@ui5/webcomponents/dist/Table.js";
 import "@ui5/webcomponents/dist/TableGrowing.js";
 import "@ui5/webcomponents/dist/TableHeaderRow.js";
 import "@ui5/webcomponents/dist/TableHeaderCell.js";
-import "@ui5/webcomponents/dist/Label.js";
 import "@ui5/webcomponents/dist/Input.js";
+import "@ui5/webcomponents/dist/Text.js";
 
 const MAX_GROW = 20;
 

--- a/packages/website/docs/_samples/main/Table/ScrollToLoad/sample.html
+++ b/packages/website/docs/_samples/main/Table/ScrollToLoad/sample.html
@@ -22,25 +22,25 @@
 				<ui5-table-header-cell id="priceCol">Price</ui5-table-header-cell>
 			</ui5-table-header-row>
 			<ui5-table-row row-key="0">
-				<ui5-table-cell><ui5-label><b>Notebook Basic 15</b><br>HT-1000</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>Very Best Screens</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>30 x 18 x 3 cm</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>4.2</b> KG</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label><b>956</b> EUR</ui5-label></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>Notebook Basic 15</b><br>HT-1000</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>Very Best Screens</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>30 x 18 x 3 cm</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text style="color: #2b7c2b"><b>4.2</b> KG</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>956</b> EUR</ui5-text></ui5-table-cell>
 			</ui5-table-row>
 			<ui5-table-row row-key="1">
-				<ui5-table-cell><ui5-label><b>Notebook Basic 17</b><br>HT-1001</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>Smartcards</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>29 x 17 x 3.1 cm</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>4.5</b> KG</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label><b>1249</b> EUR</ui5-label></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>Notebook Basic 17</b><br>HT-1001</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>Smartcards</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>29 x 17 x 3.1 cm</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text style="color: #2b7c2b"><b>4.5</b> KG</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>1249</b> EUR</ui5-text></ui5-table-cell>
 			</ui5-table-row>
 			<ui5-table-row row-key="2">
-				<ui5-table-cell><ui5-label><b>Notebook Basic 18</b><br>HT-1002</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>Technocom</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>32 x 21 x 4 cm</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>3.7</b> KG</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label><b>29</b> EUR</ui5-label></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>Notebook Basic 18</b><br>HT-1002</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>Technocom</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>32 x 21 x 4 cm</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text style="color: #2b7c2b"><b>3.7</b> KG</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>29</b> EUR</ui5-text></ui5-table-cell>
 			</ui5-table-row>
 <!-- playground-fold-end -->
 		</ui5-table>

--- a/packages/website/docs/_samples/main/Table/ScrollToLoad/sample.tsx
+++ b/packages/website/docs/_samples/main/Table/ScrollToLoad/sample.tsx
@@ -1,20 +1,20 @@
 import { useState } from "react";
 import createReactComponent from "@ui5/webcomponents-base/dist/createReactComponent.js";
-import LabelClass from "@ui5/webcomponents/dist/Label.js";
 import TableClass from "@ui5/webcomponents/dist/Table.js";
 import TableCellClass from "@ui5/webcomponents/dist/TableCell.js";
 import TableGrowingClass from "@ui5/webcomponents/dist/TableGrowing.js";
 import TableHeaderCellClass from "@ui5/webcomponents/dist/TableHeaderCell.js";
 import TableHeaderRowClass from "@ui5/webcomponents/dist/TableHeaderRow.js";
 import TableRowClass from "@ui5/webcomponents/dist/TableRow.js";
+import TextClass from "@ui5/webcomponents/dist/Text.js";
 
-const Label = createReactComponent(LabelClass);
 const Table = createReactComponent(TableClass);
 const TableCell = createReactComponent(TableCellClass);
 const TableGrowing = createReactComponent(TableGrowingClass);
 const TableHeaderCell = createReactComponent(TableHeaderCellClass);
 const TableHeaderRow = createReactComponent(TableHeaderRowClass);
 const TableRow = createReactComponent(TableRowClass);
+const Text = createReactComponent(TextClass);
 
 const MAX_GROW = 20;
 
@@ -66,103 +66,103 @@ function App() {
         </TableHeaderRow>
         <TableRow rowKey="0">
           <TableCell>
-            <Label>
+            <Text>
               <b>Notebook Basic 15</b>
               <br />
               HT-1000
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Very Best Screens</Label>
+            <Text>Very Best Screens</Text>
           </TableCell>
           <TableCell>
-            <Label>30 x 18 x 3 cm</Label>
+            <Text>30 x 18 x 3 cm</Text>
           </TableCell>
           <TableCell>
-            <Label style={{ color: "#2b7c2b" }}>
+            <Text style={{ color: "#2b7c2b" }}>
               <b>4.2</b> KG
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>
+            <Text>
               <b>956</b> EUR
-            </Label>
+            </Text>
           </TableCell>
         </TableRow>
         <TableRow rowKey="1">
           <TableCell>
-            <Label>
+            <Text>
               <b>Notebook Basic 17</b>
               <br />
               HT-1001
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Smartcards</Label>
+            <Text>Smartcards</Text>
           </TableCell>
           <TableCell>
-            <Label>29 x 17 x 3.1 cm</Label>
+            <Text>29 x 17 x 3.1 cm</Text>
           </TableCell>
           <TableCell>
-            <Label style={{ color: "#2b7c2b" }}>
+            <Text style={{ color: "#2b7c2b" }}>
               <b>4.5</b> KG
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>
+            <Text>
               <b>1249</b> EUR
-            </Label>
+            </Text>
           </TableCell>
         </TableRow>
         <TableRow rowKey="2">
           <TableCell>
-            <Label>
+            <Text>
               <b>Notebook Basic 18</b>
               <br />
               HT-1002
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Technocom</Label>
+            <Text>Technocom</Text>
           </TableCell>
           <TableCell>
-            <Label>32 x 21 x 4 cm</Label>
+            <Text>32 x 21 x 4 cm</Text>
           </TableCell>
           <TableCell>
-            <Label style={{ color: "#2b7c2b" }}>
+            <Text style={{ color: "#2b7c2b" }}>
               <b>3.7</b> KG
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>
+            <Text>
               <b>29</b> EUR
-            </Label>
+            </Text>
           </TableCell>
         </TableRow>
         {extraRows.map((row) => (
           <TableRow rowKey={String(row.key)} key={row.key}>
             <TableCell>
-              <Label>
+              <Text>
                 <b>{row.name}</b>
                 <br />
                 {row.code}
-              </Label>
+              </Text>
             </TableCell>
             <TableCell>
-              <Label>Technocom</Label>
+              <Text>Technocom</Text>
             </TableCell>
             <TableCell>
-              <Label>32 x 21 x 4 cm</Label>
+              <Text>32 x 21 x 4 cm</Text>
             </TableCell>
             <TableCell>
-              <Label style={{ color: "#2b7c2b" }}>
+              <Text style={{ color: "#2b7c2b" }}>
                 <b>3.7</b> KG
-              </Label>
+              </Text>
             </TableCell>
             <TableCell>
-              <Label>
+              <Text>
                 <b>29</b> EUR
-              </Label>
+              </Text>
             </TableCell>
           </TableRow>
         ))}

--- a/packages/website/docs/_samples/main/Table/Selection/main.js
+++ b/packages/website/docs/_samples/main/Table/Selection/main.js
@@ -2,10 +2,10 @@ import "@ui5/webcomponents/dist/Table.js";
 import "@ui5/webcomponents/dist/TableHeaderRow.js";
 import "@ui5/webcomponents/dist/TableHeaderCell.js";
 import "@ui5/webcomponents/dist/TableSelection.js";
-import "@ui5/webcomponents/dist/Label.js";
 import "@ui5/webcomponents/dist/Input.js";
 import "@ui5/webcomponents/dist/ComboBox.js";
 import "@ui5/webcomponents/dist/ComboBoxItem.js";
+import "@ui5/webcomponents/dist/Text.js";
 
 const selectionFeature = document.getElementById("selection");
 const selectionGroup = document.getElementById("selectionGroup");

--- a/packages/website/docs/_samples/main/Table/Selection/sample.html
+++ b/packages/website/docs/_samples/main/Table/Selection/sample.html
@@ -28,25 +28,25 @@
 				<ui5-table-header-cell id="priceCol" min-width="220px" style="text-align: end;">Price</ui5-table-header-cell>
 			</ui5-table-header-row>
 			<ui5-table-row row-key="0">
-				<ui5-table-cell><ui5-label><b>Notebook Basic 15</b><br>HT-1000</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>Very Best Screens</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>30 x 18 x 3 cm</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>4.2</b> KG</ui5-label></ui5-table-cell>
-				<ui5-table-cell style="text-align: end;"><ui5-label style="text-align: end;"><b>956</b> EUR</ui5-label></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>Notebook Basic 15</b><br>HT-1000</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>Very Best Screens</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>30 x 18 x 3 cm</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text style="color: #2b7c2b"><b>4.2</b> KG</ui5-text></ui5-table-cell>
+				<ui5-table-cell style="text-align: end;"><ui5-text style="text-align: end;"><b>956</b> EUR</ui5-text></ui5-table-cell>
 			</ui5-table-row>
 			<ui5-table-row row-key="1">
-				<ui5-table-cell><ui5-label><b>Notebook Basic 17</b><br>HT-1001</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>Smartcards</ui5-label></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>Notebook Basic 17</b><br>HT-1001</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>Smartcards</ui5-text></ui5-table-cell>
 				<ui5-table-cell><ui5-input value="29 x 17 x 3.1 cm" accessible-name-ref="dimensionsCol"></ui5-input></ui5-table-cell>
-				<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>4.5</b> KG</ui5-label></ui5-table-cell>
-				<ui5-table-cell style="text-align: end;"><ui5-label style="text-align: end;"><b>1249</b> EUR</ui5-label></ui5-table-cell>
+				<ui5-table-cell><ui5-text style="color: #2b7c2b"><b>4.5</b> KG</ui5-text></ui5-table-cell>
+				<ui5-table-cell style="text-align: end;"><ui5-text style="text-align: end;"><b>1249</b> EUR</ui5-text></ui5-table-cell>
 			</ui5-table-row>
 			<ui5-table-row row-key="2">
-				<ui5-table-cell><ui5-label><b>Notebook Basic 18</b><br>HT-1002</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>Technocom</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>32 x 21 x 4 cm</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>3.7</b> KG</ui5-label></ui5-table-cell>
-				<ui5-table-cell style="text-align: end;"><ui5-label style="text-align: end;"><b>29</b> EUR</ui5-label></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>Notebook Basic 18</b><br>HT-1002</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>Technocom</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>32 x 21 x 4 cm</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text style="color: #2b7c2b"><b>3.7</b> KG</ui5-text></ui5-table-cell>
+				<ui5-table-cell style="text-align: end;"><ui5-text style="text-align: end;"><b>29</b> EUR</ui5-text></ui5-table-cell>
 			</ui5-table-row>
 <!-- playground-fold-end -->
 		</ui5-table>

--- a/packages/website/docs/_samples/main/Table/Selection/sample.tsx
+++ b/packages/website/docs/_samples/main/Table/Selection/sample.tsx
@@ -1,7 +1,6 @@
 import { useRef } from "react";
 import createReactComponent from "@ui5/webcomponents-base/dist/createReactComponent.js";
 import InputClass from "@ui5/webcomponents/dist/Input.js";
-import LabelClass from "@ui5/webcomponents/dist/Label.js";
 import RadioButtonClass from "@ui5/webcomponents/dist/RadioButton.js";
 import TableClass from "@ui5/webcomponents/dist/Table.js";
 import TableCellClass from "@ui5/webcomponents/dist/TableCell.js";
@@ -9,9 +8,9 @@ import TableHeaderCellClass from "@ui5/webcomponents/dist/TableHeaderCell.js";
 import TableHeaderRowClass from "@ui5/webcomponents/dist/TableHeaderRow.js";
 import TableRowClass from "@ui5/webcomponents/dist/TableRow.js";
 import TableSelectionClass from "@ui5/webcomponents/dist/TableSelection.js";
+import TextClass from "@ui5/webcomponents/dist/Text.js";
 
 const Input = createReactComponent(InputClass);
-const Label = createReactComponent(LabelClass);
 const RadioButton = createReactComponent(RadioButtonClass);
 const Table = createReactComponent(TableClass);
 const TableCell = createReactComponent(TableCellClass);
@@ -19,6 +18,7 @@ const TableHeaderCell = createReactComponent(TableHeaderCellClass);
 const TableHeaderRow = createReactComponent(TableHeaderRowClass);
 const TableRow = createReactComponent(TableRowClass);
 const TableSelection = createReactComponent(TableSelectionClass);
+const Text = createReactComponent(TextClass);
 
 function App() {
   const selectionRef = useRef(null);
@@ -67,77 +67,77 @@ function App() {
         </TableHeaderRow>
         <TableRow rowKey="0">
           <TableCell>
-            <Label>
+            <Text>
               <b>Notebook Basic 15</b>
               <br />
               HT-1000
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Very Best Screens</Label>
+            <Text>Very Best Screens</Text>
           </TableCell>
           <TableCell>
-            <Label>30 x 18 x 3 cm</Label>
+            <Text>30 x 18 x 3 cm</Text>
           </TableCell>
           <TableCell>
-            <Label style={{ color: "#2b7c2b" }}>
+            <Text style={{ color: "#2b7c2b" }}>
               <b>4.2</b> KG
-            </Label>
+            </Text>
           </TableCell>
           <TableCell style={{ textAlign: "end" }}>
-            <Label style={{ textAlign: "end" }}>
+            <Text style={{ textAlign: "end" }}>
               <b>956</b> EUR
-            </Label>
+            </Text>
           </TableCell>
         </TableRow>
         <TableRow rowKey="1">
           <TableCell>
-            <Label>
+            <Text>
               <b>Notebook Basic 17</b>
               <br />
               HT-1001
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Smartcards</Label>
+            <Text>Smartcards</Text>
           </TableCell>
           <TableCell>
             <Input value="29 x 17 x 3.1 cm" accessibleNameRef="dimensionsCol" />
           </TableCell>
           <TableCell>
-            <Label style={{ color: "#2b7c2b" }}>
+            <Text style={{ color: "#2b7c2b" }}>
               <b>4.5</b> KG
-            </Label>
+            </Text>
           </TableCell>
           <TableCell style={{ textAlign: "end" }}>
-            <Label style={{ textAlign: "end" }}>
+            <Text style={{ textAlign: "end" }}>
               <b>1249</b> EUR
-            </Label>
+            </Text>
           </TableCell>
         </TableRow>
         <TableRow rowKey="2">
           <TableCell>
-            <Label>
+            <Text>
               <b>Notebook Basic 18</b>
               <br />
               HT-1002
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Technocom</Label>
+            <Text>Technocom</Text>
           </TableCell>
           <TableCell>
-            <Label>32 x 21 x 4 cm</Label>
+            <Text>32 x 21 x 4 cm</Text>
           </TableCell>
           <TableCell>
-            <Label style={{ color: "#2b7c2b" }}>
+            <Text style={{ color: "#2b7c2b" }}>
               <b>3.7</b> KG
-            </Label>
+            </Text>
           </TableCell>
           <TableCell style={{ textAlign: "end" }}>
-            <Label style={{ textAlign: "end" }}>
+            <Text style={{ textAlign: "end" }}>
               <b>29</b> EUR
-            </Label>
+            </Text>
           </TableCell>
         </TableRow>
         {/* playground-fold-end */}

--- a/packages/website/docs/_samples/main/Table/SelectionMulti/main.js
+++ b/packages/website/docs/_samples/main/Table/SelectionMulti/main.js
@@ -5,6 +5,7 @@ import "@ui5/webcomponents/dist/TableHeaderRow.js";
 import "@ui5/webcomponents/dist/TableHeaderCell.js";
 import "@ui5/webcomponents/dist/TableSelectionMulti.js";
 import "@ui5/webcomponents/dist/Label.js";
+import "@ui5/webcomponents/dist/Text.js";
 
 const selectionFeature = document.getElementById("selection");
 let oldSelectedSet = selectionFeature.getSelectedAsSet();

--- a/packages/website/docs/_samples/main/Table/SelectionMulti/sample.html
+++ b/packages/website/docs/_samples/main/Table/SelectionMulti/sample.html
@@ -35,25 +35,25 @@
 				<ui5-table-header-cell id="priceCol" width="1fr" horizontal-align="End">Price</ui5-table-header-cell>
 			</ui5-table-header-row>
 			<ui5-table-row row-key="Row1">
-				<ui5-table-cell><ui5-label><b>Notebook Basic 15</b><br>HT-1000</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>Very Best Screens</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>30 x 18 x 3 cm</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>4.2</b> KG</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label><b>956</b> EUR</ui5-label></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>Notebook Basic 15</b><br>HT-1000</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>Very Best Screens</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>30 x 18 x 3 cm</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text style="color: #2b7c2b"><b>4.2</b> KG</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>956</b> EUR</ui5-text></ui5-table-cell>
 			</ui5-table-row>
 			<ui5-table-row row-key="Row2">
-				<ui5-table-cell><ui5-label><b>Notebook Basic 17</b><br>HT-1001</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>Smartcards</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>29 x 17 x 3.1 cm</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>4.5</b> KG</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label><b>1249</b> EUR</ui5-label></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>Notebook Basic 17</b><br>HT-1001</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>Smartcards</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>29 x 17 x 3.1 cm</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text style="color: #2b7c2b"><b>4.5</b> KG</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>1249</b> EUR</ui5-text></ui5-table-cell>
 			</ui5-table-row>
 			<ui5-table-row row-key="Row3">
-				<ui5-table-cell><ui5-label><b>Notebook Basic 18</b><br>HT-1002</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>Technocom</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>32 x 21 x 4 cm</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>3.7</b> KG</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label><b>29</b> EUR</ui5-label></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>Notebook Basic 18</b><br>HT-1002</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>Technocom</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>32 x 21 x 4 cm</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text style="color: #2b7c2b"><b>3.7</b> KG</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>29</b> EUR</ui5-text></ui5-table-cell>
 			</ui5-table-row>
 <!-- playground-fold-end -->
 		</ui5-table>

--- a/packages/website/docs/_samples/main/Table/SelectionMulti/sample.tsx
+++ b/packages/website/docs/_samples/main/Table/SelectionMulti/sample.tsx
@@ -8,6 +8,7 @@ import TableHeaderCellClass from "@ui5/webcomponents/dist/TableHeaderCell.js";
 import TableHeaderRowClass from "@ui5/webcomponents/dist/TableHeaderRow.js";
 import TableRowClass from "@ui5/webcomponents/dist/TableRow.js";
 import TableSelectionMultiClass from "@ui5/webcomponents/dist/TableSelectionMulti.js";
+import TextClass from "@ui5/webcomponents/dist/Text.js";
 
 const Label = createReactComponent(LabelClass);
 const RadioButton = createReactComponent(RadioButtonClass);
@@ -17,6 +18,7 @@ const TableHeaderCell = createReactComponent(TableHeaderCellClass);
 const TableHeaderRow = createReactComponent(TableHeaderRowClass);
 const TableRow = createReactComponent(TableRowClass);
 const TableSelectionMulti = createReactComponent(TableSelectionMultiClass);
+const Text = createReactComponent(TextClass);
 
 function App() {
   const selectionRef = useRef(null);
@@ -123,77 +125,77 @@ function App() {
         </TableHeaderRow>
         <TableRow rowKey="Row1">
           <TableCell>
-            <Label>
+            <Text>
               <b>Notebook Basic 15</b>
               <br />
               HT-1000
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Very Best Screens</Label>
+            <Text>Very Best Screens</Text>
           </TableCell>
           <TableCell>
-            <Label>30 x 18 x 3 cm</Label>
+            <Text>30 x 18 x 3 cm</Text>
           </TableCell>
           <TableCell>
-            <Label style={{ color: "#2b7c2b" }}>
+            <Text style={{ color: "#2b7c2b" }}>
               <b>4.2</b> KG
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>
+            <Text>
               <b>956</b> EUR
-            </Label>
+            </Text>
           </TableCell>
         </TableRow>
         <TableRow rowKey="Row2">
           <TableCell>
-            <Label>
+            <Text>
               <b>Notebook Basic 17</b>
               <br />
               HT-1001
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Smartcards</Label>
+            <Text>Smartcards</Text>
           </TableCell>
           <TableCell>
-            <Label>29 x 17 x 3.1 cm</Label>
+            <Text>29 x 17 x 3.1 cm</Text>
           </TableCell>
           <TableCell>
-            <Label style={{ color: "#2b7c2b" }}>
+            <Text style={{ color: "#2b7c2b" }}>
               <b>4.5</b> KG
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>
+            <Text>
               <b>1249</b> EUR
-            </Label>
+            </Text>
           </TableCell>
         </TableRow>
         <TableRow rowKey="Row3">
           <TableCell>
-            <Label>
+            <Text>
               <b>Notebook Basic 18</b>
               <br />
               HT-1002
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Technocom</Label>
+            <Text>Technocom</Text>
           </TableCell>
           <TableCell>
-            <Label>32 x 21 x 4 cm</Label>
+            <Text>32 x 21 x 4 cm</Text>
           </TableCell>
           <TableCell>
-            <Label style={{ color: "#2b7c2b" }}>
+            <Text style={{ color: "#2b7c2b" }}>
               <b>3.7</b> KG
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>
+            <Text>
               <b>29</b> EUR
-            </Label>
+            </Text>
           </TableCell>
         </TableRow>
         {/* playground-fold-end */}

--- a/packages/website/docs/_samples/main/Table/SelectionSingle/main.js
+++ b/packages/website/docs/_samples/main/Table/SelectionSingle/main.js
@@ -5,6 +5,7 @@ import "@ui5/webcomponents/dist/TableHeaderRow.js";
 import "@ui5/webcomponents/dist/TableHeaderCell.js";
 import "@ui5/webcomponents/dist/TableSelectionSingle.js";
 import "@ui5/webcomponents/dist/Label.js";
+import "@ui5/webcomponents/dist/Text.js";
 
 const selectionFeature = document.getElementById("selection");
 selectionFeature.addEventListener("change", (e) => {

--- a/packages/website/docs/_samples/main/Table/SelectionSingle/sample.html
+++ b/packages/website/docs/_samples/main/Table/SelectionSingle/sample.html
@@ -29,25 +29,25 @@
 				<ui5-table-header-cell id="priceCol" width="1fr" horizontal-align="End">Price</ui5-table-header-cell>
 			</ui5-table-header-row>
 			<ui5-table-row row-key="Row1">
-				<ui5-table-cell><ui5-label><b>Notebook Basic 15</b><br>HT-1000</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>Very Best Screens</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>30 x 18 x 3 cm</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>4.2</b> KG</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-labe><b>956</b> EUR</ui5-label></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>Notebook Basic 15</b><br>HT-1000</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>Very Best Screens</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>30 x 18 x 3 cm</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text style="color: #2b7c2b"><b>4.2</b> KG</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-labe><b>956</b> EUR</ui5-text></ui5-table-cell>
 			</ui5-table-row>
 			<ui5-table-row row-key="Row2">
-				<ui5-table-cell><ui5-label><b>Notebook Basic 17</b><br>HT-1001</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>Smartcards</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>29 x 17 x 3.1 cm</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>4.5</b> KG</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label><b>1249</b> EUR</ui5-label></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>Notebook Basic 17</b><br>HT-1001</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>Smartcards</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>29 x 17 x 3.1 cm</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text style="color: #2b7c2b"><b>4.5</b> KG</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>1249</b> EUR</ui5-text></ui5-table-cell>
 			</ui5-table-row>
 			<ui5-table-row row-key="Row3">
-				<ui5-table-cell><ui5-label><b>Notebook Basic 18</b><br>HT-1002</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>Technocom</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>32 x 21 x 4 cm</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>3.7</b> KG</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label><b>29</b> EUR</ui5-label></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>Notebook Basic 18</b><br>HT-1002</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>Technocom</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>32 x 21 x 4 cm</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text style="color: #2b7c2b"><b>3.7</b> KG</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>29</b> EUR</ui5-text></ui5-table-cell>
 			</ui5-table-row>
 <!-- playground-fold-end -->
 		</ui5-table>

--- a/packages/website/docs/_samples/main/Table/SelectionSingle/sample.tsx
+++ b/packages/website/docs/_samples/main/Table/SelectionSingle/sample.tsx
@@ -8,6 +8,7 @@ import TableHeaderCellClass from "@ui5/webcomponents/dist/TableHeaderCell.js";
 import TableHeaderRowClass from "@ui5/webcomponents/dist/TableHeaderRow.js";
 import TableRowClass from "@ui5/webcomponents/dist/TableRow.js";
 import TableSelectionSingleClass from "@ui5/webcomponents/dist/TableSelectionSingle.js";
+import TextClass from "@ui5/webcomponents/dist/Text.js";
 
 const Label = createReactComponent(LabelClass);
 const RadioButton = createReactComponent(RadioButtonClass);
@@ -17,6 +18,7 @@ const TableHeaderCell = createReactComponent(TableHeaderCellClass);
 const TableHeaderRow = createReactComponent(TableHeaderRowClass);
 const TableRow = createReactComponent(TableRowClass);
 const TableSelectionSingle = createReactComponent(TableSelectionSingleClass);
+const Text = createReactComponent(TextClass);
 
 function App() {
   const selectionRef = useRef(null);
@@ -82,77 +84,77 @@ function App() {
         </TableHeaderRow>
         <TableRow rowKey="Row1">
           <TableCell>
-            <Label>
+            <Text>
               <b>Notebook Basic 15</b>
               <br />
               HT-1000
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Very Best Screens</Label>
+            <Text>Very Best Screens</Text>
           </TableCell>
           <TableCell>
-            <Label>30 x 18 x 3 cm</Label>
+            <Text>30 x 18 x 3 cm</Text>
           </TableCell>
           <TableCell>
-            <Label style={{ color: "#2b7c2b" }}>
+            <Text style={{ color: "#2b7c2b" }}>
               <b>4.2</b> KG
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>
+            <Text>
               <b>956</b> EUR
-            </Label>
+            </Text>
           </TableCell>
         </TableRow>
         <TableRow rowKey="Row2">
           <TableCell>
-            <Label>
+            <Text>
               <b>Notebook Basic 17</b>
               <br />
               HT-1001
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Smartcards</Label>
+            <Text>Smartcards</Text>
           </TableCell>
           <TableCell>
-            <Label>29 x 17 x 3.1 cm</Label>
+            <Text>29 x 17 x 3.1 cm</Text>
           </TableCell>
           <TableCell>
-            <Label style={{ color: "#2b7c2b" }}>
+            <Text style={{ color: "#2b7c2b" }}>
               <b>4.5</b> KG
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>
+            <Text>
               <b>1249</b> EUR
-            </Label>
+            </Text>
           </TableCell>
         </TableRow>
         <TableRow rowKey="Row3">
           <TableCell>
-            <Label>
+            <Text>
               <b>Notebook Basic 18</b>
               <br />
               HT-1002
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Technocom</Label>
+            <Text>Technocom</Text>
           </TableCell>
           <TableCell>
-            <Label>32 x 21 x 4 cm</Label>
+            <Text>32 x 21 x 4 cm</Text>
           </TableCell>
           <TableCell>
-            <Label style={{ color: "#2b7c2b" }}>
+            <Text style={{ color: "#2b7c2b" }}>
               <b>3.7</b> KG
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>
+            <Text>
               <b>29</b> EUR
-            </Label>
+            </Text>
           </TableCell>
         </TableRow>
         {/* playground-fold-end */}

--- a/packages/website/docs/_samples/main/Table/StickyHeader/main.js
+++ b/packages/website/docs/_samples/main/Table/StickyHeader/main.js
@@ -2,6 +2,6 @@ import "@ui5/webcomponents/dist/Table.js";
 import "@ui5/webcomponents/dist/TableGrowing.js";
 import "@ui5/webcomponents/dist/TableHeaderRow.js";
 import "@ui5/webcomponents/dist/TableHeaderCell.js";
-import "@ui5/webcomponents/dist/Label.js";
 import "@ui5/webcomponents/dist/Input.js";
 import "@ui5/webcomponents/dist/Title.js";
+import "@ui5/webcomponents/dist/Text.js";

--- a/packages/website/docs/_samples/main/Table/StickyHeader/sample.html
+++ b/packages/website/docs/_samples/main/Table/StickyHeader/sample.html
@@ -20,46 +20,46 @@
 		</ui5-table-header-row>
 <!-- playground-fold -->
 		<ui5-table-row>
-			<ui5-table-cell><ui5-label><b>Notebook Basic 15</b><br>HT-1000</ui5-label></ui5-table-cell>
-			<ui5-table-cell><ui5-label>Very Best Screens</ui5-label></ui5-table-cell>
-			<ui5-table-cell><ui5-label>30 x 18 x 3 cm</ui5-label></ui5-table-cell>
-			<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>4.2</b> KG</ui5-label></ui5-table-cell>
-			<ui5-table-cell><ui5-label><b>956</b> EUR</ui5-label></ui5-table-cell>
+			<ui5-table-cell><ui5-text><b>Notebook Basic 15</b><br>HT-1000</ui5-text></ui5-table-cell>
+			<ui5-table-cell><ui5-text>Very Best Screens</ui5-text></ui5-table-cell>
+			<ui5-table-cell><ui5-text>30 x 18 x 3 cm</ui5-text></ui5-table-cell>
+			<ui5-table-cell><ui5-text style="color: #2b7c2b"><b>4.2</b> KG</ui5-text></ui5-table-cell>
+			<ui5-table-cell><ui5-text><b>956</b> EUR</ui5-text></ui5-table-cell>
 		</ui5-table-row>
 		<ui5-table-row>
-			<ui5-table-cell><ui5-label><b>Notebook Basic 17</b><br>HT-1001</ui5-label></ui5-table-cell>
-			<ui5-table-cell><ui5-label>Smartcards</ui5-label></ui5-table-cell>
-			<ui5-table-cell><ui5-label>29 x 17 x 3.1 cm</ui5-label></ui5-table-cell>
-			<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>4.5</b> KG</ui5-label></ui5-table-cell>
-			<ui5-table-cell><ui5-label><b>1249</b> EUR</ui5-label></ui5-table-cell>
+			<ui5-table-cell><ui5-text><b>Notebook Basic 17</b><br>HT-1001</ui5-text></ui5-table-cell>
+			<ui5-table-cell><ui5-text>Smartcards</ui5-text></ui5-table-cell>
+			<ui5-table-cell><ui5-text>29 x 17 x 3.1 cm</ui5-text></ui5-table-cell>
+			<ui5-table-cell><ui5-text style="color: #2b7c2b"><b>4.5</b> KG</ui5-text></ui5-table-cell>
+			<ui5-table-cell><ui5-text><b>1249</b> EUR</ui5-text></ui5-table-cell>
 		</ui5-table-row>
 		<ui5-table-row>
-			<ui5-table-cell><ui5-label><b>Notebook Basic 18</b><br>HT-1002</ui5-label></ui5-table-cell>
-			<ui5-table-cell><ui5-label>Technocom</ui5-label></ui5-table-cell>
-			<ui5-table-cell><ui5-label>32 x 21 x 4 cm</ui5-label></ui5-table-cell>
-			<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>3.7</b> KG</ui5-label></ui5-table-cell>
-			<ui5-table-cell><ui5-label><b>29</b> EUR</ui5-label></ui5-table-cell>
+			<ui5-table-cell><ui5-text><b>Notebook Basic 18</b><br>HT-1002</ui5-text></ui5-table-cell>
+			<ui5-table-cell><ui5-text>Technocom</ui5-text></ui5-table-cell>
+			<ui5-table-cell><ui5-text>32 x 21 x 4 cm</ui5-text></ui5-table-cell>
+			<ui5-table-cell><ui5-text style="color: #2b7c2b"><b>3.7</b> KG</ui5-text></ui5-table-cell>
+			<ui5-table-cell><ui5-text><b>29</b> EUR</ui5-text></ui5-table-cell>
 		</ui5-table-row>
 		<ui5-table-row>
-			<ui5-table-cell><ui5-label><b>Notebook Basic 19</b><br>HT-1003</ui5-label></ui5-table-cell>
-			<ui5-table-cell><ui5-label>Very Best Screens</ui5-label></ui5-table-cell>
-			<ui5-table-cell><ui5-label>30 x 18 x 3 cm</ui5-label></ui5-table-cell>
-			<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>4.2</b> KG</ui5-label></ui5-table-cell>
-			<ui5-table-cell><ui5-label><b>956</b> EUR</ui5-label></ui5-table-cell>
+			<ui5-table-cell><ui5-text><b>Notebook Basic 19</b><br>HT-1003</ui5-text></ui5-table-cell>
+			<ui5-table-cell><ui5-text>Very Best Screens</ui5-text></ui5-table-cell>
+			<ui5-table-cell><ui5-text>30 x 18 x 3 cm</ui5-text></ui5-table-cell>
+			<ui5-table-cell><ui5-text style="color: #2b7c2b"><b>4.2</b> KG</ui5-text></ui5-table-cell>
+			<ui5-table-cell><ui5-text><b>956</b> EUR</ui5-text></ui5-table-cell>
 		</ui5-table-row>
 		<ui5-table-row>
-			<ui5-table-cell><ui5-label><b>Notebook Basic 20</b><br>HT-1004</ui5-label></ui5-table-cell>
-			<ui5-table-cell><ui5-label>Smartcards</ui5-label></ui5-table-cell>
-			<ui5-table-cell><ui5-label>29 x 17 x 3.1 cm</ui5-label></ui5-table-cell>
-			<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>4.5</b> KG</ui5-label></ui5-table-cell>
-			<ui5-table-cell><ui5-label><b>1249</b> EUR</ui5-label></ui5-table-cell>
+			<ui5-table-cell><ui5-text><b>Notebook Basic 20</b><br>HT-1004</ui5-text></ui5-table-cell>
+			<ui5-table-cell><ui5-text>Smartcards</ui5-text></ui5-table-cell>
+			<ui5-table-cell><ui5-text>29 x 17 x 3.1 cm</ui5-text></ui5-table-cell>
+			<ui5-table-cell><ui5-text style="color: #2b7c2b"><b>4.5</b> KG</ui5-text></ui5-table-cell>
+			<ui5-table-cell><ui5-text><b>1249</b> EUR</ui5-text></ui5-table-cell>
 		</ui5-table-row>
 		<ui5-table-row>
-			<ui5-table-cell><ui5-label><b>Notebook Basic 21</b><br>HT-1005</ui5-label></ui5-table-cell>
-			<ui5-table-cell><ui5-label>Technocom</ui5-label></ui5-table-cell>
-			<ui5-table-cell><ui5-label>32 x 21 x 4 cm</ui5-label></ui5-table-cell>
-			<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>3.7</b> KG</ui5-label></ui5-table-cell>
-			<ui5-table-cell><ui5-label><b>29</b> EUR</ui5-label></ui5-table-cell>
+			<ui5-table-cell><ui5-text><b>Notebook Basic 21</b><br>HT-1005</ui5-text></ui5-table-cell>
+			<ui5-table-cell><ui5-text>Technocom</ui5-text></ui5-table-cell>
+			<ui5-table-cell><ui5-text>32 x 21 x 4 cm</ui5-text></ui5-table-cell>
+			<ui5-table-cell><ui5-text style="color: #2b7c2b"><b>3.7</b> KG</ui5-text></ui5-table-cell>
+			<ui5-table-cell><ui5-text><b>29</b> EUR</ui5-text></ui5-table-cell>
 		</ui5-table-row>
 <!-- playground-fold-end -->
 	</ui5-table>

--- a/packages/website/docs/_samples/main/Table/StickyHeader/sample.tsx
+++ b/packages/website/docs/_samples/main/Table/StickyHeader/sample.tsx
@@ -1,17 +1,17 @@
 import createReactComponent from "@ui5/webcomponents-base/dist/createReactComponent.js";
-import LabelClass from "@ui5/webcomponents/dist/Label.js";
 import TableClass from "@ui5/webcomponents/dist/Table.js";
 import TableCellClass from "@ui5/webcomponents/dist/TableCell.js";
 import TableHeaderCellClass from "@ui5/webcomponents/dist/TableHeaderCell.js";
 import TableHeaderRowClass from "@ui5/webcomponents/dist/TableHeaderRow.js";
 import TableRowClass from "@ui5/webcomponents/dist/TableRow.js";
+import TextClass from "@ui5/webcomponents/dist/Text.js";
 
-const Label = createReactComponent(LabelClass);
 const Table = createReactComponent(TableClass);
 const TableCell = createReactComponent(TableCellClass);
 const TableHeaderCell = createReactComponent(TableHeaderCellClass);
 const TableHeaderRow = createReactComponent(TableHeaderRowClass);
 const TableRow = createReactComponent(TableRowClass);
+const Text = createReactComponent(TextClass);
 
 function App() {
   return (
@@ -31,152 +31,152 @@ function App() {
         {/* playground-fold */}
         <TableRow>
           <TableCell>
-            <Label>
+            <Text>
               <b>Notebook Basic 15</b>
               <br />
               HT-1000
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Very Best Screens</Label>
+            <Text>Very Best Screens</Text>
           </TableCell>
           <TableCell>
-            <Label>30 x 18 x 3 cm</Label>
+            <Text>30 x 18 x 3 cm</Text>
           </TableCell>
           <TableCell>
-            <Label style={{ color: "#2b7c2b" }}>
+            <Text style={{ color: "#2b7c2b" }}>
               <b>4.2</b> KG
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>
+            <Text>
               <b>956</b> EUR
-            </Label>
+            </Text>
           </TableCell>
         </TableRow>
         <TableRow>
           <TableCell>
-            <Label>
+            <Text>
               <b>Notebook Basic 17</b>
               <br />
               HT-1001
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Smartcards</Label>
+            <Text>Smartcards</Text>
           </TableCell>
           <TableCell>
-            <Label>29 x 17 x 3.1 cm</Label>
+            <Text>29 x 17 x 3.1 cm</Text>
           </TableCell>
           <TableCell>
-            <Label style={{ color: "#2b7c2b" }}>
+            <Text style={{ color: "#2b7c2b" }}>
               <b>4.5</b> KG
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>
+            <Text>
               <b>1249</b> EUR
-            </Label>
+            </Text>
           </TableCell>
         </TableRow>
         <TableRow>
           <TableCell>
-            <Label>
+            <Text>
               <b>Notebook Basic 18</b>
               <br />
               HT-1002
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Technocom</Label>
+            <Text>Technocom</Text>
           </TableCell>
           <TableCell>
-            <Label>32 x 21 x 4 cm</Label>
+            <Text>32 x 21 x 4 cm</Text>
           </TableCell>
           <TableCell>
-            <Label style={{ color: "#2b7c2b" }}>
+            <Text style={{ color: "#2b7c2b" }}>
               <b>3.7</b> KG
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>
+            <Text>
               <b>29</b> EUR
-            </Label>
+            </Text>
           </TableCell>
         </TableRow>
         <TableRow>
           <TableCell>
-            <Label>
+            <Text>
               <b>Notebook Basic 19</b>
               <br />
               HT-1003
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Very Best Screens</Label>
+            <Text>Very Best Screens</Text>
           </TableCell>
           <TableCell>
-            <Label>30 x 18 x 3 cm</Label>
+            <Text>30 x 18 x 3 cm</Text>
           </TableCell>
           <TableCell>
-            <Label style={{ color: "#2b7c2b" }}>
+            <Text style={{ color: "#2b7c2b" }}>
               <b>4.2</b> KG
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>
+            <Text>
               <b>956</b> EUR
-            </Label>
+            </Text>
           </TableCell>
         </TableRow>
         <TableRow>
           <TableCell>
-            <Label>
+            <Text>
               <b>Notebook Basic 20</b>
               <br />
               HT-1004
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Smartcards</Label>
+            <Text>Smartcards</Text>
           </TableCell>
           <TableCell>
-            <Label>29 x 17 x 3.1 cm</Label>
+            <Text>29 x 17 x 3.1 cm</Text>
           </TableCell>
           <TableCell>
-            <Label style={{ color: "#2b7c2b" }}>
+            <Text style={{ color: "#2b7c2b" }}>
               <b>4.5</b> KG
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>
+            <Text>
               <b>1249</b> EUR
-            </Label>
+            </Text>
           </TableCell>
         </TableRow>
         <TableRow>
           <TableCell>
-            <Label>
+            <Text>
               <b>Notebook Basic 21</b>
               <br />
               HT-1005
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>Technocom</Label>
+            <Text>Technocom</Text>
           </TableCell>
           <TableCell>
-            <Label>32 x 21 x 4 cm</Label>
+            <Text>32 x 21 x 4 cm</Text>
           </TableCell>
           <TableCell>
-            <Label style={{ color: "#2b7c2b" }}>
+            <Text style={{ color: "#2b7c2b" }}>
               <b>3.7</b> KG
-            </Label>
+            </Text>
           </TableCell>
           <TableCell>
-            <Label>
+            <Text>
               <b>29</b> EUR
-            </Label>
+            </Text>
           </TableCell>
         </TableRow>
         {/* playground-fold-end */}

--- a/packages/website/docs/_samples/main/Table/StickyHeaderContainer/main.js
+++ b/packages/website/docs/_samples/main/Table/StickyHeaderContainer/main.js
@@ -2,7 +2,7 @@ import "@ui5/webcomponents/dist/Table.js";
 import "@ui5/webcomponents/dist/TableGrowing.js";
 import "@ui5/webcomponents/dist/TableHeaderRow.js";
 import "@ui5/webcomponents/dist/TableHeaderCell.js";
-import "@ui5/webcomponents/dist/Label.js";
 import "@ui5/webcomponents/dist/Input.js";
 import "@ui5/webcomponents/dist/Title.js";
 import "@ui5/webcomponents/dist/Bar.js";
+import "@ui5/webcomponents/dist/Text.js";

--- a/packages/website/docs/_samples/main/Table/StickyHeaderContainer/sample.html
+++ b/packages/website/docs/_samples/main/Table/StickyHeaderContainer/sample.html
@@ -24,46 +24,46 @@
 			</ui5-table-header-row>
 <!-- playground-fold -->
 			<ui5-table-row>
-				<ui5-table-cell><ui5-label><b>Notebook Basic 15</b><br>HT-1000</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>Very Best Screens</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>30 x 18 x 3 cm</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>4.2</b> KG</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label><b>956</b> EUR</ui5-label></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>Notebook Basic 15</b><br>HT-1000</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>Very Best Screens</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>30 x 18 x 3 cm</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text style="color: #2b7c2b"><b>4.2</b> KG</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>956</b> EUR</ui5-text></ui5-table-cell>
 			</ui5-table-row>
 			<ui5-table-row>
-				<ui5-table-cell><ui5-label><b>Notebook Basic 17</b><br>HT-1001</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>Smartcards</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>29 x 17 x 3.1 cm</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>4.5</b> KG</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label><b>1249</b> EUR</ui5-label></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>Notebook Basic 17</b><br>HT-1001</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>Smartcards</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>29 x 17 x 3.1 cm</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text style="color: #2b7c2b"><b>4.5</b> KG</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>1249</b> EUR</ui5-text></ui5-table-cell>
 			</ui5-table-row>
 			<ui5-table-row>
-				<ui5-table-cell><ui5-label><b>Notebook Basic 18</b><br>HT-1002</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>Technocom</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>32 x 21 x 4 cm</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>3.7</b> KG</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label><b>29</b> EUR</ui5-label></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>Notebook Basic 18</b><br>HT-1002</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>Technocom</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>32 x 21 x 4 cm</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text style="color: #2b7c2b"><b>3.7</b> KG</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>29</b> EUR</ui5-text></ui5-table-cell>
 			</ui5-table-row>
 			<ui5-table-row>
-				<ui5-table-cell><ui5-label><b>Notebook Basic 19</b><br>HT-1003</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>Very Best Screens</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>30 x 18 x 3 cm</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>4.2</b> KG</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label><b>956</b> EUR</ui5-label></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>Notebook Basic 19</b><br>HT-1003</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>Very Best Screens</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>30 x 18 x 3 cm</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text style="color: #2b7c2b"><b>4.2</b> KG</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>956</b> EUR</ui5-text></ui5-table-cell>
 			</ui5-table-row>
 			<ui5-table-row>
-				<ui5-table-cell><ui5-label><b>Notebook Basic 20</b><br>HT-1004</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>Smartcards</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>29 x 17 x 3.1 cm</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>4.5</b> KG</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label><b>1249</b> EUR</ui5-label></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>Notebook Basic 20</b><br>HT-1004</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>Smartcards</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>29 x 17 x 3.1 cm</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text style="color: #2b7c2b"><b>4.5</b> KG</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>1249</b> EUR</ui5-text></ui5-table-cell>
 			</ui5-table-row>
 			<ui5-table-row>
-				<ui5-table-cell><ui5-label><b>Notebook Basic 21</b><br>HT-1005</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>Technocom</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label>32 x 21 x 4 cm</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label style="color: #2b7c2b"><b>3.7</b> KG</ui5-label></ui5-table-cell>
-				<ui5-table-cell><ui5-label><b>29</b> EUR</ui5-label></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>Notebook Basic 21</b><br>HT-1005</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>Technocom</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text>32 x 21 x 4 cm</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text style="color: #2b7c2b"><b>3.7</b> KG</ui5-text></ui5-table-cell>
+				<ui5-table-cell><ui5-text><b>29</b> EUR</ui5-text></ui5-table-cell>
 			</ui5-table-row>
 <!-- playground-fold-end -->
 		</ui5-table>

--- a/packages/website/docs/_samples/main/Table/StickyHeaderContainer/sample.tsx
+++ b/packages/website/docs/_samples/main/Table/StickyHeaderContainer/sample.tsx
@@ -1,21 +1,21 @@
 import createReactComponent from "@ui5/webcomponents-base/dist/createReactComponent.js";
 import BarClass from "@ui5/webcomponents/dist/Bar.js";
-import LabelClass from "@ui5/webcomponents/dist/Label.js";
 import TableClass from "@ui5/webcomponents/dist/Table.js";
 import TableCellClass from "@ui5/webcomponents/dist/TableCell.js";
 import TableHeaderCellClass from "@ui5/webcomponents/dist/TableHeaderCell.js";
 import TableHeaderRowClass from "@ui5/webcomponents/dist/TableHeaderRow.js";
 import TableRowClass from "@ui5/webcomponents/dist/TableRow.js";
 import TitleClass from "@ui5/webcomponents/dist/Title.js";
+import TextClass from "@ui5/webcomponents/dist/Text.js";
 
 const Bar = createReactComponent(BarClass);
-const Label = createReactComponent(LabelClass);
 const Table = createReactComponent(TableClass);
 const TableCell = createReactComponent(TableCellClass);
 const TableHeaderCell = createReactComponent(TableHeaderCellClass);
 const TableHeaderRow = createReactComponent(TableHeaderRowClass);
 const TableRow = createReactComponent(TableRowClass);
 const Title = createReactComponent(TitleClass);
+const Text = createReactComponent(TextClass);
 
 function App() {
   return (
@@ -46,152 +46,152 @@ function App() {
           {/* playground-fold */}
           <TableRow>
             <TableCell>
-              <Label>
+              <Text>
                 <b>Notebook Basic 15</b>
                 <br />
                 HT-1000
-              </Label>
+              </Text>
             </TableCell>
             <TableCell>
-              <Label>Very Best Screens</Label>
+              <Text>Very Best Screens</Text>
             </TableCell>
             <TableCell>
-              <Label>30 x 18 x 3 cm</Label>
+              <Text>30 x 18 x 3 cm</Text>
             </TableCell>
             <TableCell>
-              <Label style={{ color: "#2b7c2b" }}>
+              <Text style={{ color: "#2b7c2b" }}>
                 <b>4.2</b> KG
-              </Label>
+              </Text>
             </TableCell>
             <TableCell>
-              <Label>
+              <Text>
                 <b>956</b> EUR
-              </Label>
+              </Text>
             </TableCell>
           </TableRow>
           <TableRow>
             <TableCell>
-              <Label>
+              <Text>
                 <b>Notebook Basic 17</b>
                 <br />
                 HT-1001
-              </Label>
+              </Text>
             </TableCell>
             <TableCell>
-              <Label>Smartcards</Label>
+              <Text>Smartcards</Text>
             </TableCell>
             <TableCell>
-              <Label>29 x 17 x 3.1 cm</Label>
+              <Text>29 x 17 x 3.1 cm</Text>
             </TableCell>
             <TableCell>
-              <Label style={{ color: "#2b7c2b" }}>
+              <Text style={{ color: "#2b7c2b" }}>
                 <b>4.5</b> KG
-              </Label>
+              </Text>
             </TableCell>
             <TableCell>
-              <Label>
+              <Text>
                 <b>1249</b> EUR
-              </Label>
+              </Text>
             </TableCell>
           </TableRow>
           <TableRow>
             <TableCell>
-              <Label>
+              <Text>
                 <b>Notebook Basic 18</b>
                 <br />
                 HT-1002
-              </Label>
+              </Text>
             </TableCell>
             <TableCell>
-              <Label>Technocom</Label>
+              <Text>Technocom</Text>
             </TableCell>
             <TableCell>
-              <Label>32 x 21 x 4 cm</Label>
+              <Text>32 x 21 x 4 cm</Text>
             </TableCell>
             <TableCell>
-              <Label style={{ color: "#2b7c2b" }}>
+              <Text style={{ color: "#2b7c2b" }}>
                 <b>3.7</b> KG
-              </Label>
+              </Text>
             </TableCell>
             <TableCell>
-              <Label>
+              <Text>
                 <b>29</b> EUR
-              </Label>
+              </Text>
             </TableCell>
           </TableRow>
           <TableRow>
             <TableCell>
-              <Label>
+              <Text>
                 <b>Notebook Basic 19</b>
                 <br />
                 HT-1003
-              </Label>
+              </Text>
             </TableCell>
             <TableCell>
-              <Label>Very Best Screens</Label>
+              <Text>Very Best Screens</Text>
             </TableCell>
             <TableCell>
-              <Label>30 x 18 x 3 cm</Label>
+              <Text>30 x 18 x 3 cm</Text>
             </TableCell>
             <TableCell>
-              <Label style={{ color: "#2b7c2b" }}>
+              <Text style={{ color: "#2b7c2b" }}>
                 <b>4.2</b> KG
-              </Label>
+              </Text>
             </TableCell>
             <TableCell>
-              <Label>
+              <Text>
                 <b>956</b> EUR
-              </Label>
+              </Text>
             </TableCell>
           </TableRow>
           <TableRow>
             <TableCell>
-              <Label>
+              <Text>
                 <b>Notebook Basic 20</b>
                 <br />
                 HT-1004
-              </Label>
+              </Text>
             </TableCell>
             <TableCell>
-              <Label>Smartcards</Label>
+              <Text>Smartcards</Text>
             </TableCell>
             <TableCell>
-              <Label>29 x 17 x 3.1 cm</Label>
+              <Text>29 x 17 x 3.1 cm</Text>
             </TableCell>
             <TableCell>
-              <Label style={{ color: "#2b7c2b" }}>
+              <Text style={{ color: "#2b7c2b" }}>
                 <b>4.5</b> KG
-              </Label>
+              </Text>
             </TableCell>
             <TableCell>
-              <Label>
+              <Text>
                 <b>1249</b> EUR
-              </Label>
+              </Text>
             </TableCell>
           </TableRow>
           <TableRow>
             <TableCell>
-              <Label>
+              <Text>
                 <b>Notebook Basic 21</b>
                 <br />
                 HT-1005
-              </Label>
+              </Text>
             </TableCell>
             <TableCell>
-              <Label>Technocom</Label>
+              <Text>Technocom</Text>
             </TableCell>
             <TableCell>
-              <Label>32 x 21 x 4 cm</Label>
+              <Text>32 x 21 x 4 cm</Text>
             </TableCell>
             <TableCell>
-              <Label style={{ color: "#2b7c2b" }}>
+              <Text style={{ color: "#2b7c2b" }}>
                 <b>3.7</b> KG
-              </Label>
+              </Text>
             </TableCell>
             <TableCell>
-              <Label>
+              <Text>
                 <b>29</b> EUR
-              </Label>
+              </Text>
             </TableCell>
           </TableRow>
           {/* playground-fold-end */}


### PR DESCRIPTION
  - Adds a runtime `console.warn` when `<ui5-table-row-action-navigation>` is connected without the (deprecated) `interactive` property and nudges consumers toward the accessible button rendering before V3 removal.
  - No behavior change. Samples and tests already set `interactive={true}` and are unaffected.
  - Test pages now uses Text component in the `ui5-table-cell` instead of Label component.
  - Stacking context is set on the table for the sticky elements. Fixes: #13483