### PR TITLE
fix(ui5-text): unify truncation across all max-lines values

### DIFF
--- a/packages/compat/src/TableCellTemplate.tsx
+++ b/packages/compat/src/TableCellTemplate.tsx
@@ -7,9 +7,7 @@ export default function TableCellTemplate(this: TableCell) {
 			part="cell"
 			role="cell"
 		>
-			<div class="ui5-table-cell-content">
-				<slot></slot>
-			</div>
+			<slot></slot>
 		</td>
 	);
 }

--- a/packages/compat/src/themes/TableCell.css
+++ b/packages/compat/src/themes/TableCell.css
@@ -5,19 +5,12 @@
 	height: var(--ui5_table_row_height);
 	box-sizing: border-box;
 	color: var(--sapList_TextColor);
+	word-break: break-word;
 	vertical-align: middle;
-	overflow: hidden;
-	max-width: 0;
 }
 
 td {
 	display: contents;
-}
-
-.ui5-table-cell-content {
-	display: block;
-	width: 100%;
-	overflow: hidden;
 }
 
 :host([popined]) {

--- a/packages/fiori/test/pages/F6TestPage.html
+++ b/packages/fiori/test/pages/F6TestPage.html
@@ -88,19 +88,11 @@
 	<br><br>
 
 	<ui5-table class="demo-table" id="testRowClick">
-		<ui5-table-column id="column-1" slot="columns">
-			<ui5-label>City</ui5-label>
-		</ui5-table-column>
-
-		<ui5-table-column id="column-2" slot="columns" min-width="500" popin-text="Supplier">
-			<ui5-label>Supplier</ui5-label>
-		</ui5-table-column>
-
-		<ui5-table-column id="column-3" slot="columns" min-width="500" popin-text="Country" demand-popin>
-			<div class="column-content">
-				<ui5-label>Country</ui5-label>
-			</div>
-		</ui5-table-column>
+		<ui5-table-header-row slot="headerRow">
+			<ui5-table-header-cell id="column-1">City</ui5-table-header-cell>
+			<ui5-table-header-cell id="column-2" min-width="500px" popin-text="Supplier" popin-hidden>Supplier</ui5-table-header-cell>
+			<ui5-table-header-cell id="column-3" min-width="500px" popin-text="Country" popin-hidden>Country</ui5-table-header-cell>
+		</ui5-table-header-row>
 
 		<ui5-table-row data-city="Dublin">
 			<ui5-table-cell><span id="testRowClickCell1">Dublin</span></ui5-table-cell>

--- a/packages/main/cypress/specs/Text.cy.tsx
+++ b/packages/main/cypress/specs/Text.cy.tsx
@@ -22,10 +22,9 @@ describe("Text", () => {
 		cy.mount(<Text maxLines={1}>Text</Text>);
 
 		cy.get("[ui5-text]")
-			.should("have.css", "display", "inline-block")
 			.should("have.css", "overflow", "hidden")
-			.should("have.css", "text-overflow", "ellipsis")
-			.should("have.css", "white-space", "nowrap");
+			.should("have.css", "-webkit-line-clamp", "1")
+			.should("have.css", "-webkit-box-orient", "vertical");
 	});
 
 	it("tests maxLines > 1", () => {

--- a/packages/main/src/themes/Text.css
+++ b/packages/main/src/themes/Text.css
@@ -6,15 +6,6 @@
 	line-height: normal;
 	cursor: text;
 	overflow: hidden;
-}
-
-:host([max-lines="1"]) {
-	display: inline-block;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-}
-
-:host(:not([max-lines="1"])) {
 	display: -webkit-inline-box;
 	-webkit-line-clamp: var(--_ui5_text_max_lines);
 	line-clamp: var(--_ui5_text_max_lines);

--- a/packages/main/src/themes/Text.css
+++ b/packages/main/src/themes/Text.css
@@ -14,6 +14,10 @@
 	word-wrap: break-word;
 }
 
+:host([max-lines="1"]) {
+	word-break: break-all;
+}
+
 .empty-indicator-aria-label {
 	position: absolute !important;
 	clip: rect(1px, 1px, 1px, 1px);

--- a/packages/main/test/pages/Text.html
+++ b/packages/main/test/pages/Text.html
@@ -12,6 +12,18 @@
 <body>
 	<ui5-text>Simple text</ui5-text>
 
+	<br><br />
+
+	<ui5-text style="width: 6rem">Simple Texttttttttttttttttttttttttttttttttttttt</ui5-text>
+
+	<br><br />
+
+	<ui5-text max-lines="1" style="width: 6rem">Simple Texttttttttttttttttttttttttttttttttttttt</ui5-text>
+
+	<br><br />
+
+	<ui5-text max-lines="2" style="width: 6rem">Simple Text Texttttttttttttttttttttttttttttttttttttt</ui5-text>
+
 	<br><br>
 
 	<ui5-title level="H5">Long text</ui5-title>

--- a/packages/main/test/pages/Text.html
+++ b/packages/main/test/pages/Text.html
@@ -12,21 +12,8 @@
 <body>
 	<ui5-text>Simple text</ui5-text>
 
-	<br><br />
-
-	<ui5-text style="width: 6rem">Simple Texttttttttttttttttttttttttttttttttttttt</ui5-text>
-
-	<br><br />
-
-	<ui5-text max-lines="1" style="width: 6rem">Simple Texttttttttttttttttttttttttttttttttttttt</ui5-text>
-
-	<br><br />
-
-	<ui5-text max-lines="2" style="width: 6rem">Simple Text Texttttttttttttttttttttttttttttttttttttt</ui5-text>
-
-	<br><br>
-
 	<ui5-title level="H5">Long text</ui5-title>
+
 	<ui5-text id="text1">
 		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet
 		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet
@@ -36,7 +23,17 @@
 
 	<br><br>
 
+	<ui5-text id="text1" style="width: 6rem;">
+		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet
+		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet
+		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet
+		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet
+	</ui5-text>
+
+	<br><br>
+
 	<ui5-title level="H5">Long text and max-lines 1</ui5-title>
+
 	<ui5-text id="text2" max-lines="1">
 		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet
 		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet
@@ -46,7 +43,17 @@
 
 	<br><br>
 
+	<ui5-text id="text2" max-lines="1" style="width: 6rem;">
+		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet
+		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet
+		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet
+		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet
+	</ui5-text>
+
+	<br><br>
+
 	<ui5-title level="H5">Long text and max-lines 2</ui5-title>
+
 	<ui5-text max-lines="2">
 		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet
 		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet
@@ -56,7 +63,17 @@
 
 	<br><br>
 
+	<ui5-text max-lines="2" style="width: 6rem;">
+		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet
+		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet
+		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet
+		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet
+	</ui5-text>
+
+	<br><br>
+
 	<ui5-title level="H5">Long text and max-lines 3</ui5-title>
+
 	<ui5-text empty-indicator-mode="On" max-lines="3">
 		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet
 		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet
@@ -66,8 +83,27 @@
 
 	<br><br>
 
+	<ui5-text empty-indicator-mode="On" max-lines="3" style="width: 6rem;">
+		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet
+		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet
+		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet
+		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet
+	</ui5-text>
+
+	<br><br>
+
 	<ui5-title level="H5">Long text and max-lines 4</ui5-title>
+
 	<ui5-text max-lines="4">
+		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet
+		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet
+		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet
+		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet
+	</ui5-text>
+
+	<br><br>
+
+	<ui5-text max-lines="4" style="width: 6rem;">
 		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet
 		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet
 		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet


### PR DESCRIPTION
Previously, single-line truncation (max-lines="1") used a separate CSS. All other values relied on `-webkit-line-clamp` via a `:not([max-lines="1"])` selector.

This split caused inconsistent behavior and required two code paths for what is semantically the same feature. Since `-webkit-line-clamp: 1` produces equivalent truncation to the `inline-block` approach, both cases are now handled by the single `-webkit-line-clamp` path.

`Infinity` as the CSS variable value maps to `none` on `-webkit-line-clamp` (browsers treat an unrecognised/non-integer value as unset), so the default "no truncation" behaviour is preserved without an explicit reset rule.

The core reasoning: max-lines="1" no longer needs its own display/whitespace block — -webkit-line-clamp: 1 does the same job, and Infinity as a CSS value is treated as none/unset by the browser, so no truncation applies at the default.

In this change https://github.com/UI5/webcomponents/pull/13566 is reverted as well.

Fixes: https://github.com/UI5/webcomponents/issues/10721