### PR TITLE
fix(ui5-search-field): correct scope select border and icon sizing

### DIFF
--- a/packages/fiori/src/themes/SearchField.css
+++ b/packages/fiori/src/themes/SearchField.css
@@ -87,6 +87,8 @@
 	--_ui5_select_label_color: var(--sapShell_TextColor);
 	/* Remove Select's default focus outline without affecting dropdown items */
 	--_ui5_input_focus_outline_color: transparent;
+	/* Suppress Select's bottom border gradient inside ShellBar search */
+	--_ui5_select_bottom_border_gradient: none;
 }
 
 [ui5-select]:hover:not(:active):not(:focus-within) {
@@ -261,8 +263,6 @@
 }
 .ui5-shell-search-field-icon::part(root) {
 	padding: var(--_ui5_search_icon_padding);
-	width: 1rem;
-	height: 1rem;
 	outline-offset: -0.125rem;
 }
 


### PR DESCRIPTION
- Suppress the Select component's bottom border gradient inside the search field's scope dropdown, and let the search icons fill their container instead of being clamped to 1rem.

- The gradient was introduced for Horizon theme compliance (#13408) but should not appear in ShellBar context. The fixed 1rem icon size conflicted with the new container-query-based icon sizing (#13569), which left search-related icons rendering smaller than intended.

Fixes #13605