### PR TITLE
ci(release): rebase before push in rc-release to avoid non-fast-forward errors

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,15 +70,6 @@ jobs:
 
       - name: Push Changes
         run: |
-          # Rebase the local lerna version-bump commit onto the latest remote
-          # branch in case other commits landed during the build, then re-point
-          # the tag(s) lerna created so they reference the rebased commit.
-          NEW_TAGS=$(git tag --points-at HEAD)
-          git fetch origin ${{ github.ref_name }}
-          git rebase origin/${{ github.ref_name }}
-          for tag in $NEW_TAGS; do
-            git tag -f "$tag" HEAD
-          done
           git push origin HEAD
           git push origin --tags
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -289,15 +289,6 @@ jobs:
 
       - name: Push Changes
         run: |
-          # Rebase the local lerna version-bump commit onto the latest remote
-          # branch in case other commits landed during the build, then re-point
-          # the tag(s) lerna created so they reference the rebased commit.
-          NEW_TAGS=$(git tag --points-at HEAD)
-          git fetch origin ${{ github.ref_name }}
-          git rebase origin/${{ github.ref_name }}
-          for tag in $NEW_TAGS; do
-            git tag -f "$tag" HEAD
-          done
           git push origin HEAD
           git push origin --tags
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,6 +70,15 @@ jobs:
 
       - name: Push Changes
         run: |
+          # Rebase the local lerna version-bump commit onto the latest remote
+          # branch in case other commits landed during the build, then re-point
+          # the tag(s) lerna created so they reference the rebased commit.
+          NEW_TAGS=$(git tag --points-at HEAD)
+          git fetch origin ${{ github.ref_name }}
+          git rebase origin/${{ github.ref_name }}
+          for tag in $NEW_TAGS; do
+            git tag -f "$tag" HEAD
+          done
           git push origin HEAD
           git push origin --tags
 
@@ -178,6 +187,15 @@ jobs:
 
       - name: Push Changes
         run: |
+          # Rebase the local lerna version-bump commit onto the latest remote
+          # branch in case other commits landed during the build, then re-point
+          # the tag(s) lerna created so they reference the rebased commit.
+          NEW_TAGS=$(git tag --points-at HEAD)
+          git fetch origin ${{ github.ref_name }}
+          git rebase origin/${{ github.ref_name }}
+          for tag in $NEW_TAGS; do
+            git tag -f "$tag" HEAD
+          done
           git push origin HEAD
           git push origin --tags
 
@@ -271,6 +289,15 @@ jobs:
 
       - name: Push Changes
         run: |
+          # Rebase the local lerna version-bump commit onto the latest remote
+          # branch in case other commits landed during the build, then re-point
+          # the tag(s) lerna created so they reference the rebased commit.
+          NEW_TAGS=$(git tag --points-at HEAD)
+          git fetch origin ${{ github.ref_name }}
+          git rebase origin/${{ github.ref_name }}
+          for tag in $NEW_TAGS; do
+            git tag -f "$tag" HEAD
+          done
           git push origin HEAD
           git push origin --tags
 


### PR DESCRIPTION
## Summary

- The `rc-release` job's `Push Changes` step was rejecting pushes with `non-fast-forward` when other commits landed on `main` between checkout and push (recent example: an RC build racing against a Translation Delivery PR merge — [run 26216559548](https://github.com/UI5/webcomponents/actions/runs/26216559548/job/77140316121)).
- Before pushing, fetch `main`, rebase the local lerna version-bump commit onto the latest remote tip, and re-point the lerna-created tag(s) to the rebased commit so the tag push references the right SHA.
- Scoped to `rc-release` only — that's the job that hit the race in practice. `stable-release` and `hotfix-release` are left alone.

## Why re-point the tags

`lerna version --no-push` creates one local commit and one tag. `git rebase` rewrites that commit to a new SHA, leaving the tag stuck on the old (now unreachable) commit — so a plain `git push --tags` would publish a tag pointing at content that isn't on `main`, and `lerna publish from-git` (the next step) wouldn't find the tag at HEAD. `git tag -f "$tag" HEAD` after the rebase moves the tag onto the rebased commit. If `origin` didn't move, the rebase and the re-point are both no-ops.

If a rebase ever does fail (real conflict, or another push lands during the rebase itself), the job fails loudly and a re-run is safe — the local tag/commit are discarded with the runner, the version bump just runs again from the new `main`.

## Test plan

- [ ] Trigger an RC release manually (`workflow_dispatch` with `release_type: rc`) and confirm the new step succeeds when no concurrent merge is happening.
- [ ] If feasible, verify the rebase path by merging a no-op PR into `main` while the release workflow is mid-build, and confirm the push still succeeds with the tag pointing at the rebased commit.