### PR TITLE
ci: migrate remaining workflows from PAT to GitHub App token

### DIFF
--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -40,6 +40,13 @@ jobs:
     environment: netlify-preview
 
     steps:
+    - name: Generate App Token
+      id: app-token
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+      with:
+        app-id: ${{ secrets.RELEASE_APP_ID }}
+        private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
     - name: Checkout
       uses: actions/checkout@v4
       with:
@@ -77,7 +84,7 @@ jobs:
       if: always()
       uses: actions/github-script@v7
       with:
-        github-token: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+        github-token: ${{ steps.app-token.outputs.token }}
         script: |
           const { data: pr } = await github.rest.pulls.get({
             owner: context.repo.owner,
@@ -120,7 +127,7 @@ jobs:
       with:
         publish-dir: './packages/website/build'
         production-deploy: false
-        github-token: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+        github-token: ${{ steps.app-token.outputs.token }}
         deploy-message: "Deploy preview for PR #${{ github.event.number }}"
         alias: pr-${{ github.event.number }}
         enable-pull-request-comment: true

--- a/.github/workflows/issue-monthly-report.yaml
+++ b/.github/workflows/issue-monthly-report.yaml
@@ -17,9 +17,16 @@ jobs:
     permissions:
       issues: write
     steps:
+      - name: Generate App Token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const REPORT_ISSUE_NUMBER = 13080; // Monthly Issues Report tracking issue
             const isDryRun = context.eventName === 'workflow_dispatch' && ${{ inputs.dry_run || false }};

--- a/.github/workflows/reset-gh-pages.yaml
+++ b/.github/workflows/reset-gh-pages.yaml
@@ -11,14 +11,21 @@ jobs:
   reset-gh-pages:
     runs-on: ubuntu-latest
     steps:
+    - name: Generate App Token
+      id: app-token
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+      with:
+        app-id: ${{ secrets.RELEASE_APP_ID }}
+        private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
     - uses: actions/checkout@v4
       with:
-        token: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+        token: ${{ steps.app-token.outputs.token }}
         fetch-depth: 0
 
     - name: Reset gh-pages git history
       env:
-        GH_TOKEN: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
       run: |
         git config user.name "${{ secrets.UI5_WEBCOMP_BOT_NAME }}"
         git config user.email "${{ secrets.UI5_WEBCOMP_BOT_EMAIL }}"

--- a/.github/workflows/reset-preview-deploy.yaml
+++ b/.github/workflows/reset-preview-deploy.yaml
@@ -33,6 +33,13 @@ jobs:
     environment: netlify-preview
 
     steps:
+    - name: Generate App Token
+      id: app-token
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+      with:
+        app-id: ${{ secrets.RELEASE_APP_ID }}
+        private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
     - name: Create empty content
       run: |
         mkdir -p empty-site
@@ -57,7 +64,7 @@ jobs:
       with:
         publish-dir: './empty-site'
         production-deploy: false
-        github-token: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+        github-token: ${{ steps.app-token.outputs.token }}
         deploy-message: "chore: cleanup preview for closed PR #${{ github.event.number }}"
         alias: pr-${{ github.event.number }}
         enable-pull-request-comment: false
@@ -71,7 +78,7 @@ jobs:
     - name: Update PR with cleanup notification
       uses: actions/github-script@v7
       with:
-        github-token: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+        github-token: ${{ steps.app-token.outputs.token }}
         script: |
           const prNumber = context.payload.pull_request.number;
           const cleanupUrl = `https://pr-${prNumber}--ui5-webcomponents.netlify.app`;


### PR DESCRIPTION
Follow-up to #13604.

Replaces `secrets.UI5_WEBCOMP_BOT_GH_TOKEN` with a per-run installation token from `actions/create-github-app-token@v3.2.0` (pinned by SHA) in the four workflows that were intentionally left out of scope when the release workflow was migrated:

- `deploy-preview.yaml`
- `reset-preview-deploy.yaml`
- `reset-gh-pages.yaml`
- `issue-monthly-report.yaml`

## Why

Completes the [OSPO Hardening Control #4](https://wiki.one.int.sap/wiki/spaces/ospodocs/pages/6139514269/GitHub+Hardening+Controls#GitHubHardeningControls-4.Replacelong-livedsecretswithOIDC) migration: replace long-lived static credentials (PATs) with short-lived per-workflow tokens. App tokens are valid for ~1 hour and disappear when the run ends, drastically reducing the blast radius compared to the long-lived PAT.

## After merge

Once each workflow has run green at least once, the `UI5_WEBCOMP_BOT_GH_TOKEN` secret can be deleted and the underlying PAT revoked.

`UI5_WEBCOMP_BOT_NAME` and `UI5_WEBCOMP_BOT_EMAIL` are kept — they are git identity strings, not credentials.

## Required (already in place from #13604)

- `RELEASE_APP_ID` repo secret
- `RELEASE_APP_PRIVATE_KEY` repo secret
- The `sap-ui5-webcomponents-release` GitHub App installed on this repo (only needs Contents/Issues/PRs write — no branch protection bypass changes required, since none of these workflows push to `main`)