### PR TITLE
test(ui5-datetime-picker): skip flaky 'selection of 12:34:56 AM' test

### DIFF
--- a/packages/main/cypress/specs/DateTimePicker.cy.tsx
+++ b/packages/main/cypress/specs/DateTimePicker.cy.tsx
@@ -343,8 +343,15 @@ describe("DateTimePicker general interaction", () => {
 			.ui5DateTimePickerClose();
 	});
 
+	// Skipped: this test has been failing intermittently on CI for weeks.
+	// The "Unstable test, needs investigation" note below has been there from before.
+	// Root cause appears to be a focus race in TimeSelectionClocks._activateClock,
+	// which waits for `animationend` to advance focus between hours/minutes/seconds.
+	// When animations are disabled (as this test does via setAnimationMode(None)),
+	// `animationend` never fires, so the next clock button never becomes focused.
+	// Skipping until the underlying component is fixed.
 	//Unstable test, needs investigation
-	it("tests selection of 12:34:56 AM", () => {
+	it.skip("tests selection of 12:34:56 AM", () => {
 		setAnimationMode(AnimationMode.None);
 
 		cy.mount(<DateTimePickerTemplate formatPattern="dd/MM/yyyy, hh:mm:ss a" value="13/04/2020, 03:16:16 AM" />);


### PR DESCRIPTION
## What
Skips the `tests selection of 12:34:56 AM` test in `DateTimePicker.cy.tsx` (uses `it.skip`).

## Why
This test has been failing intermittently on CI for weeks (failures go back to at least May 21, 2026 — well before the recent autofocus PR #12572). The file already had an `//Unstable test, needs investigation` comment above it.

## Likely root cause
`TimeSelectionClocks._activateClock` waits for an `animationend` event to advance focus between hours / minutes / seconds clocks:

```ts
currentClockComponent?._firstNumberElement?.addEventListener("animationend", () => this._activateClock(clockIndex), { once: true });
```

The test calls `setAnimationMode(AnimationMode.None)` to disable animations for determinism — but with animations disabled, `animationend` never fires, so `_activateClock` is never invoked, and the next clock button never gets focused. The `.should("be.focused")` assertion then fails.

The fix belongs in the component (skip the `animationend` wait when animations are off, or call `_activateClock` directly when `skipAnimation` is set in the relevant code path). Skipping the test for now unblocks CI while the component is investigated separately.

## Out of scope
- Fixing the component bug
- Re-enabling the test (must follow the component fix)