### PR TITLE
fix(ui5-bar, ui5-button): prevent button badge from being clipped inside `ui5-bar`

### DIFF
--- a/packages/main/src/themes/Bar.css
+++ b/packages/main/src/themes/Bar.css
@@ -16,7 +16,8 @@
 	box-shadow: inherit;
 	border-radius: inherit;
 	min-width: 0;
-	overflow: hidden;
+	overflow-x: clip;
+	overflow-y: visible;
 }
 
 .ui5-bar-root .ui5-bar-startcontent-container,
@@ -39,7 +40,8 @@
 	flex: 1 1 auto;
 	padding: 0 var(--_ui5_bar-mid-container-padding-start-end);
 	min-width: 0;
-	overflow: hidden;
+	overflow-x: clip;
+	overflow-y: visible;
 }
 
 .ui5-bar-root .ui5-bar-startcontent-container {
@@ -54,7 +56,8 @@
 
 .ui5-bar-root.ui5-bar-root-shrinked .ui5-bar-content-container {
 	min-width: 0px;
-	overflow: hidden;
+	overflow-x: clip;
+	overflow-y: visible;
 	height: 100%;
 }
 
@@ -80,7 +83,7 @@
 	border: none;
 }
 
-::slotted(*:not([hidden])) {
+::slotted(*:not([hidden]):not([ui5-button])) {
 	margin: 0 0.25rem;
 	display: inline-block;
     max-width: 100%;
@@ -88,4 +91,9 @@
     overflow: hidden;
     text-overflow: ellipsis;
     box-sizing: border-box;
+}
+
+::slotted([ui5-button]) {
+	margin: 0 0.25rem;
+	--_ui5_button_overlay_badge_offset: -0.25rem;
 }

--- a/packages/main/src/themes/Bar.css
+++ b/packages/main/src/themes/Bar.css
@@ -93,7 +93,14 @@
     box-sizing: border-box;
 }
 
+/* Scoped here (not in Bar-parameters.css) so the override applies only to buttons inside a Bar, not to standalone buttons on the page. */
 ::slotted([ui5-button]) {
 	margin: 0 0.25rem;
 	--_ui5_button_overlay_badge_offset: -0.25rem;
+}
+
+@container style(--ui5_content_density: compact) {
+	::slotted([ui5-button]) {
+		--_ui5_button_overlay_badge_offset: initial;
+	}
 }

--- a/packages/main/src/themes/Button.css
+++ b/packages/main/src/themes/Button.css
@@ -318,7 +318,7 @@ bdi {
 	position: absolute;
 	top: 0;
 	inset-inline-end: 0;
-	margin: -0.5rem;
+	margin: var(--_ui5_button_overlay_badge_offset, -0.5rem);
 	z-index: 1;
 	font-family: var(--sapButton_FontFamily);
 	font-size: var(--sapFontSmallSize);


### PR DESCRIPTION
## Overview

Button badges were cut off when the button sat inside a `ui5-bar`. The bar's overflow rules clipped the badge that intentionally sticks out above the button.

## What We Did

- Loosened the bar's overflow rules so badges and similar protruding visuals stay visible above the bar.
- Kept slotted titles and labels truncating with ellipsis as before.
- Tightened the badge offset only for buttons placed inside a bar, so the badge sits closer to the button corner.

## What This Fixes

- **Badge visibility**, badges on buttons inside a bar render fully.
- **Visual fit**, the badge overhang inside a bar is reduced; standalone buttons look unchanged.
- **No regressions**, long titles still cannot spill past the bar's sides, and ellipsis still applies to slotted text content.

## Before
<img width="332" height="94" alt="image" src="https://github.com/user-attachments/assets/2336f357-1d54-41f0-9f86-6561ce92fa5d" />

## After
<img width="358" height="95" alt="image" src="https://github.com/user-attachments/assets/6c07cce7-f6ee-4d91-9a4f-ccf9946296bb" />

Fixes: #13541 