### PR TITLE
fix(ui5-breadcrumbs): acc findings fixed

### DIFF
--- a/packages/main/cypress/specs/Breadcrumbs.cy.tsx
+++ b/packages/main/cypress/specs/Breadcrumbs.cy.tsx
@@ -1186,4 +1186,3 @@ describe("Breadcrumbs - accessibleName property", () => {
 			.should("have.attr", "aria-label", "My Custom Breadcrumbs");
 	});
 });
-});

--- a/packages/main/cypress/specs/Breadcrumbs.cy.tsx
+++ b/packages/main/cypress/specs/Breadcrumbs.cy.tsx
@@ -1156,3 +1156,34 @@ describe("BreadcrumbsItem click event", () => {
 		});
 	});
 });
+
+describe("Breadcrumbs - accessibleName property", () => {
+	it("uses the default 'Breadcrumb Trail' label when accessibleName is not set", () => {
+		cy.mount(
+			<Breadcrumbs>
+				<BreadcrumbsItem href="#">Link1</BreadcrumbsItem>
+				<BreadcrumbsItem>Location</BreadcrumbsItem>
+			</Breadcrumbs>
+		);
+
+		cy.get("[ui5-breadcrumbs]")
+			.shadow()
+			.find(".ui5-breadcrumbs-root")
+			.should("have.attr", "aria-label", "Breadcrumb Trail");
+	});
+
+	it("reflects accessibleName on the nav element's aria-label", () => {
+		cy.mount(
+			<Breadcrumbs accessibleName="My Custom Breadcrumbs">
+				<BreadcrumbsItem href="#">Link1</BreadcrumbsItem>
+				<BreadcrumbsItem>Location</BreadcrumbsItem>
+			</Breadcrumbs>
+		);
+
+		cy.get("[ui5-breadcrumbs]")
+			.shadow()
+			.find(".ui5-breadcrumbs-root")
+			.should("have.attr", "aria-label", "My Custom Breadcrumbs");
+	});
+});
+});

--- a/packages/main/src/Breadcrumbs.ts
+++ b/packages/main/src/Breadcrumbs.ts
@@ -662,7 +662,9 @@ class Breadcrumbs extends UI5Element implements IToolbarItemContent {
 	}
 
 	get _accessibleNameText() {
-		return Breadcrumbs.i18nBundle.getText(BREADCRUMBS_ARIA_LABEL);
+		const baseLabel = Breadcrumbs.i18nBundle.getText(BREADCRUMBS_ARIA_LABEL);
+		const currentLocation = this._currentLocationText;
+		return currentLocation ? `${baseLabel} ${currentLocation}` : baseLabel;
 	}
 
 	get _dropdownArrowAccessibleNameText() {

--- a/packages/main/src/Breadcrumbs.ts
+++ b/packages/main/src/Breadcrumbs.ts
@@ -136,6 +136,15 @@ class Breadcrumbs extends UI5Element implements IToolbarItemContent {
 	separators: `${BreadcrumbsSeparator}` = "Slash";
 
 	/**
+	 * Defines the accessible name of the component.
+	 * @default undefined
+	 * @public
+	 * @since 2.22.0
+	 */
+	@property()
+	accessibleName?: string;
+
+	/**
 	 * Holds the number of items in the overflow.
 	 * @default 0
 	 * @private
@@ -662,9 +671,7 @@ class Breadcrumbs extends UI5Element implements IToolbarItemContent {
 	}
 
 	get _accessibleNameText() {
-		const baseLabel = Breadcrumbs.i18nBundle.getText(BREADCRUMBS_ARIA_LABEL);
-		const currentLocation = this._currentLocationText;
-		return currentLocation ? `${baseLabel} ${currentLocation}` : baseLabel;
+		return this.accessibleName || Breadcrumbs.i18nBundle.getText(BREADCRUMBS_ARIA_LABEL);
 	}
 
 	get _dropdownArrowAccessibleNameText() {


### PR DESCRIPTION
### 7) Breadcrumbs (10 failing)
- Landmark uniqueness failures (duplicate navigation labeling patterns).
- Interaction issues in overflow/popover flows in interactive tests.
- Includes failures in scenarios like selecting overflow item and focus/closure flow.


| Component | Issue | Not by spec | Good to have | Spec refs | Spec quote sentence | Coverage strength |
| --- | --- | --- | --- | --- | --- | --- |
| Breadcrumbs | Duplicate navigation labeling | Likely Yes | No | ACC-267, ACC-264 | "Container (div or nav) should have role=navigation and aria-label=Breadcrumb Trail" and "Label 'Breadcrumb Trail' must be announced on entry" | Partial (uniqueness not explicit in extracted quote) |
| Breadcrumbs | Overflow/popover keyboard/focus failures | Likely Yes | No | ACC-270, ACC-272, ACC-269 | "Focus must be put inside dialog on active control" and "Like any other Popover (role=dialog and so on)" | Direct |

