### PR TITLE
test: reduce mutation observer delay from 200ms to 0ms

### DIFF
--- a/packages/base/src/Render.ts
+++ b/packages/base/src/Render.ts
@@ -92,7 +92,7 @@ const scheduleRenderTask = async () => {
 						if (invalidatedWebComponents.isEmpty()) {
 							_resolveTaskPromise();
 						}
-					}, 200);
+					}, 0);
 				}
 			});
 		});


### PR DESCRIPTION
## Purpose

Experimental PR to measure the impact of the mutation observer delay on CI test execution speed.

## Change

In `packages/base/src/Render.ts`, the mutation observer timer in `scheduleRenderTask` currently waits **200ms** before resolving the render task promise. This PR reduces that delay to **0ms** to evaluate whether tests run faster on CI.

```diff
-					}, 200);
+					}, 0);
```

## Note

Not intended for merge — purely a benchmark to compare CI run duration against the baseline.