### PR TITLE
ci(issue-reopen): add sap-ui5-webcomponents-release to system user allowlist

### DIFF
--- a/.github/workflows/issue-reopen.yaml
+++ b/.github/workflows/issue-reopen.yaml
@@ -29,7 +29,7 @@ jobs:
             const commenter = context.payload.comment.user.login;
 
             // Allowed bots
-            const isSystemUser = ['ui5-webcomponents-bot', 'github-actions[bot]'].includes(commenter);
+            const isSystemUser = ['ui5-webcomponents-bot', 'github-actions[bot]', 'sap-ui5-webcomponents-release'].includes(commenter);
 
             const fs = require('fs');
             fs.appendFileSync(process.env.GITHUB_OUTPUT, `shouldReopen=${!isSystemUser && commentAt > closedAt}\n`);


### PR DESCRIPTION
## Why

The release bot `sap-ui5-webcomponents-release` posts release-comments on fixed issues after each release. Without it being in the allowlist in `.github/workflows/issue-reopen.yaml`, those comments would re-open closed issues.

## What

Adds `sap-ui5-webcomponents-release` to the `isSystemUser` allowlist alongside `ui5-webcomponents-bot` and `github-actions[bot]`.