### PR TITLE
fix(ui5-dialog): announce content for VoiceOver when used as message box

### DIFF
--- a/packages/main/src/Dialog.ts
+++ b/packages/main/src/Dialog.ts
@@ -198,6 +198,10 @@ class Dialog extends Popup {
 	_cachedMinHeight?: number;
 	_draggedOrResized = false;
 	_dragHandlerRegistered = false;
+	_liveTextTimeout?: ReturnType<typeof setTimeout>;
+
+	@property({ noAttribute: true })
+	_liveText = "";
 
 	/**
 	 * Defines the header HTML Element.
@@ -327,9 +331,33 @@ class Dialog extends Popup {
 		return toLowercaseEnumValue(this.accessibleRole);
 	}
 
+	get _contentDescriptionText(): string {
+		return this.content
+			.map(el => {
+				return (el instanceof HTMLElement) ? el.textContent?.trim() : "";
+			})
+			.filter(Boolean)
+			.join(" ");
+	}
+
 	_show() {
 		super._show();
 		this._center();
+
+		// VoiceOver on macOS does not announce text from the dialog content,
+		// so aria-live region is used to announce text-only content when the dialog opens.
+		const text = this._contentDescriptionText;
+		if (text) {
+			this._liveTextTimeout = setTimeout(() => {
+				this._liveText = text;
+			}, 100);
+		}
+	}
+
+	closePopup(escPressed = false, preventRegistryUpdate = false, preventFocusRestore = false): void {
+		clearTimeout(this._liveTextTimeout);
+		this._liveText = "";
+		super.closePopup(escPressed, preventRegistryUpdate, preventFocusRestore);
 	}
 
 	onBeforeRendering() {

--- a/packages/main/src/DialogTemplate.tsx
+++ b/packages/main/src/DialogTemplate.tsx
@@ -53,6 +53,7 @@ function beforeContent(this: Dialog) {
 
 function afterContent(this: Dialog) {
 	return (<>
+		<span class="ui5-hidden-text" aria-live="assertive">{this._liveText}</span>
 		{!!this.footer.length &&
 			<footer class="ui5-popup-footer-root" part="footer">
 				<slot name="footer"></slot>

--- a/packages/main/test/pages/Dialog.html
+++ b/packages/main/test/pages/Dialog.html
@@ -52,6 +52,9 @@
 		<ui5-button id="message">Open Message Dialog</ui5-button>
 		<br>
 		<br>
+		<ui5-button id="messageBoxOpener">Open Message Dialog Focused Button </ui5-button>
+		<br>
+		<br>
 		<ui5-button id="prevent">Open Prevent closing Dialog</ui5-button>
 		<br>
 		<br>
@@ -110,6 +113,23 @@
 		<ui5-input></ui5-input>
 		<div slot="footer" class="dialogFooter">
 			<ui5-button design="Emphasized" id="btnCloseDialogWithInput">Close</ui5-button>
+		</div>
+	</ui5-dialog>
+
+	<ui5-dialog id="messageBox" accessible-name-ref="messageBoxTitle messageBoxText" accessible-role="AlertDialog"
+		header-text="Confirmation" data-type="Confirm" class="messageBox">
+		<div slot="header" class="messageBoxHeader">
+			<ui5-icon class="messageBoxConfirmIcon" name="sys-help-2"></ui5-icon>
+			<span class="messageBoxSpacer"></span>
+			<ui5-title id="messageBoxTitle" wrapping-type="Normal" level="H1" size="H5">Confirmation</ui5-title>
+		</div>
+		<ui5-text id="messageBoxText">You can close the MessageBox by pressing "Escape" or selecting one of the footer
+			buttons.</ui5-text>
+		<div slot="footer" class="messageBoxFooter">
+			<ui5-button class="messageBoxCloser" data-action="OK" design="Emphasized">OK</ui5-button>
+			<ui5-button class="messageBoxCloser" data-action="Custom Action" design="Transparent">Custom Action</ui5-button>
+			<ui5-button class="messageBoxCloser" data-action="Cancel" design="Transparent">Cancel</ui5-button>
+			<ui5-button class="messageBoxCloser" data-action="3: custom action" design="Default">Custom Button</ui5-button>
 		</div>
 	</ui5-dialog>
 
@@ -948,6 +968,10 @@
 
 		message.addEventListener("click", function () {
 			window["msg-dialog"].open = true;
+		});
+
+		messageBoxOpener.addEventListener("click", function () {
+			window["messageBox"].open = true;
 		});
 
 		window["prevent-dialog"].addEventListener("ui5-before-close", function (event) {


### PR DESCRIPTION
VoiceOver on macOS does not announce the dialog content when focus lands on a button inside the dialog. An aria-live region is now used to announce text-only content when the dialog opens.

Fixes: #13572 
