### PR TITLE
fix(ui5-checkbox): align horizon checkbox hover states with selector tokens

### DIFF
--- a/packages/main/src/themes/sap_horizon/CheckBox-parameters.css
+++ b/packages/main/src/themes/sap_horizon/CheckBox-parameters.css
@@ -11,7 +11,7 @@
 	--_ui5_checkbox_inner_border_radius: var(--sapField_BorderCornerRadius);
 	--_ui5_checkbox_checkmark_color: var(--sapContent_Selected_ForegroundColor);
 	/* hover & active */
-	--_ui5_checkbox_hover_background: var(--sapContent_Selected_Hover_Background);
+	--_ui5_checkbox_hover_background: var(--sapField_Selector_Hover_Background);
 	--_ui5_checkbox_inner_hover_border_color: var(--sapField_Hover_BorderColor);
 	--_ui5_checkbox_inner_hover_checked_border_color: var(--sapField_Hover_BorderColor);
 	--_ui5_checkbox_inner_selected_border_color: var(--sapField_BorderColor);
@@ -21,19 +21,19 @@
 	--_ui5_checkbox_inner_readonly_border: var(--sapElement_BorderWidth)  var(--sapField_ReadOnly_BorderColor) dashed;
 	/* error state */
 	--_ui5_checkbox_inner_error_border: var(--sapField_InvalidBorderWidth) solid var(--sapField_InvalidColor);
-	--_ui5_checkbox_inner_error_background_hover: var(--sapField_Hover_Background);
+	--_ui5_checkbox_inner_error_background_hover: var(--sapField_Selector_Hover_InvalidBackground);
 	/* warning state */
 	--_ui5_checkbox_inner_warning_border:  var(--sapField_WarningBorderWidth) solid var(--sapField_WarningColor);
 	--_ui5_checkbox_inner_warning_color: var(--sapField_WarningColor);
-	--_ui5_checkbox_inner_warning_background_hover: var(--sapField_Hover_Background);
+	--_ui5_checkbox_inner_warning_background_hover: var(--sapField_Selector_Hover_WarningBackground);
 	--_ui5_checkbox_checkmark_warning_color: var(--sapField_WarningColor);
 	/* success state */
 	--_ui5_checkbox_inner_success_border: var(--sapField_SuccessBorderWidth) solid var(--sapField_SuccessColor);
-	--_ui5_checkbox_inner_success_background_hover: var(--sapField_Hover_Background);
+	--_ui5_checkbox_inner_success_background_hover: var(--sapField_Selector_Hover_SuccessBackground);
 	/* information state */
 	--_ui5_checkbox_inner_information_color: var(--sapField_InformationColor);
 	--_ui5_checkbox_inner_information_border: var(--sapField_InformationBorderWidth) solid var(--sapField_InformationColor);
-	--_ui5_checkbox_inner_information_background_hover: var(--sapField_Hover_Background);
+	--_ui5_checkbox_inner_information_background_hover: var(--sapField_Selector_Hover_InformationBackground);
 	/* disabled */
 	--_ui5_checkbox_disabled_opacity: var(--sapContent_DisabledOpacity);
 	/* focus */

--- a/packages/main/src/themes/sap_horizon_dark/CheckBox-parameters.css
+++ b/packages/main/src/themes/sap_horizon_dark/CheckBox-parameters.css
@@ -11,7 +11,7 @@
 	--_ui5_checkbox_inner_border_radius: var(--sapField_BorderCornerRadius);
 	--_ui5_checkbox_checkmark_color: var(--sapContent_Selected_ForegroundColor);
 	/* hover & active */
-	--_ui5_checkbox_hover_background: var(--sapContent_Selected_Hover_Background);
+	--_ui5_checkbox_hover_background: var(--sapField_Selector_Hover_Background);
 	--_ui5_checkbox_inner_hover_border_color: var(--sapField_Hover_BorderColor);
 	--_ui5_checkbox_inner_hover_checked_border_color: var(--sapField_Hover_BorderColor);
 	--_ui5_checkbox_inner_selected_border_color: var(--sapField_BorderColor);
@@ -21,19 +21,19 @@
 	--_ui5_checkbox_inner_readonly_border: var(--sapElement_BorderWidth)  var(--sapField_ReadOnly_BorderColor) dashed;
 	/* error state */
 	--_ui5_checkbox_inner_error_border: var(--sapField_InvalidBorderWidth) solid var(--sapField_InvalidColor);
-	--_ui5_checkbox_inner_error_background_hover: var(--sapField_Hover_Background);
+	--_ui5_checkbox_inner_error_background_hover: var(--sapField_Selector_Hover_InvalidBackground);
 	/* warning state */
 	--_ui5_checkbox_inner_warning_border:  var(--sapField_WarningBorderWidth) solid var(--sapField_WarningColor);
 	--_ui5_checkbox_inner_warning_color: var(--sapField_WarningColor);
-	--_ui5_checkbox_inner_warning_background_hover: var(--sapField_Hover_Background);
+	--_ui5_checkbox_inner_warning_background_hover: var(--sapField_Selector_Hover_WarningBackground);
 	--_ui5_checkbox_checkmark_warning_color: var(--sapField_WarningColor);
 	/* success state */
 	--_ui5_checkbox_inner_success_border: var(--sapField_SuccessBorderWidth) solid var(--sapField_SuccessColor);
-	--_ui5_checkbox_inner_success_background_hover: var(--sapField_Hover_Background);
+	--_ui5_checkbox_inner_success_background_hover: var(--sapField_Selector_Hover_SuccessBackground);
 	/* information state */
 	--_ui5_checkbox_inner_information_color: var(--sapField_InformationColor);
 	--_ui5_checkbox_inner_information_border: var(--sapField_InformationBorderWidth) solid var(--sapField_InformationColor);
-	--_ui5_checkbox_inner_information_background_hover: var(--sapField_Hover_Background);
+	--_ui5_checkbox_inner_information_background_hover: var(--sapField_Selector_Hover_InformationBackground);
 	/* disabled */
 	--_ui5_checkbox_disabled_opacity: var(--sapContent_DisabledOpacity);
 	/* focus */

--- a/packages/main/src/themes/sap_horizon_hcb/CheckBox-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcb/CheckBox-parameters.css
@@ -12,7 +12,7 @@
 	--_ui5_checkbox_inner_border_radius: var(--sapField_BorderCornerRadius);
 	--_ui5_checkbox_checkmark_color: var(--sapContent_Selected_ForegroundColor);
 	/* hover & active */
-	--_ui5_checkbox_hover_background: var(--sapSelectedColor);
+	--_ui5_checkbox_hover_background: var(--sapField_Selector_Hover_Background);
 	--_ui5_checkbox_inner_hover_border_color: var(--sapField_Hover_BorderColor);
 	--_ui5_checkbox_inner_hover_checked_border_color: var(--sapField_Hover_BorderColor);
 	--_ui5_checkbox_inner_selected_border_color: var(--sapField_Hover_BorderColor);
@@ -23,19 +23,19 @@
 	--_ui5_checkbox_inner_readonly_border: var(--sapElement_BorderWidth)  var(--sapField_ReadOnly_BorderColor) solid;
 	/* error state */
 	--_ui5_checkbox_inner_error_border: var(--sapField_InvalidBorderWidth) dashed var(--sapField_InvalidColor);
-	--_ui5_checkbox_inner_error_background_hover: var(--sapField_InvalidBackground);
+	--_ui5_checkbox_inner_error_background_hover: var(--sapField_Selector_Hover_InvalidBackground);
 	/* warning state */
 	--_ui5_checkbox_inner_warning_border:  var(--sapField_WarningBorderWidth) dashed var(--sapField_WarningColor);
 	--_ui5_checkbox_inner_warning_color: var(--sapField_WarningColor);
-	--_ui5_checkbox_inner_warning_background_hover: var(--sapField_Hover_Background);
+	--_ui5_checkbox_inner_warning_background_hover: var(--sapField_Selector_Hover_WarningBackground);
 	--_ui5_checkbox_checkmark_warning_color: var(--sapField_WarningColor);
 	/* success state */
 	--_ui5_checkbox_inner_success_border: var(--sapField_SuccessBorderWidth) solid var(--sapField_SuccessColor);
-	--_ui5_checkbox_inner_success_background_hover: var(--sapField_Hover_Background);
+	--_ui5_checkbox_inner_success_background_hover: var(--sapField_Selector_Hover_SuccessBackground);
 	/* information state */
 	--_ui5_checkbox_inner_information_color: var(--sapField_InformationColor);
 	--_ui5_checkbox_inner_information_border: var(--sapField_InformationBorderWidth) dashed var(--sapField_InformationColor);
-	--_ui5_checkbox_inner_information_background_hover: var(--sapField_Hover_Background);
+	--_ui5_checkbox_inner_information_background_hover: var(--sapField_Selector_Hover_InformationBackground);
 	/* disabled */
 	--_ui5_checkbox_disabled_opacity: var(--sapContent_DisabledOpacity);
 	/* focus */

--- a/packages/main/src/themes/sap_horizon_hcw/CheckBox-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcw/CheckBox-parameters.css
@@ -12,7 +12,7 @@
 	--_ui5_checkbox_inner_border_radius: var(--sapField_BorderCornerRadius);
 	--_ui5_checkbox_checkmark_color: var(--sapContent_Selected_ForegroundColor);
 	/* hover & active */
-	--_ui5_checkbox_hover_background: var(--sapSelectedColor);
+	--_ui5_checkbox_hover_background: var(--sapField_Selector_Hover_Background);
 	--_ui5_checkbox_inner_hover_border_color: var(--sapField_Hover_BorderColor);
 	--_ui5_checkbox_inner_hover_checked_border_color: var(--sapField_Hover_BorderColor);
 	--_ui5_checkbox_inner_selected_border_color: var(--sapField_Hover_BorderColor);
@@ -23,19 +23,19 @@
 	--_ui5_checkbox_inner_readonly_border: var(--sapElement_BorderWidth)  var(--sapField_ReadOnly_BorderColor) solid;
 	/* error state */
 	--_ui5_checkbox_inner_error_border: var(--sapField_InvalidBorderWidth) dashed var(--sapField_InvalidColor);
-	--_ui5_checkbox_inner_error_background_hover: var(--sapField_InvalidBackground);
+	--_ui5_checkbox_inner_error_background_hover: var(--sapField_Selector_Hover_InvalidBackground);
 	/* warning state */
 	--_ui5_checkbox_inner_warning_border:  var(--sapField_WarningBorderWidth) dashed var(--sapField_WarningColor);
 	--_ui5_checkbox_inner_warning_color: var(--sapField_WarningColor);
-	--_ui5_checkbox_inner_warning_background_hover: var(--sapField_Hover_Background);
+	--_ui5_checkbox_inner_warning_background_hover: var(--sapField_Selector_Hover_WarningBackground);
 	--_ui5_checkbox_checkmark_warning_color: var(--sapField_WarningColor);
 	/* success state */
 	--_ui5_checkbox_inner_success_border: var(--sapField_SuccessBorderWidth) solid var(--sapField_SuccessColor);
-	--_ui5_checkbox_inner_success_background_hover: var(--sapField_Hover_Background);
+	--_ui5_checkbox_inner_success_background_hover: var(--sapField_Selector_Hover_SuccessBackground);
 	/* information state */
 	--_ui5_checkbox_inner_information_color: var(--sapField_InformationColor);
 	--_ui5_checkbox_inner_information_border: var(--sapField_InformationBorderWidth) dashed var(--sapField_InformationColor);
-	--_ui5_checkbox_inner_information_background_hover: var(--sapField_Hover_Background);
+	--_ui5_checkbox_inner_information_background_hover: var(--sapField_Selector_Hover_InformationBackground);
 	/* disabled */
 	--_ui5_checkbox_disabled_opacity: var(--sapContent_DisabledOpacity);
 	/* focus */


### PR DESCRIPTION
Update Horizon checkbox parameter mappings to use selector-specific hover tokens for consistent theme deltas:

set regular hover background to --sapField_Selector_Hover_Background set Negative/Critical/Positive/Information hover backgrounds to: --sapField_Selector_Hover_InvalidBackground
--sapField_Selector_Hover_WarningBackground
--sapField_Selector_Hover_SuccessBackground
--sapField_Selector_Hover_InformationBackground
Applied in sap_horizon, sap_horizon_dark, sap_horizon_hcb, and sap_horizon_hcw checkbox parameter files.

JIRA: BGSOFUIPIRIN-7048

