### PR TITLE
fix(tools): resolve airbnb-base eslint config from tools package location

### DIFF
--- a/packages/tools/components-package/eslint.js
+++ b/packages/tools/components-package/eslint.js
@@ -66,7 +66,7 @@ module.exports = {
 		"es6": true
 	},
 	"root": true,
-	"extends": "airbnb-base",
+	"extends": require.resolve("eslint-config-airbnb-base"),
 	"overrides": tsMode ? getTsModeOverrides() : [],
 	"parserOptions": {
 		"ecmaVersion": 2018,


### PR DESCRIPTION
Using `"extends": "airbnb-base"` made ESLint look for the package in the consuming project's node_modules instead of the tools package. This forced external projects to add `eslint-config-airbnb-base` as their own dependency. Using `require.resolve` fixes this by loading it directly from the tools package.