### PR TITLE
feat(ui5-icon): add fontIcon slot for font-based icon libraries

### DIFF
--- a/packages/main/cypress/specs/Icon.cy.tsx
+++ b/packages/main/cypress/specs/Icon.cy.tsx
@@ -297,7 +297,7 @@ describe("Icon general interaction", () => {
         cy.get("[ui5-icon][mode='Interactive']").then($icon => {
             const icon = $icon[0] as any;
             const accessibilityInfo = icon.accessibilityInfo;
-            
+
             // For Interactive mode, accessibilityInfo should have role, type and description
             expect(accessibilityInfo).to.not.be.undefined;
             expect(accessibilityInfo.role).to.equal("button");
@@ -317,7 +317,7 @@ describe("Icon general interaction", () => {
         cy.get("[ui5-icon][mode='Decorative']").then($icon => {
             const icon = $icon[0] as any;
             const accessibilityInfo = icon.accessibilityInfo;
-            
+
             // For Decorative mode, accessibilityInfo should return an empty object
             expect(accessibilityInfo).to.deep.equal({});
         });
@@ -334,12 +334,152 @@ describe("Icon general interaction", () => {
         cy.get("[ui5-icon][mode='Image']").then($icon => {
             const icon = $icon[0] as any;
             const accessibilityInfo = icon.accessibilityInfo;
-            
+
             // For Image mode, accessibilityInfo should have role, type and description
             expect(accessibilityInfo).to.not.be.undefined;
             expect(accessibilityInfo.role).to.equal("img");
             expect(accessibilityInfo.type).to.equal("Image");
             expect(accessibilityInfo.description).to.equal(accessibleName);
         });
+    });
+});
+
+describe("Icon symbol slot", () => {
+    it("renders a span root instead of svg when symbol slot is used", () => {
+        cy.mount(
+            <Icon>
+                <span slot="symbol">★</span>
+            </Icon>
+        );
+
+        cy.get("[ui5-icon]").shadow().find("span.ui5-icon-root").should("exist");
+        cy.get("[ui5-icon]").shadow().find("svg").should("not.exist");
+    });
+
+    it("Decorative mode: span root has role=presentation and aria-hidden=true", () => {
+        cy.mount(
+            <Icon>
+                <span slot="symbol">★</span>
+            </Icon>
+        );
+
+        cy.get("[ui5-icon]").shadow().find("span.ui5-icon-root")
+            .should("have.attr", "role", "presentation")
+            .should("have.attr", "aria-hidden", "true");
+    });
+
+    it("Image mode: span root has role=img and aria-label", () => {
+        cy.mount(
+            <Icon mode="Image" accessibleName="Star">
+                <span slot="symbol">★</span>
+            </Icon>
+        );
+
+        cy.get("[ui5-icon]").shadow().find("span.ui5-icon-root")
+            .should("have.attr", "role", "img")
+            .should("have.attr", "aria-label", "Star")
+            .should("not.have.attr", "aria-hidden");
+    });
+
+    it("Interactive mode: span root has role=button and tabindex=0", () => {
+        cy.mount(
+            <Icon mode="Interactive" accessibleName="Add">
+                <span slot="symbol">＋</span>
+            </Icon>
+        );
+
+        cy.get("[ui5-icon]").shadow().find("span.ui5-icon-root")
+            .should("have.attr", "role", "button")
+            .should("have.attr", "tabindex", "0")
+            .should("have.attr", "aria-label", "Add");
+    });
+
+    it("Interactive mode: fires ui5-click on mouse click", () => {
+        cy.mount(
+            <Icon mode="Interactive" accessibleName="Add">
+                <span slot="symbol">＋</span>
+            </Icon>
+        );
+
+        cy.get("[ui5-icon]").then($icon => {
+            $icon[0].addEventListener("ui5-click", cy.stub().as("ui5Click"));
+        });
+
+        cy.get("[ui5-icon]").realClick();
+        cy.get("@ui5Click").should("have.been.calledOnce");
+    });
+
+    it("Interactive mode: fires ui5-click on Enter key", () => {
+        cy.mount(
+            <Icon mode="Interactive" accessibleName="Add">
+                <span slot="symbol">＋</span>
+            </Icon>
+        );
+
+        cy.get("[ui5-icon]").then($icon => {
+            $icon[0].addEventListener("ui5-click", cy.stub().as("ui5Click"));
+        });
+
+        cy.get("[ui5-icon]").shadow().find("span.ui5-icon-root").focus();
+        cy.realPress("Enter");
+        cy.get("@ui5Click").should("have.been.calledOnce");
+    });
+
+    it("Interactive mode: fires ui5-click on Space key", () => {
+        cy.mount(
+            <Icon mode="Interactive" accessibleName="Add">
+                <span slot="symbol">＋</span>
+            </Icon>
+        );
+
+        cy.get("[ui5-icon]").then($icon => {
+            $icon[0].addEventListener("ui5-click", cy.stub().as("ui5Click"));
+        });
+
+        cy.get("[ui5-icon]").shadow().find("span.ui5-icon-root").focus();
+        cy.realPress("Space");
+        cy.get("@ui5Click").should("have.been.calledOnce");
+    });
+
+    it("Decorative mode: does not fire ui5-click on click", () => {
+        cy.mount(
+            <Icon>
+                <span slot="symbol">★</span>
+            </Icon>
+        );
+
+        cy.get("[ui5-icon]").then($icon => {
+            $icon[0].addEventListener("ui5-click", cy.stub().as("ui5Click"));
+        });
+
+        cy.get("[ui5-icon]").realClick();
+        cy.get("@ui5Click").should("not.have.been.called");
+    });
+
+    it("no accessible-name: aria-label is not set", () => {
+        cy.mount(
+            <Icon mode="Image">
+                <span slot="symbol">★</span>
+            </Icon>
+        );
+
+        cy.get("[ui5-icon]").shadow().find("span.ui5-icon-root")
+            .should("not.have.attr", "aria-label");
+    });
+
+    it("accessible-name takes effect when set", () => {
+        cy.mount(
+            <Icon mode="Image" accessibleName="Initial">
+                <span slot="symbol">★</span>
+            </Icon>
+        );
+
+        cy.get("[ui5-icon]").shadow().find("span.ui5-icon-root")
+            .should("have.attr", "aria-label", "Initial");
+
+        cy.get("[ui5-icon]").invoke("prop", "accessibleName", "Updated");
+
+        cy.get("[ui5-icon]").shadow().find("span.ui5-icon-root")
+            .should("have.attr", "aria-label", "Updated");
     });
 });

--- a/packages/main/cypress/specs/Icon.cy.tsx
+++ b/packages/main/cypress/specs/Icon.cy.tsx
@@ -344,11 +344,11 @@ describe("Icon general interaction", () => {
     });
 });
 
-describe("Icon symbol slot", () => {
-    it("renders a span root instead of svg when symbol slot is used", () => {
+describe("Icon fontIcon slot", () => {
+    it("renders a span root instead of svg when fontIcon slot is used", () => {
         cy.mount(
             <Icon>
-                <span slot="symbol">★</span>
+                <span slot="fontIcon">★</span>
             </Icon>
         );
 
@@ -359,7 +359,7 @@ describe("Icon symbol slot", () => {
     it("Decorative mode: span root has role=presentation and aria-hidden=true", () => {
         cy.mount(
             <Icon>
-                <span slot="symbol">★</span>
+                <span slot="fontIcon">★</span>
             </Icon>
         );
 
@@ -371,7 +371,7 @@ describe("Icon symbol slot", () => {
     it("Image mode: span root has role=img and aria-label", () => {
         cy.mount(
             <Icon mode="Image" accessibleName="Star">
-                <span slot="symbol">★</span>
+                <span slot="fontIcon">★</span>
             </Icon>
         );
 
@@ -384,7 +384,7 @@ describe("Icon symbol slot", () => {
     it("Interactive mode: span root has role=button and tabindex=0", () => {
         cy.mount(
             <Icon mode="Interactive" accessibleName="Add">
-                <span slot="symbol">＋</span>
+                <span slot="fontIcon">＋</span>
             </Icon>
         );
 
@@ -397,7 +397,7 @@ describe("Icon symbol slot", () => {
     it("Interactive mode: fires ui5-click on mouse click", () => {
         cy.mount(
             <Icon mode="Interactive" accessibleName="Add">
-                <span slot="symbol">＋</span>
+                <span slot="fontIcon">＋</span>
             </Icon>
         );
 
@@ -412,7 +412,7 @@ describe("Icon symbol slot", () => {
     it("Interactive mode: fires ui5-click on Enter key", () => {
         cy.mount(
             <Icon mode="Interactive" accessibleName="Add">
-                <span slot="symbol">＋</span>
+                <span slot="fontIcon">＋</span>
             </Icon>
         );
 
@@ -428,7 +428,7 @@ describe("Icon symbol slot", () => {
     it("Interactive mode: fires ui5-click on Space key", () => {
         cy.mount(
             <Icon mode="Interactive" accessibleName="Add">
-                <span slot="symbol">＋</span>
+                <span slot="fontIcon">＋</span>
             </Icon>
         );
 
@@ -444,7 +444,7 @@ describe("Icon symbol slot", () => {
     it("Decorative mode: does not fire ui5-click on click", () => {
         cy.mount(
             <Icon>
-                <span slot="symbol">★</span>
+                <span slot="fontIcon">★</span>
             </Icon>
         );
 
@@ -459,7 +459,7 @@ describe("Icon symbol slot", () => {
     it("no accessible-name: aria-label is not set", () => {
         cy.mount(
             <Icon mode="Image">
-                <span slot="symbol">★</span>
+                <span slot="fontIcon">★</span>
             </Icon>
         );
 
@@ -470,7 +470,7 @@ describe("Icon symbol slot", () => {
     it("accessible-name takes effect when set", () => {
         cy.mount(
             <Icon mode="Image" accessibleName="Initial">
-                <span slot="symbol">★</span>
+                <span slot="fontIcon">★</span>
             </Icon>
         );
 

--- a/packages/main/src/Icon.ts
+++ b/packages/main/src/Icon.ts
@@ -198,7 +198,7 @@ class Icon extends UI5Element implements IIcon {
 
 	/**
 	 * Defines the font icon to be used as an icon.
-	 * Intended for font-based icon libraries (e.g. Font Awesome, Material Icons) where
+	 * Intended for font-based icon libraries where
 	 * the application loads the font and provides a slotted element with the unicode character.
 	 * When this slot is used, the component renders a `<span>` instead of an `<svg>`.
 	 * Accessibility is fully delegated to the application — set `accessible-name` and `mode` explicitly.

--- a/packages/main/src/Icon.ts
+++ b/packages/main/src/Icon.ts
@@ -210,7 +210,7 @@ class Icon extends UI5Element implements IIcon {
 	 * </ui5-icon>
 	 * ```
 	 * @public
-	 * @since 2.12.0
+	 * @since 2.23.0
 	 */
 	@slot({ type: HTMLElement })
 	symbol!: Slot<HTMLElement>;

--- a/packages/main/src/Icon.ts
+++ b/packages/main/src/Icon.ts
@@ -3,7 +3,9 @@ import jsxRender from "@ui5/webcomponents-base/dist/renderer/JsxRenderer.js";
 import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
 import event from "@ui5/webcomponents-base/dist/decorators/event-strict.js";
 import property from "@ui5/webcomponents-base/dist/decorators/property.js";
+import slot from "@ui5/webcomponents-base/dist/decorators/slot-strict.js";
 import type { AriaRole } from "@ui5/webcomponents-base/dist/types.js";
+import type { Slot } from "@ui5/webcomponents-base/dist/UI5Element.js";
 import type { IconData, UnsafeIconData } from "@ui5/webcomponents-base/dist/asset-registries/Icons.js";
 import { getIconData, getIconDataSync } from "@ui5/webcomponents-base/dist/asset-registries/Icons.js";
 import { getI18nBundle } from "@ui5/webcomponents-base/dist/i18nBundle.js";
@@ -195,6 +197,25 @@ class Icon extends UI5Element implements IIcon {
 	mode: `${IconMode}` = "Decorative";
 
 	/**
+	 * Defines the symbol to be used as an icon.
+	 * Intended for font-based icon libraries (e.g. Font Awesome, Material Icons) where
+	 * the application loads the font and provides a slotted element with the unicode character.
+	 * When this slot is used, the component renders a `<span>` instead of an `<svg>`.
+	 * Accessibility is fully delegated to the application — set `accessible-name` and `mode` explicitly.
+	 *
+	 * **Example:**
+	 * ```html
+	 * <ui5-icon mode="Image" accessible-name="Home">
+	 *   <i class="fa fa-home" slot="symbol"></i>
+	 * </ui5-icon>
+	 * ```
+	 * @public
+	 * @since 2.12.0
+	 */
+	@slot({ type: HTMLElement })
+	symbol!: Slot<HTMLElement>;
+
+	/**
 	 * @private
 	 */
 	@property({ type: Array, noAttribute: true })
@@ -288,6 +309,16 @@ class Icon extends UI5Element implements IIcon {
 	}
 
 	async onBeforeRendering() {
+		if (this.symbol.length) {
+			// Font-based icon via slot — skip registry, accessibility is app's responsibility
+			if (!this.accessibleName) {
+				this.effectiveAccessibleName = undefined;
+			} else {
+				this.effectiveAccessibleName = this.accessibleName;
+			}
+			return;
+		}
+
 		const name = this.name;
 		if (!name) {
 			return;
@@ -342,6 +373,10 @@ class Icon extends UI5Element implements IIcon {
 		} else {
 			this.effectiveAccessibleName = undefined;
 		}
+	}
+
+	get hasSymbol() {
+		return this.symbol.length > 0;
 	}
 
 	get hasIconTooltip() {

--- a/packages/main/src/Icon.ts
+++ b/packages/main/src/Icon.ts
@@ -197,7 +197,7 @@ class Icon extends UI5Element implements IIcon {
 	mode: `${IconMode}` = "Decorative";
 
 	/**
-	 * Defines the symbol to be used as an icon.
+	 * Defines the font icon to be used as an icon.
 	 * Intended for font-based icon libraries (e.g. Font Awesome, Material Icons) where
 	 * the application loads the font and provides a slotted element with the unicode character.
 	 * When this slot is used, the component renders a `<span>` instead of an `<svg>`.
@@ -206,14 +206,14 @@ class Icon extends UI5Element implements IIcon {
 	 * **Example:**
 	 * ```html
 	 * <ui5-icon mode="Image" accessible-name="Home">
-	 *   <i class="fa fa-home" slot="symbol"></i>
+	 *   <i class="fa fa-home" slot="fontIcon"></i>
 	 * </ui5-icon>
 	 * ```
 	 * @public
 	 * @since 2.23.0
 	 */
 	@slot({ type: HTMLElement })
-	symbol!: Slot<HTMLElement>;
+	fontIcon!: Slot<HTMLElement>;
 
 	/**
 	 * @private
@@ -309,7 +309,7 @@ class Icon extends UI5Element implements IIcon {
 	}
 
 	async onBeforeRendering() {
-		if (this.symbol.length) {
+		if (this.fontIcon.length) {
 			// Font-based icon via slot — skip registry, accessibility is app's responsibility
 			if (!this.accessibleName) {
 				this.effectiveAccessibleName = undefined;
@@ -375,8 +375,8 @@ class Icon extends UI5Element implements IIcon {
 		}
 	}
 
-	get hasSymbol() {
-		return this.symbol.length > 0;
+	get hasFontIcon() {
+		return this.fontIcon.length > 0;
 	}
 
 	get hasIconTooltip() {

--- a/packages/main/src/IconTemplate.tsx
+++ b/packages/main/src/IconTemplate.tsx
@@ -1,7 +1,7 @@
 import type Icon from "./Icon.js";
 
 export default function IconTemplate(this: Icon) {
-	if (this.hasSymbol) {
+	if (this.hasFontIcon) {
 		return (
 			<span
 				class="ui5-icon-root"
@@ -14,7 +14,7 @@ export default function IconTemplate(this: Icon) {
 				onKeyUp={this._onkeyup}
 				onClick={this._onclick}
 			>
-				<slot name="symbol"></slot>
+				<slot name="fontIcon"></slot>
 			</span>
 		);
 	}

--- a/packages/main/src/IconTemplate.tsx
+++ b/packages/main/src/IconTemplate.tsx
@@ -1,6 +1,24 @@
 import type Icon from "./Icon.js";
 
 export default function IconTemplate(this: Icon) {
+	if (this.hasSymbol) {
+		return (
+			<span
+				class="ui5-icon-root"
+				part="root"
+				tabindex={this._tabIndex}
+				role={this.effectiveAccessibleRole}
+				aria-label={this.effectiveAccessibleName}
+				aria-hidden={this.effectiveAriaHidden}
+				onKeyDown={this._onkeydown}
+				onKeyUp={this._onkeyup}
+				onClick={this._onclick}
+			>
+				<slot name="symbol"></slot>
+			</span>
+		);
+	}
+
 	return (
 		<svg
 			class="ui5-icon-root"

--- a/packages/main/src/themes/Icon.css
+++ b/packages/main/src/themes/Icon.css
@@ -20,6 +20,7 @@
 	color: var(--sapContent_IconColor);
 	fill: currentColor;
 	outline: none;
+	container-type: size;
 }
 
 :host([design="Contrast"]) {
@@ -62,6 +63,11 @@
 	width: 100%;
 	outline: none;
 	vertical-align: top;
+	box-sizing: border-box;
+	align-items: center;
+	justify-content: center;
+	font-size: min(100cqw, 100cqh);
+	line-height: 1;
 }
 
 

--- a/packages/main/test/pages/Icon_symbol.html
+++ b/packages/main/test/pages/Icon_symbol.html
@@ -67,6 +67,19 @@
 			height: 1.5rem;
 		}
 	</style>
+	<!-- SAP Icons font (application-hosted) -->
+	<style>
+		@font-face {
+			font-family: "SAP-icons-font";
+			src: url("https://cdn.jsdelivr.net/npm/@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/SAP-icons.woff2") format("woff2");
+			font-weight: normal;
+			font-style: normal;
+		}
+
+		.sap-icon-font {
+			font-family: "SAP-icons-font";
+		}
+	</style>
 </head>
 
 <body>
@@ -78,6 +91,7 @@
 			<tr>
 				<th>Scenario</th>
 				<th>SAP Icons (SVG)</th>
+				<th>SAP Icons (font)</th>
 				<th>Material Symbols</th>
 				<th>Font Awesome</th>
 				<th>Bootstrap Icons</th>
@@ -88,6 +102,11 @@
 			<tr>
 				<td>Decorative (default)</td>
 				<td><ui5-icon name="accept"></ui5-icon></td>
+				<td>
+					<ui5-icon>
+						<span slot="symbol" class="sap-icon-font">&#xe05b;</span>
+					</ui5-icon>
+				</td>
 				<td>
 					<ui5-icon>
 						<span slot="symbol" class="material-symbols-outlined">check_circle</span>
@@ -114,6 +133,11 @@
 				<td><ui5-icon name="home" mode="Image" accessible-name="Home"></ui5-icon></td>
 				<td>
 					<ui5-icon mode="Image" accessible-name="Home">
+						<span slot="symbol" class="sap-icon-font">&#xe070;</span>
+					</ui5-icon>
+				</td>
+				<td>
+					<ui5-icon mode="Image" accessible-name="Home">
 						<span slot="symbol" class="material-symbols-outlined">home</span>
 					</ui5-icon>
 				</td>
@@ -136,6 +160,11 @@
 			<tr>
 				<td>Interactive mode</td>
 				<td><ui5-icon name="add" mode="Interactive" accessible-name="Add"></ui5-icon></td>
+				<td>
+					<ui5-icon mode="Interactive" accessible-name="Add">
+						<span slot="symbol" class="sap-icon-font">&#xe058;</span>
+					</ui5-icon>
+				</td>
 				<td>
 					<ui5-icon mode="Interactive" accessible-name="Add">
 						<span slot="symbol" class="material-symbols-outlined">add_circle</span>
@@ -162,6 +191,11 @@
 				<td><ui5-icon name="accept" design="Positive"></ui5-icon></td>
 				<td>
 					<ui5-icon design="Positive">
+						<span slot="symbol" class="sap-icon-font">&#xe05b;</span>
+					</ui5-icon>
+				</td>
+				<td>
+					<ui5-icon design="Positive">
 						<span slot="symbol" class="material-symbols-outlined">check_circle</span>
 					</ui5-icon>
 				</td>
@@ -184,6 +218,11 @@
 			<tr>
 				<td>design="Negative"</td>
 				<td><ui5-icon name="error" design="Negative"></ui5-icon></td>
+				<td>
+					<ui5-icon design="Negative">
+						<span slot="symbol" class="sap-icon-font">&#xe1ec;</span>
+					</ui5-icon>
+				</td>
 				<td>
 					<ui5-icon design="Negative">
 						<span slot="symbol" class="material-symbols-outlined">cancel</span>
@@ -210,6 +249,11 @@
 				<td><ui5-icon name="alert" design="Critical"></ui5-icon></td>
 				<td>
 					<ui5-icon design="Critical">
+						<span slot="symbol" class="sap-icon-font">&#xe053;</span>
+					</ui5-icon>
+				</td>
+				<td>
+					<ui5-icon design="Critical">
 						<span slot="symbol" class="material-symbols-outlined">warning</span>
 					</ui5-icon>
 				</td>
@@ -232,6 +276,11 @@
 			<tr>
 				<td>3rem size</td>
 				<td><ui5-icon name="settings" style="width:3rem;height:3rem"></ui5-icon></td>
+				<td>
+					<ui5-icon style="width:3rem;height:3rem">
+						<span slot="symbol" class="sap-icon-font">&#xe00c;</span>
+					</ui5-icon>
+				</td>
 				<td>
 					<ui5-icon style="width:3rem;height:3rem">
 						<span slot="symbol" class="material-symbols-outlined">settings</span>
@@ -258,6 +307,11 @@
 				<td><ui5-icon name="settings" style="width:5rem;height:5rem; font-size: 2rem;"></ui5-icon></td>
 				<td>
 					<ui5-icon style="width:5rem;height:5rem">
+						<span slot="symbol" class="sap-icon-font" style="font-size:2rem">&#xe00c;</span>
+					</ui5-icon>
+				</td>
+				<td>
+					<ui5-icon style="width:5rem;height:5rem">
 						<span slot="symbol" class="material-symbols-outlined" style="font-size:2rem">settings</span>
 					</ui5-icon>
 				</td>
@@ -280,6 +334,11 @@
 			<tr>
 				<td>Custom color</td>
 				<td><ui5-icon name="settings" style="color: red;"></ui5-icon></td>
+				<td>
+					<ui5-icon style="color: red;">
+						<span slot="symbol" class="sap-icon-font">&#xe00c;</span>
+					</ui5-icon>
+				</td>
 				<td>
 					<ui5-icon style="color: red;">
 						<span slot="symbol" class="material-symbols-outlined">settings</span>

--- a/packages/main/test/pages/Icon_symbol.html
+++ b/packages/main/test/pages/Icon_symbol.html
@@ -104,27 +104,27 @@
 				<td><ui5-icon name="accept"></ui5-icon></td>
 				<td>
 					<ui5-icon>
-						<span slot="symbol" class="sap-icon-font">&#xe05b;</span>
+						<span slot="fontIcon" class="sap-icon-font">&#xe05b;</span>
 					</ui5-icon>
 				</td>
 				<td>
 					<ui5-icon>
-						<span slot="symbol" class="material-symbols-outlined">check_circle</span>
+						<span slot="fontIcon" class="material-symbols-outlined">check_circle</span>
 					</ui5-icon>
 				</td>
 				<td>
 					<ui5-icon>
-						<i slot="symbol" class="fa-solid fa-circle-check"></i>
+						<i slot="fontIcon" class="fa-solid fa-circle-check"></i>
 					</ui5-icon>
 				</td>
 				<td>
 					<ui5-icon>
-						<i slot="symbol" class="bi bi-check-circle"></i>
+						<i slot="fontIcon" class="bi bi-check-circle"></i>
 					</ui5-icon>
 				</td>
 				<td>
 					<ui5-icon>
-						<i slot="symbol" class="ph ph-check-circle"></i>
+						<i slot="fontIcon" class="ph ph-check-circle"></i>
 					</ui5-icon>
 				</td>
 			</tr>
@@ -133,27 +133,27 @@
 				<td><ui5-icon name="home" mode="Image" accessible-name="Home"></ui5-icon></td>
 				<td>
 					<ui5-icon mode="Image" accessible-name="Home">
-						<span slot="symbol" class="sap-icon-font">&#xe070;</span>
+						<span slot="fontIcon" class="sap-icon-font">&#xe070;</span>
 					</ui5-icon>
 				</td>
 				<td>
 					<ui5-icon mode="Image" accessible-name="Home">
-						<span slot="symbol" class="material-symbols-outlined">home</span>
+						<span slot="fontIcon" class="material-symbols-outlined">home</span>
 					</ui5-icon>
 				</td>
 				<td>
 					<ui5-icon mode="Image" accessible-name="Home">
-						<i slot="symbol" class="fa-solid fa-house"></i>
+						<i slot="fontIcon" class="fa-solid fa-house"></i>
 					</ui5-icon>
 				</td>
 				<td>
 					<ui5-icon mode="Image" accessible-name="Home">
-						<i slot="symbol" class="bi bi-house"></i>
+						<i slot="fontIcon" class="bi bi-house"></i>
 					</ui5-icon>
 				</td>
 				<td>
 					<ui5-icon mode="Image" accessible-name="Home">
-						<i slot="symbol" class="ph ph-house"></i>
+						<i slot="fontIcon" class="ph ph-house"></i>
 					</ui5-icon>
 				</td>
 			</tr>
@@ -162,27 +162,27 @@
 				<td><ui5-icon name="add" mode="Interactive" accessible-name="Add"></ui5-icon></td>
 				<td>
 					<ui5-icon mode="Interactive" accessible-name="Add">
-						<span slot="symbol" class="sap-icon-font">&#xe058;</span>
+						<span slot="fontIcon" class="sap-icon-font">&#xe058;</span>
 					</ui5-icon>
 				</td>
 				<td>
 					<ui5-icon mode="Interactive" accessible-name="Add">
-						<span slot="symbol" class="material-symbols-outlined">add_circle</span>
+						<span slot="fontIcon" class="material-symbols-outlined">add_circle</span>
 					</ui5-icon>
 				</td>
 				<td>
 					<ui5-icon mode="Interactive" accessible-name="Add">
-						<i slot="symbol" class="fa-solid fa-circle-plus"></i>
+						<i slot="fontIcon" class="fa-solid fa-circle-plus"></i>
 					</ui5-icon>
 				</td>
 				<td>
 					<ui5-icon mode="Interactive" accessible-name="Add">
-						<i slot="symbol" class="bi bi-plus-circle"></i>
+						<i slot="fontIcon" class="bi bi-plus-circle"></i>
 					</ui5-icon>
 				</td>
 				<td>
 					<ui5-icon mode="Interactive" accessible-name="Add">
-						<i slot="symbol" class="ph ph-plus-circle"></i>
+						<i slot="fontIcon" class="ph ph-plus-circle"></i>
 					</ui5-icon>
 				</td>
 			</tr>
@@ -191,27 +191,27 @@
 				<td><ui5-icon name="accept" design="Positive"></ui5-icon></td>
 				<td>
 					<ui5-icon design="Positive">
-						<span slot="symbol" class="sap-icon-font">&#xe05b;</span>
+						<span slot="fontIcon" class="sap-icon-font">&#xe05b;</span>
 					</ui5-icon>
 				</td>
 				<td>
 					<ui5-icon design="Positive">
-						<span slot="symbol" class="material-symbols-outlined">check_circle</span>
+						<span slot="fontIcon" class="material-symbols-outlined">check_circle</span>
 					</ui5-icon>
 				</td>
 				<td>
 					<ui5-icon design="Positive">
-						<i slot="symbol" class="fa-solid fa-circle-check"></i>
+						<i slot="fontIcon" class="fa-solid fa-circle-check"></i>
 					</ui5-icon>
 				</td>
 				<td>
 					<ui5-icon design="Positive">
-						<i slot="symbol" class="bi bi-check-circle"></i>
+						<i slot="fontIcon" class="bi bi-check-circle"></i>
 					</ui5-icon>
 				</td>
 				<td>
 					<ui5-icon design="Positive">
-						<i slot="symbol" class="ph ph-check-circle"></i>
+						<i slot="fontIcon" class="ph ph-check-circle"></i>
 					</ui5-icon>
 				</td>
 			</tr>
@@ -220,27 +220,27 @@
 				<td><ui5-icon name="error" design="Negative"></ui5-icon></td>
 				<td>
 					<ui5-icon design="Negative">
-						<span slot="symbol" class="sap-icon-font">&#xe1ec;</span>
+						<span slot="fontIcon" class="sap-icon-font">&#xe1ec;</span>
 					</ui5-icon>
 				</td>
 				<td>
 					<ui5-icon design="Negative">
-						<span slot="symbol" class="material-symbols-outlined">cancel</span>
+						<span slot="fontIcon" class="material-symbols-outlined">cancel</span>
 					</ui5-icon>
 				</td>
 				<td>
 					<ui5-icon design="Negative">
-						<i slot="symbol" class="fa-solid fa-circle-xmark"></i>
+						<i slot="fontIcon" class="fa-solid fa-circle-xmark"></i>
 					</ui5-icon>
 				</td>
 				<td>
 					<ui5-icon design="Negative">
-						<i slot="symbol" class="bi bi-x-circle"></i>
+						<i slot="fontIcon" class="bi bi-x-circle"></i>
 					</ui5-icon>
 				</td>
 				<td>
 					<ui5-icon design="Negative">
-						<i slot="symbol" class="ph ph-x-circle"></i>
+						<i slot="fontIcon" class="ph ph-x-circle"></i>
 					</ui5-icon>
 				</td>
 			</tr>
@@ -249,27 +249,27 @@
 				<td><ui5-icon name="alert" design="Critical"></ui5-icon></td>
 				<td>
 					<ui5-icon design="Critical">
-						<span slot="symbol" class="sap-icon-font">&#xe053;</span>
+						<span slot="fontIcon" class="sap-icon-font">&#xe053;</span>
 					</ui5-icon>
 				</td>
 				<td>
 					<ui5-icon design="Critical">
-						<span slot="symbol" class="material-symbols-outlined">warning</span>
+						<span slot="fontIcon" class="material-symbols-outlined">warning</span>
 					</ui5-icon>
 				</td>
 				<td>
 					<ui5-icon design="Critical">
-						<i slot="symbol" class="fa-solid fa-triangle-exclamation"></i>
+						<i slot="fontIcon" class="fa-solid fa-triangle-exclamation"></i>
 					</ui5-icon>
 				</td>
 				<td>
 					<ui5-icon design="Critical">
-						<i slot="symbol" class="bi bi-exclamation-triangle"></i>
+						<i slot="fontIcon" class="bi bi-exclamation-triangle"></i>
 					</ui5-icon>
 				</td>
 				<td>
 					<ui5-icon design="Critical">
-						<i slot="symbol" class="ph ph-warning"></i>
+						<i slot="fontIcon" class="ph ph-warning"></i>
 					</ui5-icon>
 				</td>
 			</tr>
@@ -278,27 +278,27 @@
 				<td><ui5-icon name="settings" style="width:3rem;height:3rem"></ui5-icon></td>
 				<td>
 					<ui5-icon style="width:3rem;height:3rem">
-						<span slot="symbol" class="sap-icon-font">&#xe00c;</span>
+						<span slot="fontIcon" class="sap-icon-font">&#xe00c;</span>
 					</ui5-icon>
 				</td>
 				<td>
 					<ui5-icon style="width:3rem;height:3rem">
-						<span slot="symbol" class="material-symbols-outlined">settings</span>
+						<span slot="fontIcon" class="material-symbols-outlined">settings</span>
 					</ui5-icon>
 				</td>
 				<td>
 					<ui5-icon style="width:3rem;height:3rem">
-						<i slot="symbol" class="fa-solid fa-gear"></i>
+						<i slot="fontIcon" class="fa-solid fa-gear"></i>
 					</ui5-icon>
 				</td>
 				<td>
 					<ui5-icon style="width:3rem;height:3rem">
-						<i slot="symbol" class="bi bi-gear"></i>
+						<i slot="fontIcon" class="bi bi-gear"></i>
 					</ui5-icon>
 				</td>
 				<td>
 					<ui5-icon style="width:3rem;height:3rem">
-						<i slot="symbol" class="ph ph-gear"></i>
+						<i slot="fontIcon" class="ph ph-gear"></i>
 					</ui5-icon>
 				</td>
 			</tr>
@@ -307,27 +307,27 @@
 				<td><ui5-icon name="settings" style="width:5rem;height:5rem; font-size: 2rem;"></ui5-icon></td>
 				<td>
 					<ui5-icon style="width:5rem;height:5rem">
-						<span slot="symbol" class="sap-icon-font" style="font-size:2rem">&#xe00c;</span>
+						<span slot="fontIcon" class="sap-icon-font" style="font-size:2rem">&#xe00c;</span>
 					</ui5-icon>
 				</td>
 				<td>
 					<ui5-icon style="width:5rem;height:5rem">
-						<span slot="symbol" class="material-symbols-outlined" style="font-size:2rem">settings</span>
+						<span slot="fontIcon" class="material-symbols-outlined" style="font-size:2rem">settings</span>
 					</ui5-icon>
 				</td>
 				<td>
 					<ui5-icon style="width:5rem;height:5rem">
-						<i slot="symbol" class="fa-solid fa-gear" style="font-size:2rem"></i>
+						<i slot="fontIcon" class="fa-solid fa-gear" style="font-size:2rem"></i>
 					</ui5-icon>
 				</td>
 				<td>
 					<ui5-icon style="width:5rem;height:5rem">
-						<i slot="symbol" class="bi bi-gear" style="font-size:2rem"></i>
+						<i slot="fontIcon" class="bi bi-gear" style="font-size:2rem"></i>
 					</ui5-icon>
 				</td>
 				<td>
 					<ui5-icon style="width:5rem;height:5rem">
-						<i slot="symbol" class="ph ph-gear" style="font-size:2rem"></i>
+						<i slot="fontIcon" class="ph ph-gear" style="font-size:2rem"></i>
 					</ui5-icon>
 				</td>
 			</tr>
@@ -336,27 +336,27 @@
 				<td><ui5-icon name="settings" style="color: red;"></ui5-icon></td>
 				<td>
 					<ui5-icon style="color: red;">
-						<span slot="symbol" class="sap-icon-font">&#xe00c;</span>
+						<span slot="fontIcon" class="sap-icon-font">&#xe00c;</span>
 					</ui5-icon>
 				</td>
 				<td>
 					<ui5-icon style="color: red;">
-						<span slot="symbol" class="material-symbols-outlined">settings</span>
+						<span slot="fontIcon" class="material-symbols-outlined">settings</span>
 					</ui5-icon>
 				</td>
 				<td>
 					<ui5-icon style="color: red;">
-						<i slot="symbol" class="fa-solid fa-gear"></i>
+						<i slot="fontIcon" class="fa-solid fa-gear"></i>
 					</ui5-icon>
 				</td>
 				<td>
 					<ui5-icon style="color: red;">
-						<i slot="symbol" class="bi bi-gear"></i>
+						<i slot="fontIcon" class="bi bi-gear"></i>
 					</ui5-icon>
 				</td>
 				<td>
 					<ui5-icon style="color: red;">
-						<i slot="symbol" class="ph ph-gear"></i>
+						<i slot="fontIcon" class="ph ph-gear"></i>
 					</ui5-icon>
 				</td>
 			</tr>

--- a/packages/main/test/pages/Icon_symbol.html
+++ b/packages/main/test/pages/Icon_symbol.html
@@ -1,0 +1,308 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta charset="utf-8">
+
+	<title>Icon - Symbol Slot (Font-based Icons)</title>
+	<script src="%VITE_BUNDLE_PATH%" type="module"></script>
+
+	<!-- Material Symbols -->
+	<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" />
+
+	<!-- Font Awesome Free -->
+	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css" />
+
+	<!-- Bootstrap Icons -->
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
+
+	<!-- Phosphor Icons -->
+	<script src="https://unpkg.com/@phosphor-icons/web"></script>
+
+	<style>
+		body {
+			background-color: var(--sapBackgroundColor);
+			font-family: var(--sapFontFamily);
+			padding: 1rem;
+		}
+
+		/*
+		 * Material Symbols sets its own font-size via the Google Fonts stylesheet.
+		 * Override with font-size: inherit so it picks up the size set by ui5-icon
+		 * (which derives it from the host width/height via container query units).
+		 * Other libraries (FA, Bootstrap Icons, Phosphor) don't set font-size,
+		 * so they inherit correctly without this override.
+		 */
+		.material-symbols-outlined {
+			font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+			font-size: inherit;
+		}
+
+		table {
+			border-collapse: collapse;
+			margin-top: 1rem;
+		}
+
+		th, td {
+			border: 1px solid var(--sapList_BorderColor, #ccc);
+			padding: 0.5rem 1rem;
+			text-align: center;
+			vertical-align: middle;
+		}
+
+		th {
+			background-color: var(--sapList_HeaderBackground);
+			font-weight: bold;
+		}
+
+		td:first-child {
+			text-align: left;
+			font-size: 0.875rem;
+			color: var(--sapTextColor);
+		}
+
+		ui5-icon {
+			width: 1.5rem;
+			height: 1.5rem;
+		}
+	</style>
+</head>
+
+<body>
+	<h2>Icon - symbol slot</h2>
+	<p>Font-based icons via the <code>symbol</code> slot. The application loads the font; <code>ui5-icon</code> wraps it for sizing, design tokens, and accessibility.</p>
+
+	<table>
+		<thead>
+			<tr>
+				<th>Scenario</th>
+				<th>SAP Icons (SVG)</th>
+				<th>Material Symbols</th>
+				<th>Font Awesome</th>
+				<th>Bootstrap Icons</th>
+				<th>Phosphor Icons</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<td>Decorative (default)</td>
+				<td><ui5-icon name="accept"></ui5-icon></td>
+				<td>
+					<ui5-icon>
+						<span slot="symbol" class="material-symbols-outlined">check_circle</span>
+					</ui5-icon>
+				</td>
+				<td>
+					<ui5-icon>
+						<i slot="symbol" class="fa-solid fa-circle-check"></i>
+					</ui5-icon>
+				</td>
+				<td>
+					<ui5-icon>
+						<i slot="symbol" class="bi bi-check-circle"></i>
+					</ui5-icon>
+				</td>
+				<td>
+					<ui5-icon>
+						<i slot="symbol" class="ph ph-check-circle"></i>
+					</ui5-icon>
+				</td>
+			</tr>
+			<tr>
+				<td>Image mode + accessible-name</td>
+				<td><ui5-icon name="home" mode="Image" accessible-name="Home"></ui5-icon></td>
+				<td>
+					<ui5-icon mode="Image" accessible-name="Home">
+						<span slot="symbol" class="material-symbols-outlined">home</span>
+					</ui5-icon>
+				</td>
+				<td>
+					<ui5-icon mode="Image" accessible-name="Home">
+						<i slot="symbol" class="fa-solid fa-house"></i>
+					</ui5-icon>
+				</td>
+				<td>
+					<ui5-icon mode="Image" accessible-name="Home">
+						<i slot="symbol" class="bi bi-house"></i>
+					</ui5-icon>
+				</td>
+				<td>
+					<ui5-icon mode="Image" accessible-name="Home">
+						<i slot="symbol" class="ph ph-house"></i>
+					</ui5-icon>
+				</td>
+			</tr>
+			<tr>
+				<td>Interactive mode</td>
+				<td><ui5-icon name="add" mode="Interactive" accessible-name="Add"></ui5-icon></td>
+				<td>
+					<ui5-icon mode="Interactive" accessible-name="Add">
+						<span slot="symbol" class="material-symbols-outlined">add_circle</span>
+					</ui5-icon>
+				</td>
+				<td>
+					<ui5-icon mode="Interactive" accessible-name="Add">
+						<i slot="symbol" class="fa-solid fa-circle-plus"></i>
+					</ui5-icon>
+				</td>
+				<td>
+					<ui5-icon mode="Interactive" accessible-name="Add">
+						<i slot="symbol" class="bi bi-plus-circle"></i>
+					</ui5-icon>
+				</td>
+				<td>
+					<ui5-icon mode="Interactive" accessible-name="Add">
+						<i slot="symbol" class="ph ph-plus-circle"></i>
+					</ui5-icon>
+				</td>
+			</tr>
+			<tr>
+				<td>design="Positive"</td>
+				<td><ui5-icon name="accept" design="Positive"></ui5-icon></td>
+				<td>
+					<ui5-icon design="Positive">
+						<span slot="symbol" class="material-symbols-outlined">check_circle</span>
+					</ui5-icon>
+				</td>
+				<td>
+					<ui5-icon design="Positive">
+						<i slot="symbol" class="fa-solid fa-circle-check"></i>
+					</ui5-icon>
+				</td>
+				<td>
+					<ui5-icon design="Positive">
+						<i slot="symbol" class="bi bi-check-circle"></i>
+					</ui5-icon>
+				</td>
+				<td>
+					<ui5-icon design="Positive">
+						<i slot="symbol" class="ph ph-check-circle"></i>
+					</ui5-icon>
+				</td>
+			</tr>
+			<tr>
+				<td>design="Negative"</td>
+				<td><ui5-icon name="error" design="Negative"></ui5-icon></td>
+				<td>
+					<ui5-icon design="Negative">
+						<span slot="symbol" class="material-symbols-outlined">cancel</span>
+					</ui5-icon>
+				</td>
+				<td>
+					<ui5-icon design="Negative">
+						<i slot="symbol" class="fa-solid fa-circle-xmark"></i>
+					</ui5-icon>
+				</td>
+				<td>
+					<ui5-icon design="Negative">
+						<i slot="symbol" class="bi bi-x-circle"></i>
+					</ui5-icon>
+				</td>
+				<td>
+					<ui5-icon design="Negative">
+						<i slot="symbol" class="ph ph-x-circle"></i>
+					</ui5-icon>
+				</td>
+			</tr>
+			<tr>
+				<td>design="Critical"</td>
+				<td><ui5-icon name="alert" design="Critical"></ui5-icon></td>
+				<td>
+					<ui5-icon design="Critical">
+						<span slot="symbol" class="material-symbols-outlined">warning</span>
+					</ui5-icon>
+				</td>
+				<td>
+					<ui5-icon design="Critical">
+						<i slot="symbol" class="fa-solid fa-triangle-exclamation"></i>
+					</ui5-icon>
+				</td>
+				<td>
+					<ui5-icon design="Critical">
+						<i slot="symbol" class="bi bi-exclamation-triangle"></i>
+					</ui5-icon>
+				</td>
+				<td>
+					<ui5-icon design="Critical">
+						<i slot="symbol" class="ph ph-warning"></i>
+					</ui5-icon>
+				</td>
+			</tr>
+			<tr>
+				<td>3rem size</td>
+				<td><ui5-icon name="settings" style="width:3rem;height:3rem"></ui5-icon></td>
+				<td>
+					<ui5-icon style="width:3rem;height:3rem">
+						<span slot="symbol" class="material-symbols-outlined">settings</span>
+					</ui5-icon>
+				</td>
+				<td>
+					<ui5-icon style="width:3rem;height:3rem">
+						<i slot="symbol" class="fa-solid fa-gear"></i>
+					</ui5-icon>
+				</td>
+				<td>
+					<ui5-icon style="width:3rem;height:3rem">
+						<i slot="symbol" class="bi bi-gear"></i>
+					</ui5-icon>
+				</td>
+				<td>
+					<ui5-icon style="width:3rem;height:3rem">
+						<i slot="symbol" class="ph ph-gear"></i>
+					</ui5-icon>
+				</td>
+			</tr>
+			<tr>
+				<td>5rem×5rem, different font-size per icon<br><small>(tests font-size vs width/height independence)</small></td>
+				<td><ui5-icon name="settings" style="width:5rem;height:5rem; font-size: 2rem;"></ui5-icon></td>
+				<td>
+					<ui5-icon style="width:5rem;height:5rem">
+						<span slot="symbol" class="material-symbols-outlined" style="font-size:2rem">settings</span>
+					</ui5-icon>
+				</td>
+				<td>
+					<ui5-icon style="width:5rem;height:5rem">
+						<i slot="symbol" class="fa-solid fa-gear" style="font-size:2rem"></i>
+					</ui5-icon>
+				</td>
+				<td>
+					<ui5-icon style="width:5rem;height:5rem">
+						<i slot="symbol" class="bi bi-gear" style="font-size:2rem"></i>
+					</ui5-icon>
+				</td>
+				<td>
+					<ui5-icon style="width:5rem;height:5rem">
+						<i slot="symbol" class="ph ph-gear" style="font-size:2rem"></i>
+					</ui5-icon>
+				</td>
+			</tr>
+			<tr>
+				<td>Custom color</td>
+				<td><ui5-icon name="settings" style="color: red;"></ui5-icon></td>
+				<td>
+					<ui5-icon style="color: red;">
+						<span slot="symbol" class="material-symbols-outlined">settings</span>
+					</ui5-icon>
+				</td>
+				<td>
+					<ui5-icon style="color: red;">
+						<i slot="symbol" class="fa-solid fa-gear"></i>
+					</ui5-icon>
+				</td>
+				<td>
+					<ui5-icon style="color: red;">
+						<i slot="symbol" class="bi bi-gear"></i>
+					</ui5-icon>
+				</td>
+				<td>
+					<ui5-icon style="color: red;">
+						<i slot="symbol" class="ph ph-gear"></i>
+					</ui5-icon>
+				</td>
+			</tr>
+		</tbody>
+	</table>
+</body>
+
+</html>


### PR DESCRIPTION
Introduces a named slot that renders a <span> wrapper instead of <svg>, allowing applications to use font-based icon libraries (Font Awesome, Material Icons, Bootstrap Icons, Phosphor, etc.) while keeping ui5-icon as the host for sizing, design tokens, color, and accessibility.

Usage:
```
<ui5-icon>
  <i slot="fontIcon" class="fa-solid fa-house"></i>
</ui5-icon>
```

Fixes: https://github.com/UI5/webcomponents/issues/8186