### PR TITLE
fix: break circular dependency between Runtimes and CustomElementsRegistry

### DIFF
--- a/packages/base/src/CustomElementsRegistry.ts
+++ b/packages/base/src/CustomElementsRegistry.ts
@@ -1,9 +1,14 @@
 import getSharedResource from "./getSharedResource.js";
 import { getCurrentRuntimeIndex, compareRuntimes, getAllRuntimes } from "./Runtimes.js";
+import {
+	addRegisteredTag,
+	isTagRegistered,
+	hasRegisteredTags,
+	getAllRegisteredTags,
+} from "./RegisteredElements.js";
 import type { Timeout } from "./types.js";
 
 const Tags = getSharedResource<Map<string, number>>("Tags", new Map());
-const Definitions = new Set<string>();
 
 let Failures = new Map<number, Set<string>>();
 let failureTimeout: Timeout | undefined;
@@ -11,20 +16,8 @@ let failureTimeout: Timeout | undefined;
 const UNKNOWN_RUNTIME = -1;
 
 const registerTag = (tag: string) => {
-	Definitions.add(tag);
+	addRegisteredTag(tag);
 	Tags.set(tag, getCurrentRuntimeIndex());
-};
-
-const isTagRegistered = (tag: string) => {
-	return Definitions.has(tag);
-};
-
-const hasRegisteredTags = () => {
-	return Definitions.size > 0;
-};
-
-const getAllRegisteredTags = () => {
-	return [...Definitions.values()];
 };
 
 const recordTagRegistrationFailure = (tag: string) => {

--- a/packages/base/src/RegisteredElements.ts
+++ b/packages/base/src/RegisteredElements.ts
@@ -1,0 +1,24 @@
+const Definitions = new Set<string>();
+
+const addRegisteredTag = (tag: string) => {
+	Definitions.add(tag);
+};
+
+const isTagRegistered = (tag: string) => {
+	return Definitions.has(tag);
+};
+
+const hasRegisteredTags = () => {
+	return Definitions.size > 0;
+};
+
+const getAllRegisteredTags = () => {
+	return [...Definitions.values()];
+};
+
+export {
+	addRegisteredTag,
+	isTagRegistered,
+	hasRegisteredTags,
+	getAllRegisteredTags,
+};

--- a/packages/base/src/Runtimes.ts
+++ b/packages/base/src/Runtimes.ts
@@ -1,4 +1,4 @@
-import { getAllRegisteredTags } from "./CustomElementsRegistry.js";
+import { getAllRegisteredTags } from "./RegisteredElements.js";
 import { getCustomElementsScopingRules, getCustomElementsScopingSuffix } from "./CustomElementsScopeUtils.js";
 import VersionInfo from "./generated/VersionInfo.js";
 import getSharedResource from "./getSharedResource.js";


### PR DESCRIPTION
 Extracts shared tag registration state into a new RegisteredElements.ts module, eliminating the Runtimes.js → CustomElementsRegistry.js → Runtimes.js cycle that caused Node.js ESM imports to fail with "does not provide an export named 'compareRuntimes'".