### PR TITLE
fix(framework): stop reflecting object/array properties to attributes

### DIFF
--- a/packages/base/cypress/specs/UI5ElementPropsAndAttrs.cy.tsx
+++ b/packages/base/cypress/specs/UI5ElementPropsAndAttrs.cy.tsx
@@ -78,7 +78,7 @@ describe("Properties and attributes convert to each other", () => {
 			.should("not.have.attr", "object-prop");
 	});
 
-	it("Tests that array properties have attributes", () => {
+	it("Tests that array properties have no attributes when set programmatically", () => {
 		cy.mount(<Generic></Generic>);
 
 		cy.get("[ui5-test-generic]")
@@ -88,7 +88,68 @@ describe("Properties and attributes convert to each other", () => {
 			.invoke("prop", "multiProp", ["a", "b"]);
 
 		cy.get("@testGeneric")
-			.should("have.attr", "multi-prop", '["a","b"]');
+			.should("not.have.attr", "multi-prop");
+
+		cy.get("@testGeneric")
+			.invoke("prop", "multiProp")
+			.should("deep.equal", ["a", "b"]);
+	});
+
+	it("Tests that a declarative array attribute is parsed into the property and not removed by the framework", () => {
+		// Mount with the attribute pre-set (declarative input)
+		cy.mount(<Generic multi-prop='["x","y","z"]'></Generic>);
+
+		cy.get("[ui5-test-generic]")
+			.as("testGeneric");
+
+		// The attribute author-set in markup must survive first render
+		cy.get("@testGeneric")
+			.should("have.attr", "multi-prop", '["x","y","z"]');
+
+		// And it must be parsed into the property via fromAttribute
+		cy.get("@testGeneric")
+			.invoke("prop", "multiProp")
+			.should("deep.equal", ["x", "y", "z"]);
+	});
+
+	it("Tests that a later setAttribute for an array property still flows into the property", () => {
+		cy.mount(<Generic></Generic>);
+
+		cy.get("[ui5-test-generic]")
+			.as("testGeneric");
+
+		cy.get("@testGeneric")
+			.invoke("attr", "multi-prop", '["one","two"]');
+
+		cy.get("@testGeneric")
+			.invoke("prop", "multiProp")
+			.should("deep.equal", ["one", "two"]);
+
+		// Programmatic write to the property must not touch the DOM attribute -
+		// it stays at the author-set value even though it is now out of sync with the property.
+		cy.get("@testGeneric")
+			.invoke("prop", "multiProp", ["three"]);
+
+		cy.get("@testGeneric")
+			.should("have.attr", "multi-prop", '["one","two"]');
+
+		cy.get("@testGeneric")
+			.invoke("prop", "multiProp")
+			.should("deep.equal", ["three"]);
+	});
+
+	it("Tests that a declarative object attribute is parsed into the property and not removed by the framework", () => {
+		cy.mount(<Generic object-prop='{"a":1,"b":"two"}'></Generic>);
+
+		cy.get("[ui5-test-generic]")
+			.as("testGeneric");
+
+		cy.get("@testGeneric")
+			.should("have.attr", "object-prop", '{"a":1,"b":"two"}');
+
+		cy.get("@testGeneric")
+			.invoke("prop", "objectProp")
+			.should("deep.equal", { a: 1, b: "two" });
 	});
 
 	it("Tests that noAttribute properties have no attributes", () => {

--- a/packages/base/src/UI5Element.ts
+++ b/packages/base/src/UI5Element.ts
@@ -98,12 +98,14 @@ const defaultConverter = {
 			return value as boolean ? "" : null;
 		}
 
-		// don't set attributes for arrays and objects
+		// Don't reflect arrays and objects to the DOM. Attributes exist for CSS selectors
+		// (which don't apply to objects/arrays) and for debugging via the Elements panel
+		// (devs will use the console with property access for these). Declarative
+		// attribute -> property is still supported via fromAttribute (JSON.parse).
 		if (type === Object || type === Array) {
-			return JSON.stringify(value);
+			return null;
 		}
 
-		// object, array, other
 		if (value === null || value === undefined) {
 			return null;
 		}
@@ -728,6 +730,14 @@ abstract class UI5Element extends HTMLElement {
 
 		const properties = ctor.getMetadata().getProperties();
 		const propData = properties[name];
+
+		// Object and Array properties are not reflected to attributes. The attribute is only
+		// consumed as a declarative input (parsed via fromAttribute on attributeChangedCallback),
+		// so the framework must neither write nor remove it - leave any author-set attribute alone.
+		if (propData.type === Object || propData.type === Array) {
+			return;
+		}
+
 		const attrName = camelToKebabCase(name);
 		const converter = propData.converter || defaultConverter;
 

--- a/packages/base/src/UI5ElementMetadata.ts
+++ b/packages/base/src/UI5ElementMetadata.ts
@@ -133,7 +133,7 @@ class UI5ElementMetadata {
 	 */
 	hasAttribute(propName: string): boolean {
 		const propData = this.getProperties()[propName];
-		return propData.type !== Object && !propData.noAttribute;
+		return !propData.noAttribute;
 	}
 
 	/**

--- a/packages/main/cypress/specs/MultiComboBox.cy.tsx
+++ b/packages/main/cypress/specs/MultiComboBox.cy.tsx
@@ -888,7 +888,8 @@ describe("General", () => {
 		);
 
 		cy.get("ui5-multi-combobox")
-			.should("have.attr", "selected-values",'["al","en"]');
+			.invoke("prop", "selectedValues")
+			.should("deep.equal", ["al", "en"]);
 
 		cy.get("[ui5-mcb-item]")
 			.eq(0)
@@ -944,7 +945,8 @@ describe("General", () => {
 			.should("have.length", "1");
 
 		cy.get("[ui5-multi-combobox]")
-			.should("have.attr", "selected-values", '["dk"]');
+			.invoke("prop", "selectedValues")
+			.should("deep.equal", ["dk"]);
 	});
 
 	it("updates selectedValues when selecting items via checkbox", () => {
@@ -958,8 +960,11 @@ describe("General", () => {
 		);
 
 		cy.get("[ui5-multi-combobox]")
-			.as("mcb")
-			.should("have.attr", "selected-values", '[]');
+			.as("mcb");
+
+		cy.get("@mcb")
+			.invoke("prop", "selectedValues")
+			.should("deep.equal", []);
 
 		// Open the dropdown
 		cy.get("@mcb")
@@ -975,7 +980,8 @@ describe("General", () => {
 			.realClick();
 
 		cy.get("@mcb")
-			.should("have.attr", "selected-values", '["DE"]');
+			.invoke("prop", "selectedValues")
+			.should("deep.equal", ["DE"]);
 
 		// Select second item via checkbox
 		cy.get("[ui5-mcb-item]")
@@ -985,7 +991,8 @@ describe("General", () => {
 			.realClick();
 
 		cy.get("@mcb")
-			.should("have.attr", "selected-values", '["DE","FR"]');
+			.invoke("prop", "selectedValues")
+			.should("deep.equal", ["DE", "FR"]);
 
 		// Select third and fourth items
 		cy.get("[ui5-mcb-item]")
@@ -1001,7 +1008,8 @@ describe("General", () => {
 			.realClick();
 
 		cy.get("@mcb")
-			.should("have.attr", "selected-values", '["DE","FR","IT","US"]');
+			.invoke("prop", "selectedValues")
+			.should("deep.equal", ["DE", "FR", "IT", "US"]);
 	});
 
 	it("selects correct items when selectedValues is set before items are added", () => {
@@ -1011,8 +1019,11 @@ describe("General", () => {
 		);
 
 		cy.get("[ui5-multi-combobox]")
-			.as("mcb")
-			.should("have.attr", "selected-values", '["FR","US"]');
+			.as("mcb");
+
+		cy.get("@mcb")
+			.invoke("prop", "selectedValues")
+			.should("deep.equal", ["FR", "US"]);
 
 		// No tokens yet since no items
 		cy.get("@mcb")
@@ -1077,8 +1088,11 @@ describe("General", () => {
 		);
 
 		cy.get("[ui5-multi-combobox]")
-			.as("mcb")
-			.should("have.attr", "selected-values", "[]");
+			.as("mcb");
+
+		cy.get("@mcb")
+			.invoke("prop", "selectedValues")
+			.should("deep.equal", []);
 
 		// Type "Ca" to trigger typeahead for Canada
 		cy.get("@mcb")
@@ -1092,7 +1106,8 @@ describe("General", () => {
 
 		// Verify selectedValues is updated
 		cy.get("@mcb")
-			.should("have.attr", "selected-values", '["CA"]');
+			.invoke("prop", "selectedValues")
+			.should("deep.equal", ["CA"]);
 
 		// Verify token is created
 		cy.get("@mcb")
@@ -1111,7 +1126,8 @@ describe("General", () => {
 
 		// Verify selectedValues now has both values
 		cy.get("@mcb")
-			.should("have.attr", "selected-values", '["CA","JP"]');
+			.invoke("prop", "selectedValues")
+			.should("deep.equal", ["CA", "JP"]);
 	});
 });
 
@@ -2768,7 +2784,8 @@ describe("Event firing", () => {
 			return event.detail.item === undefined;
 		}));
 		cy.get("[ui5-multi-combobox]")
-			.should("have.attr", "selected-values", '[]');
+			.invoke("prop", "selectedValues")
+			.should("deep.equal", []);
 	});
 });
 


### PR DESCRIPTION
## Framework contract for Object/Array properties

> **Object and Array properties are not reflected to attributes.** The DOM attribute is purely a one-way, author-controlled declarative input — parsed into the property via `fromAttribute` on `attributeChangedCallback`. The framework neither writes nor removes the attribute. Attributes exist for CSS selectors (which don't apply to objects/arrays) and for debugging via the Elements panel (devs will inspect these via the console with property access).

## Problem

Two related issues with how the framework handled Object/Array property attributes:

1. **Array reflected out (regression).** `defaultConverter.toAttribute` was serializing arrays with `JSON.stringify` and letting `_updateAttribute` write them to the DOM, contradicting its own `// don't set attributes for arrays and objects` comment. This broke declarative attribute input: `<my-comp items='[1,2,3]'>` was parsed into the property, then on first render `updateAttributes()` round-tripped the property back onto the DOM as a stringified attribute.
2. **Object excluded from attributes entirely.** `UI5ElementMetadata.hasAttribute` had `propData.type !== Object` hard-coded, so Object-typed properties were never in `observedAttributes`. This meant declarative `<my-comp config='{...}'>` was silently ignored — no reflection in either direction.

The result was an inconsistent, undocumented split between the two collection types.

## Fix

- `defaultConverter.toAttribute` returns `null` for `Object`/`Array` (defensive; the in-tree call site no longer reaches it).
- `_updateAttribute` early-returns for `Object`/`Array` properties — neither `setAttribute` nor `removeAttribute` is called for them.
- `UI5ElementMetadata.hasAttribute` no longer excludes Object, so Object-typed properties are part of `observedAttributes` and receive declarative attribute input the same way Array does.
- `fromAttribute` is unchanged: declarative `<my-comp items='[1,2,3]'>` (or `config='{...}'`) JSON-parses into the property on `attributeChangedCallback`.

## Behavior matrix

| Scenario | Array — Before | Array — After | Object — Before | Object — After |
|---|---|---|---|---|
| `el.prop = value` (programmatic) | DOM attribute set to JSON | No DOM attribute | No DOM attribute | No DOM attribute |
| `<comp prop='[...]'>` / `<comp prop='{...}'>` (declarative) | Parsed in, then reflected back on first render | Attribute stays as authored, property holds parsed value | **Silently ignored** | Attribute stays as authored, property holds parsed value |
| `el.setAttribute('prop', '...')` later | Property updated | Property updated (unchanged) | **Silently ignored** | Property updated |
| Property write after author set the attribute | Attribute overwritten with new JSON | Attribute left alone (stale vs. property — by design; one-way input) | n/a | Attribute left alone (stale vs. property — by design; one-way input) |

Object and Array now behave identically under the contract.

## Tests

`packages/base/cypress/specs/UI5ElementPropsAndAttrs.cy.tsx`:
- The previous "array properties have attributes" test (which asserted the old broken behavior) is flipped to "have no attributes when set programmatically".
- New: declarative `multi-prop` attribute survives first render and parses into the property.
- New: later `setAttribute` flows into the property; subsequent property write does not touch the DOM attribute.
- New: same coverage for `object-prop` (now possible because Object is in `observedAttributes`).

Run with:
```bash
cd packages/base
yarn test:cypress:single cypress/specs/UI5ElementPropsAndAttrs.cy.tsx
```