### PR TITLE
fix(ui5-list): guard item-toggle against null event detail

### DIFF
--- a/packages/main/cypress/specs/List.cy.tsx
+++ b/packages/main/cypress/specs/List.cy.tsx
@@ -14,6 +14,8 @@ import Option from "../../src/Option.js";
 import CheckBox from "../../src/CheckBox.js";
 import Bar from "../../src/Bar.js";
 import Link from "../../src/Link.js";
+import Panel from "../../src/Panel.js";
+import Label from "../../src/Label.js";
 
 function getGrowingWithScrollList(length: number, height: string = "100px") {
 	return (
@@ -204,6 +206,59 @@ describe("List Tests", () => {
 			.should("exist")
 			.should("have.class", "ui5-hidden-text")
 			.should("contain.text", "This button will load additional products to the list. Click or press Enter to see more items.");
+	});
+
+	it("does not fire item-toggle for nested panel toggle events", () => {
+		cy.mount(
+			<List>
+				<ListItemCustom>
+					<Panel headerText="Panel A" style={{ width: "100%" }}>
+						<Label>Panel A content</Label>
+					</Panel>
+				</ListItemCustom>
+			</List>
+		);
+
+		cy.get("[ui5-list]").as("list");
+
+		cy.get("@list")
+			.then(list => {
+				list.get(0).addEventListener("ui5-item-toggle", cy.stub().as("itemToggle"));
+			});
+
+		cy.get("[ui5-panel]")
+			.shadow()
+			.find(".ui5-panel-header")
+			.realClick();
+
+		cy.get("[ui5-panel]")
+			.should("have.attr", "collapsed");
+
+		cy.get("@itemToggle")
+			.should("not.have.been.called");
+	});
+
+	it("does not crash when a bubbling ui5-toggle has null detail", () => {
+		cy.mount(
+			<List>
+				<ListItemCustom id="listItemWithNestedContent">
+					<div>Nested interactive content</div>
+				</ListItemCustom>
+			</List>
+		);
+
+		cy.window().then(win => {
+			const listItem = win.document.getElementById("listItemWithNestedContent");
+			const toggleEvent = new win.CustomEvent("ui5-toggle", {
+				detail: null,
+				bubbles: true,
+				composed: true,
+			});
+
+			listItem?.dispatchEvent(toggleEvent);
+		});
+
+		cy.get("[ui5-list]").should("exist");
 	});
 });
 

--- a/packages/main/src/List.ts
+++ b/packages/main/src/List.ts
@@ -1419,7 +1419,13 @@ class List extends UI5Element {
 			return;
 		}
 
-		this.fireDecoratorEvent("item-toggle", { item: e.detail.item });
+		const item = e.detail?.item;
+
+		if (!item) {
+			return;
+		}
+
+		this.fireDecoratorEvent("item-toggle", { item });
 	}
 
 	onForwardBefore(e: CustomEvent) {


### PR DESCRIPTION
Prevent runtime crashes when a bubbling ui5-toggle event reaches ui5-list with null detail (for example from nested components such as ui5-panel).

Update List.onItemToggle to safely read e.detail?.item and return early when no item is provided before firing ui5-item-toggle.

Add Cypress regression coverage in List.cy.tsx for null-detail toggle events and keep the nested panel scenario check.

Fixes: #13576

