### PR TITLE
fix(framework): prevent language-aware components from rendering before CLDR data loads

### DIFF
--- a/packages/base/src/Render.ts
+++ b/packages/base/src/Render.ts
@@ -34,13 +34,27 @@ const renderDeferred = async (webComponent: UI5Element) => {
 };
 
 /**
+ * Register all web components attached to the DOM
+ */
+const registerElement = (webComponent: UI5Element) => {
+	registeredElements.add(webComponent);
+};
+
+/**
+ * Unregister all web components detached from the DOM
+ */
+const unregisterElement = (webComponent: UI5Element) => {
+	registeredElements.delete(webComponent);
+};
+
+/**
  * Renders a component synchronously and adds it to the registry of rendered components
  *
  * @param webComponent
  */
 const renderImmediately = (webComponent: UI5Element) => {
 	eventProvider.fireEvent("beforeComponentRender", webComponent);
-	registeredElements.add(webComponent);
+	registerElement(webComponent);
 	webComponent._render();
 };
 
@@ -51,7 +65,7 @@ const renderImmediately = (webComponent: UI5Element) => {
  */
 const cancelRender = (webComponent: UI5Element) => {
 	invalidatedWebComponents.remove(webComponent);
-	registeredElements.delete(webComponent);
+	unregisterElement(webComponent);
 };
 
 /**
@@ -173,6 +187,8 @@ export {
 	renderDeferred,
 	renderImmediately,
 	cancelRender,
+	registerElement,
+	unregisterElement,
 	renderFinished,
 	reRenderAllUI5Elements,
 	attachBeforeComponentRender,

--- a/packages/base/src/UI5Element.ts
+++ b/packages/base/src/UI5Element.ts
@@ -18,6 +18,8 @@ import {
 	renderDeferred,
 	renderImmediately,
 	cancelRender,
+	unregisterElement,
+	registerElement,
 } from "./Render.js";
 import { registerTag, isTagRegistered, recordTagRegistrationFailure } from "./CustomElementsRegistry.js";
 import { observeDOMNode, unobserveDOMNode } from "./DOMObserver.js";
@@ -332,6 +334,8 @@ abstract class UI5Element extends HTMLElement {
 
 		const ctor = this.constructor as typeof UI5Element;
 
+		registerElement(this);
+
 		this.setAttribute(ctor.getMetadata().getPureTag(), "");
 		if (ctor.getMetadata().supportsF6FastNavigation() && !this.hasAttribute("data-sap-ui-fastnavgroup")) {
 			this.setAttribute("data-sap-ui-fastnavgroup", "true");
@@ -349,6 +353,10 @@ abstract class UI5Element extends HTMLElement {
 
 		if (!ctor.asyncFinished) {
 			await ctor._definePromise;
+		}
+
+		if (ctor.getMetadata().isLanguageAware() && getLanguageChangePending()) {
+			return;
 		}
 
 		if (!this._inDOM) { // Component removed from DOM while _processChildren was running
@@ -391,6 +399,7 @@ abstract class UI5Element extends HTMLElement {
 		this._domRefReadyPromise._deferredResolve!();
 
 		cancelRender(this);
+		unregisterElement(this);
 	}
 
 	/**

--- a/packages/base/src/UI5Element.ts
+++ b/packages/base/src/UI5Element.ts
@@ -355,6 +355,8 @@ abstract class UI5Element extends HTMLElement {
 			await ctor._definePromise;
 		}
 
+		// Skip rendering while a language change is in progress to avoid rendering with not fully loaded locale data.
+		// Once the locale data is loaded, the language-aware component will be re-rendered.
 		if (ctor.getMetadata().isLanguageAware() && getLanguageChangePending()) {
 			return;
 		}

--- a/packages/main/cypress/specs/DatePicker_cldr_race.cy.tsx
+++ b/packages/main/cypress/specs/DatePicker_cldr_race.cy.tsx
@@ -1,0 +1,39 @@
+import "../../src/Assets.js";
+import { setLanguage } from "@ui5/webcomponents-base/dist/config/Language.js";
+import DatePicker from "../../src/DatePicker.js";
+
+// Timestamps for Feb 2019 calendar checks
+const timestamp_3_Feb_2019 = 1549152000;
+const timestamp_28_Jan_2019 = 1548633600;
+
+describe("DatePicker CLDR race condition", () => {
+	it("mounts correctly when setLanguage is called without await before mount", () => {
+		// Capture the promise but do NOT await it — this is the race condition.
+		// Before the fix, the component rendered before CLDR data loaded → crash.
+		// After the fix, connectedCallback bails early and reRenderAllUI5Elements
+		// picks up the registered element once CLDR resolves.
+		let languageReady: Promise<void>;
+		cy.then(() => {
+			languageReady = setLanguage("bg");
+		});
+
+		cy.mount(<DatePicker value="фев 6, 2019" formatPattern="MMM d, y"></DatePicker>);
+
+		// Now wait for the language change to settle so locale data is applied
+		cy.then(() => languageReady);
+
+		cy.get("[ui5-date-picker]")
+			.as("datePicker")
+			.ui5DatePickerValueHelpIconPress();
+
+		// Monday (bg locale) should be the first displayed date — week starts Jan 28
+		cy.get<DatePicker>("@datePicker")
+			.ui5DatePickerGetFirstDisplayedDate()
+			.should("have.attr", "data-sap-timestamp", timestamp_28_Jan_2019.toString());
+
+		// Feb 3 should fall on Sunday (last day in Mon-first week = wday6)
+		cy.get<DatePicker>("@datePicker")
+			.ui5DatePickerGetPopoverDate(timestamp_3_Feb_2019)
+			.should("have.class", "ui5-dp-wday6");
+	});
+});

--- a/packages/main/test/pages/DatePicker_cldr_race.html
+++ b/packages/main/test/pages/DatePicker_cldr_race.html
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>DatePicker — CLDR race condition reproduction</title>
+
+	<script src="%VITE_BUNDLE_PATH%" type="module"></script>
+
+	<style>
+		body { font-family: sans-serif; padding: 1rem; }
+		section { margin-bottom: 2rem; border: 1px solid #ccc; padding: 1rem; border-radius: 4px; }
+		h2 { margin-top: 0; }
+		button { margin: 0.25rem; padding: 0.4rem 0.8rem; cursor: pointer; }
+		pre { background: #f4f4f4; padding: 0.5rem; border-radius: 3px; white-space: pre-wrap; font-size: 0.85rem; }
+		.ok   { color: green; font-weight: bold; }
+		.fail { color: red;   font-weight: bold; }
+	</style>
+</head>
+<body>
+<h1>DatePicker — CLDR race condition</h1>
+<p>
+	Reproduces the bug where <code>getCachedLocaleDataInstance</code> creates a <code>LocaleData</code>
+	instance before CLDR data has finished loading, leaving <code>mData</code> undefined and
+	crashing on first render.
+</p>
+
+<section>
+	<h2>Scenario 1 — setLanguage("bg") then immediately mount</h2>
+	<p>
+		Calls <code>setLanguage("bg")</code> <strong>without awaiting</strong> it, then immediately
+		adds a <code>&lt;ui5-date-picker&gt;</code>. The race: the component renders before
+		<code>fetchCldr("bg")</code> resolves, so <code>mData</code> is undefined → crash.<br>
+		<em>Click the button to trigger the race.</em>
+	</p>
+	<button id="btn-race">Trigger race (no await)</button>
+	<button id="btn-safe">Trigger safe (await setLanguage)</button>
+	<button id="btn-reset">Reset (remove picker, set EN)</button>
+	<div id="container1" style="margin-top:1rem"></div>
+	<pre id="log1">— click a button —</pre>
+</section>
+
+<section>
+	<h2>Scenario 2 — language already set, normal mount</h2>
+	<p>
+		After <code>setLanguage("bg")</code> has fully resolved (awaited), mounting a new picker
+		should work correctly and show Monday as first day of week.
+	</p>
+	<button id="btn-scenario2">Mount after await</button>
+	<button id="btn-open2">Open picker</button>
+	<div id="container2" style="margin-top:1rem"></div>
+	<pre id="log2">— click "Mount after await" —</pre>
+</section>
+
+<section>
+	<h2>Scenario 3 — rapid language switches</h2>
+	<p>
+		Switches language multiple times in quick succession without awaiting each call,
+		then mounts. Stresses the cache-poisoning path.
+	</p>
+	<button id="btn-rapid">Rapid switch + mount</button>
+	<div id="container3" style="margin-top:1rem"></div>
+	<pre id="log3">— click "Rapid switch + mount" —</pre>
+</section>
+
+<script type="module">
+	import { setLanguage } from "../../../base/src/config/Language.ts";
+
+	function log(id, msg, isOk) {
+		const el = document.getElementById(id);
+		const ts = new Date().toISOString().slice(11, 23);
+		el.textContent = `[${ts}] ${msg}`;
+		el.className = isOk === true ? "ok" : isOk === false ? "fail" : "";
+	}
+
+	function addPicker(containerId, attrs = {}) {
+		const c = document.getElementById(containerId);
+		c.innerHTML = "";
+		const dp = document.createElement("ui5-date-picker");
+		dp.setAttribute("format-pattern", "MMM d, y");
+		if (attrs.value) dp.setAttribute("value", attrs.value);
+		c.appendChild(dp);
+		return dp;
+	}
+
+	function removePicker(containerId) {
+		document.getElementById(containerId).innerHTML = "";
+	}
+
+	// ── Scenario 1: race ──────────────────────────────────────────────────────
+
+	document.getElementById("btn-race").addEventListener("click", () => {
+		log("log1", "setLanguage('bg') called (no await) → immediately adding picker...");
+		setLanguage("bg"); // intentionally NOT awaited
+		try {
+			addPicker("container1", { value: "фев 6, 2019" });
+			log("log1", "Picker added. Open it to check first-day-of-week (should be Monday for bg).");
+		} catch (e) {
+			log("log1", `CRASH: ${e}`, false);
+		}
+	});
+
+	document.getElementById("btn-safe").addEventListener("click", async () => {
+		log("log1", "awaiting setLanguage('bg')...");
+		try {
+			await setLanguage("bg");
+			log("log1", "setLanguage resolved — adding picker");
+			addPicker("container1", { value: "фев 6, 2019" });
+			log("log1", "Picker added safely. Open it — Monday should be first day of week.", true);
+		} catch (e) {
+			log("log1", `Error: ${e}`, false);
+		}
+	});
+
+	document.getElementById("btn-reset").addEventListener("click", async () => {
+		removePicker("container1");
+		await setLanguage("en");
+		log("log1", "Reset: picker removed, language set back to EN.");
+	});
+
+	// ── Scenario 2: safe mount after await ────────────────────────────────────
+
+	document.getElementById("btn-scenario2").addEventListener("click", async () => {
+		log("log2", "awaiting setLanguage('bg')...");
+		await setLanguage("bg");
+		log("log2", "Language is bg — mounting picker...");
+		const dp = addPicker("container2", { value: "фев 6, 2019" });
+		document.getElementById("btn-open2").onclick = () => {
+			dp.open = true;
+		};
+		log("log2", "Done. Click 'Open picker' — first day of week should be Monday (bg locale).", true);
+	});
+
+	// ── Scenario 3: rapid switches ────────────────────────────────────────────
+
+	document.getElementById("btn-rapid").addEventListener("click", async () => {
+		log("log3", "Rapid: en → de → bg → en → bg (no await on each)...");
+		setLanguage("en");
+		setLanguage("de");
+		setLanguage("bg");
+		setLanguage("en");
+		setLanguage("bg"); // last one wins — if CLDR races, we may get a poisoned cache
+		// now mount immediately
+		try {
+			addPicker("container3", { value: "фев 6, 2019" });
+			log("log3", "Picker mounted after rapid switches. Open it to check locale.");
+		} catch (e) {
+			log("log3", `CRASH on mount: ${e}`, false);
+		}
+		// wait a bit then check if re-render happened correctly
+		setTimeout(() => {
+			log("log3", "500ms later — if picker is open and shows Monday-first, the fix works.", true);
+		}, 500);
+	});
+
+	// capture unhandled promise rejections so crashes show in the log
+	window.addEventListener("unhandledrejection", (e) => {
+		console.error("[unhandledrejection]", e.reason);
+	});
+</script>
+</body>
+</html>


### PR DESCRIPTION
When `setLanguage()` is called without awaiting, `languageChangePending` is set to true while CLDR/i18n data is still being fetched. Previously, a language-aware component mounted during this window would call `renderImmediately` with incomplete locale data, causing a crash.

The fix registers the element in `connectedCallback` before any async work, then bails out of rendering if a language change is pending. Once CLDR resolves, `reRenderAllUI5Elements({ languageAware: true })` picks up the registered element and renders it correctly.

`registerElement`/`unregisterElement` are extracted from `renderImmediately` and `cancelRender` and exported so `UI5Element` can call them independently of the render cycle.