### PR TITLE
docs(fonts): add guide for hosting fonts locally

### DIFF
--- a/docs/2-advanced/14-fonts.md
+++ b/docs/2-advanced/14-fonts.md
@@ -80,3 +80,37 @@ For example, to use the `72-Light` font with a custom `font-display` setting:
     }
 </style>
 ```
+
+### 3. Host Fonts Locally
+
+If your application cannot reach the public CDN, you can serve the SAP `72` font family from your own infrastructure. The framework ships a ready-made stylesheet at `@ui5/webcomponents-base/dist/FontFace.css` whose `@font-face` URLs point at the `@sap-theming/theming-base-content` npm package, so a modern bundler (Vite, webpack, Rollup, esbuild, …) can resolve them from `node_modules` and emit the font files alongside your build output — no CDN call at runtime.
+
+**Note (experimental):** `@ui5/webcomponents-base/dist/FontFace.css` is provided as a convenience and its location, contents, and hosting package are subject to change — it may be relocated to a different package or restructured in a future release. If you depend on it, pin your `@ui5/webcomponents` version and re-verify the import path when upgrading.
+
+After disabling default font loading (see step 1), import the stylesheet at your application entry point:
+
+```ts
+// In your main.ts / main.js
+import "@ui5/webcomponents-base/dist/FontFace.css";
+```
+
+or from CSS:
+
+```css
+/* In your main.css */
+@import "@ui5/webcomponents-base/dist/FontFace.css";
+```
+
+Your bundler resolves the `@sap-theming/theming-base-content/...` URLs inside the stylesheet, copies the `.woff2` files into the build output, and rewrites the references to your asset paths.
+
+**Without a bundler.** If you don't have a build step, copy the font files manually. They live under `@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/` in the npm package — install the package or download them directly. The full set is:
+
+| Family       | Files                                                                                                                                                              |
+|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 72           | `72-Regular.woff2`, `72-Bold.woff2`, `72-Semibold.woff2`, `72-Light.woff2`, `72-Black.woff2`, `72-Italic.woff2`, `72-BoldItalic.woff2`, `72-Condensed.woff2`, `72-CondensedBold.woff2`, `72-SemiboldDuplex.woff2` |
+| 72 (full)    | The same files with the `-full` suffix (e.g. `72-Regular-full.woff2`) — extended Unicode coverage fallback                                                         |
+| 72Mono       | `72Mono-Regular.woff2`, `72Mono-Bold.woff2` and their `-full` variants                                                                                             |
+
+Copy the `fonts/` directory to a location served by your web server (e.g. `/static/fonts/`), then copy `FontFace.css` into your project and replace the `@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/` URL prefix with that location. Load the rewritten CSS using one of the methods from step 1.
+
+**Keep the fonts in sync.** The font files rarely change. When you upgrade `@ui5/webcomponents` to a new minor version, check the version of `@sap-theming/theming-base-content` it depends on, and re-copy the `fonts/` directory if it has been updated.


### PR DESCRIPTION
## Summary
- Adds a new "Host Fonts Locally" step under Custom (Manual) Font Loading that documents how to serve the SAP `72` font family from local infrastructure instead of the default CDN.
- Recommends importing `@ui5/webcomponents-base/dist/FontFace.css` so a bundler (Vite, webpack, Rollup, esbuild) resolves `@sap-theming/...` URLs from `node_modules` automatically — no CDN call at runtime.
- Documents a fallback path (manual copy + URL rewrite) for setups without a bundler, including the full font file list.
- Flags `FontFace.css` as experimental — its location/contents may change in future releases.

Closes #12562

## Test plan
- [ ] Build the docs website (`cd packages/website && yarn start`) and verify the new Step 3 renders correctly under `docs/advanced/fonts`.
- [ ] Verify the table renders, code blocks are highlighted, and the experimental note is visible.