### PR TITLE
ci: scope app-token secrets to environments + rename to TOKEN_APP_*

### DIFF
--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -44,8 +44,8 @@ jobs:
       id: app-token
       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       with:
-        app-id: ${{ secrets.RELEASE_APP_ID }}
-        private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+        client-id: ${{ secrets.TOKEN_APP_ID }}
+        private-key: ${{ secrets.TOKEN_APP_KEY }}
 
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/issue-monthly-report.yaml
+++ b/.github/workflows/issue-monthly-report.yaml
@@ -17,16 +17,8 @@ jobs:
     permissions:
       issues: write
     steps:
-      - name: Generate App Token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
-          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-
       - uses: actions/github-script@v7
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const REPORT_ISSUE_NUMBER = 13080; // Monthly Issues Report tracking issue
             const isDryRun = context.eventName === 'workflow_dispatch' && ${{ inputs.dry_run || false }};

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
-          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          private-key: ${{ secrets.RELEASE_APP_KEY }}
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -158,7 +158,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
-          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          private-key: ${{ secrets.RELEASE_APP_KEY }}
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -268,7 +268,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
-          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          private-key: ${{ secrets.RELEASE_APP_KEY }}
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -388,7 +388,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
-          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          private-key: ${{ secrets.RELEASE_APP_KEY }}
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/reset-gh-pages.yaml
+++ b/.github/workflows/reset-gh-pages.yaml
@@ -16,8 +16,8 @@ jobs:
       id: app-token
       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       with:
-        app-id: ${{ secrets.RELEASE_APP_ID }}
-        private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+        client-id: ${{ secrets.TOKEN_APP_ID }}
+        private-key: ${{ secrets.TOKEN_APP_KEY }}
 
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/reset-preview-deploy.yaml
+++ b/.github/workflows/reset-preview-deploy.yaml
@@ -37,8 +37,8 @@ jobs:
       id: app-token
       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       with:
-        app-id: ${{ secrets.RELEASE_APP_ID }}
-        private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+        client-id: ${{ secrets.TOKEN_APP_ID }}
+        private-key: ${{ secrets.TOKEN_APP_KEY }}
 
     - name: Create empty content
       run: |


### PR DESCRIPTION
## Summary

Continues the long-lived → short-lived token migration by moving the GitHub App credentials from repo-level secrets onto environment-level secrets, and renaming them so the names make sense outside the release context.

## Changes per workflow

| Workflow | Token | Environment | Secret pair |
|---|---|---|---|
| `release.yaml` | App | `npmjs:@ui5/webcomponents` | `RELEASE_APP_ID` / `RELEASE_APP_KEY` (renamed from `RELEASE_APP_PRIVATE_KEY`) |
| `deploy-preview.yaml` | App (`client-id`) | `netlify-preview` | `TOKEN_APP_ID` / `TOKEN_APP_KEY` |
| `reset-preview-deploy.yaml` | App (`client-id`) | `netlify-preview` | `TOKEN_APP_ID` / `TOKEN_APP_KEY` |
| `reset-gh-pages.yaml` | App (`client-id`) | `github-pages` | `TOKEN_APP_ID` / `TOKEN_APP_KEY` |
| `issue-monthly-report.yaml` | default `GITHUB_TOKEN` | — | — |

## Notes

- All non-release workflows now use the documented `client-id` input on `actions/create-github-app-token` instead of the deprecated `app-id`. `release.yaml` keeps `app-id` for now (separate follow-up if we want to flip it too).
- `issue-monthly-report.yaml` no longer needs the App token at all — its only API calls (read issues, post one comment on a tracking issue) work with the default `GITHUB_TOKEN`. This avoids needing yet another environment to scope its secrets to.
- Env-level secrets are already set:
  - `npmjs:@ui5/webcomponents` → `RELEASE_APP_ID`, `RELEASE_APP_KEY`
  - `netlify-preview` → `TOKEN_APP_ID`, `TOKEN_APP_KEY`
  - `github-pages` → `TOKEN_APP_ID`, `TOKEN_APP_KEY`
- Once this lands, the repo-level `RELEASE_APP_*` and `UI5_WEBCOMP_BOT_*` secrets can be deleted (separate cleanup PR/manual step).