### PR TITLE
ci(release): use short-lived GitHub App token instead of long-lived PAT

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,10 +39,10 @@ jobs:
     steps:
       - name: Generate App Token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
-          private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -155,10 +155,10 @@ jobs:
     steps:
       - name: Generate App Token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
-          private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -265,10 +265,10 @@ jobs:
     steps:
       - name: Generate App Token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
-          private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -341,10 +341,10 @@ jobs:
     steps:
       - name: Generate App Token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
-          private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -395,10 +395,10 @@ jobs:
     steps:
       - name: Generate App Token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
-          private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -339,13 +339,6 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
-      - name: Generate App Token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
-          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,10 +37,17 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
+      - name: Generate App Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - name: Setup Node
@@ -54,7 +61,7 @@ jobs:
 
       - name: Version Bump
         env:
-          GH_TOKEN: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git config user.name "${{ secrets.UI5_WEBCOMP_BOT_NAME }}"
           git config user.email "${{ secrets.UI5_WEBCOMP_BOT_EMAIL }}"
@@ -76,9 +83,9 @@ jobs:
       - name: Create GitHub Release
         uses: actions/github-script@v7
         env:
-          GH_TOKEN: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
-          github-token: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const extractChangelog = (await import('${{ github.workspace }}/.github/actions/extractChangelog.mjs')).default;
             const changelog = await extractChangelog();
@@ -98,9 +105,9 @@ jobs:
       - name: Merge Release Changelog
         uses: actions/github-script@v7
         env:
-            GH_TOKEN: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+            GH_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
-            github-token: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+            github-token: ${{ steps.app-token.outputs.token }}
             script: |
               const mergeReleaseChangelog = (await import('${{ github.workspace }}/.github/actions/mergeReleaseChangelog.mjs')).default;
               await mergeReleaseChangelog({ github , context });
@@ -109,9 +116,9 @@ jobs:
         uses: actions/github-script@v7
         env:
             NODE_OPTIONS: '--max-old-space-size=12096'
-            GH_TOKEN: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+            GH_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
-            github-token: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+            github-token: ${{ steps.app-token.outputs.token }}
             script: |
               const commentOnFixedIssues = (await import('${{ github.workspace }}/.github/actions/commentOnFixedIssues.mjs')).default;
               await commentOnFixedIssues({ github, context });
@@ -125,6 +132,7 @@ jobs:
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@v4.3.3
         with:
+          token: ${{ steps.app-token.outputs.token }}
           branch: gh-pages # The branch the action should deploy to.
           folder: packages/website/build # The folder the action should deploy.
           clean: true
@@ -145,10 +153,17 @@ jobs:
       pages: write
     runs-on: ubuntu-latest
     steps:
+      - name: Generate App Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - name: Setup Node
@@ -162,7 +177,7 @@ jobs:
 
       - name: Version Bump
         env:
-          GH_TOKEN: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git config user.name "${{ secrets.UI5_WEBCOMP_BOT_NAME }}"
           git config user.email "${{ secrets.UI5_WEBCOMP_BOT_EMAIL }}"
@@ -193,9 +208,9 @@ jobs:
       - name: Create GitHub Release
         uses: actions/github-script@v7
         env:
-          GH_TOKEN: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
-          github-token: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const extractChangelog = (await import('${{ github.workspace }}/.github/actions/extractChangelog.mjs')).default;
             const changelog = await extractChangelog();
@@ -220,6 +235,7 @@ jobs:
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4.3.3
         with:
+          token: ${{ steps.app-token.outputs.token }}
           branch: gh-pages
           folder: packages/website/build
           target-folder: nightly
@@ -229,9 +245,9 @@ jobs:
         uses: actions/github-script@v7
         env:
             NODE_OPTIONS: '--max-old-space-size=12096'
-            GH_TOKEN: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+            GH_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
-            github-token: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+            github-token: ${{ steps.app-token.outputs.token }}
             script: |
               const commentOnFixedIssues = (await import('${{ github.workspace }}/.github/actions/commentOnFixedIssues.mjs')).default;
               await commentOnFixedIssues({ github, context });
@@ -247,10 +263,17 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
+      - name: Generate App Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - name: Setup Node
@@ -264,7 +287,7 @@ jobs:
 
       - name: Version Bump
         env:
-          GH_TOKEN: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git config user.name "${{ secrets.UI5_WEBCOMP_BOT_NAME }}"
           git config user.email "${{ secrets.UI5_WEBCOMP_BOT_EMAIL }}"
@@ -286,9 +309,9 @@ jobs:
       - name: Create GitHub Release
         uses: actions/github-script@v7
         env:
-          GH_TOKEN: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
-          github-token: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const extractChangelog = (await import('${{ github.workspace }}/.github/actions/extractChangelog.mjs')).default;
             const changelog = await extractChangelog();
@@ -316,6 +339,13 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
+      - name: Generate App Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -363,10 +393,17 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
+      - name: Generate App Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - name: Setup Node
@@ -380,7 +417,7 @@ jobs:
 
       - name: Version Bump
         env:
-          GH_TOKEN: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
             git config user.name "${{ secrets.UI5_WEBCOMP_BOT_NAME }}"
             git config user.email "${{ secrets.UI5_WEBCOMP_BOT_EMAIL }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -342,7 +342,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
       - name: Setup Node
@@ -355,8 +354,6 @@ jobs:
         run: yarn --immutable
 
       - name: Version Bump
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "${{ secrets.UI5_WEBCOMP_BOT_NAME }}"
           git config user.email "${{ secrets.UI5_WEBCOMP_BOT_EMAIL }}"


### PR DESCRIPTION
**Background**

Aligns release.yaml with OSPO Guideline **# 4.Replace long-lived secrets with OIDC** 

**Change**

Replace every `secrets.UI5_WEBCOMP_BOT_GH_TOKEN` usage in the release workflow with a per-run installation token generated by `actions/create-github-app-token@v3`. App tokens are valid for ~1 hour and disappear when the run ends, drastically reducing the blast radius compared to a long-lived PAT.

**Prerequisite (one-time, before merge ):**

by OSPO team
- Register a GitHub App with Contents/Issues/Pull-requests: write
- Install it on UI5/webcomponents
- Add it to the branch-protection bypass list for release branches

by us
- Add repo secrets RELEASE_APP_ID and RELEASE_APP_PRIVATE_KEY
