### PR TITLE
docs: correct api description

### DIFF
--- a/packages/main/src/FormGroup.ts
+++ b/packages/main/src/FormGroup.ts
@@ -82,6 +82,7 @@ class FormGroup extends UI5Element implements IFormItem {
 	 * **Note:** This property is ignored if `columnSpan` is set, as it is expected that the column span is defined.
 	 *
 	 * @default undefined
+	 * @since 2.23.0
 	 * @public
 	 */
 	@property()

--- a/packages/main/src/ListItemBase.ts
+++ b/packages/main/src/ListItemBase.ts
@@ -26,7 +26,7 @@ type ListItemBasePressEventDetail = {
 }
 
 type ListItemBaseClickEventDetail = {
-	item: ListItemBase,
+	item?: ListItemBase,
 	originalEvent: Event,
 }
 
@@ -48,9 +48,8 @@ type ListItemBaseClickEventDetail = {
  *
  * **Note:** The event will not be fired if the `disabled` property is set to `true`.
  *
- * @since 2.22.0
+ * @since 2.23.0
  * @public
- * @param {ListItemBase} item The activated item.
  * @param {Event} originalEvent The original event from the user interaction.
  */
 @event("click", {


### PR DESCRIPTION
- Add since tag two newly added `colSpan` property in FormGroup
- Remove `item` parameter from ListItem's click event as it is the same as `event.target`