### PR TITLE
ci: scope Netlify secrets to netlify-preview environment

### DIFF
--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -37,6 +37,7 @@ jobs:
     # so the deploy step would always fail. A skipped check does not block merge.
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    environment: netlify-preview
 
     steps:
     - name: Checkout

--- a/.github/workflows/reset-preview-deploy.yaml
+++ b/.github/workflows/reset-preview-deploy.yaml
@@ -30,7 +30,8 @@ permissions:
 jobs:
   cleanup-preview:
     runs-on: ubuntu-latest
-    
+    environment: netlify-preview
+
     steps:
     - name: Create empty content
       run: |


### PR DESCRIPTION
## What

Move `NETLIFY_AUTH_TOKEN` and `NETLIFY_SITE_ID` out of repository-level secrets and into a dedicated GitHub Environment named `netlify-preview`. The two preview-deploy workflows now declare `environment: netlify-preview`, so they can only see those secrets when the environment's branch / reviewer protections allow.

## Why

Repository-level secrets are exposed to every workflow run on every branch. Scoping deploy/publish secrets to GitHub Environments is part of the security hardening for this repo (companion to the existing `npmjs:@ui5/webcomponents` environment used by `release.yaml`).

## Files changed

- `.github/workflows/deploy-preview.yaml` → `deploy-preview` job now uses `environment: netlify-preview`
- `.github/workflows/reset-preview-deploy.yaml` → `cleanup-preview` job now uses `environment: netlify-preview`

## Required action before merge

The `netlify-preview` environment must exist in **Settings → Environments** with:

- Secret: `NETLIFY_AUTH_TOKEN`
- Secret: `NETLIFY_SITE_ID`
- Protection rules as desired (no required reviewers, otherwise PR previews block forever)

After this merges and the next preview deploy succeeds, the repository-level copies of `NETLIFY_AUTH_TOKEN` and `NETLIFY_SITE_ID` should be deleted.

## Out of scope

`UI5_WEBCOMP_BOT_GH_TOKEN` is intentionally left at the repository level for now — it is consumed by several non-deploy workflows (issue automation, etc.) and migrating it is a separate refactor.