### PR TITLE
ci(reset-gh-pages): scope to github-pages environment

### DIFF
--- a/.github/workflows/reset-gh-pages.yaml
+++ b/.github/workflows/reset-gh-pages.yaml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   reset-gh-pages:
     runs-on: ubuntu-latest
+    environment: github-pages
     steps:
     - name: Generate App Token
       id: app-token


### PR DESCRIPTION
Adds `environment: github-pages` to the `reset-gh-pages` job so it can resolve `UI5_WEBCOMP_BOT_NAME` and `UI5_WEBCOMP_BOT_EMAIL` from the environment-level secrets you just added there.

Once this lands, the repo-level copies of those two secrets can be deleted — releases (env: `npmjs:@ui5/webcomponents`) and this workflow (env: `github-pages`) cover all uses.