### PR TITLE
fix(ui5-form): replace Cyrillic А with Latin A in effectiveAccessibleNameRef

### DIFF
--- a/packages/main/src/Form.ts
+++ b/packages/main/src/Form.ts
@@ -506,7 +506,7 @@ class Form extends UI5Element {
 		return this.hasHeader ? undefined : Form.i18nBundle.getText(FORM_ACCESSIBLE_NAME);
 	}
 
-	get effectiveАccessibleNameRef(): string | undefined {
+	get effectiveAccessibleNameRef(): string | undefined {
 		if (this.accessibleName || this.accessibleNameRef) {
 			return;
 		}

--- a/packages/main/src/FormTemplate.tsx
+++ b/packages/main/src/FormTemplate.tsx
@@ -7,7 +7,7 @@ export default function FormTemplate(this: Form) {
 			class="ui5-form-root"
 			role={this.effectiveAccessibleRole}
 			aria-label={this.effectiveAccessibleName}
-			aria-labelledby={this.effectiveАccessibleNameRef}
+			aria-labelledby={this.effectiveAccessibleNameRef}
 			style={{
 				"--ui5-form-columns-s": this.columnsS,
 				"--ui5-form-columns-m": this.columnsM,


### PR DESCRIPTION
The getter `effectiveAccessibleNameRef` and its call site in FormTemplate.tsx contained a Cyrillic capital А (U+0410) instead of a Latin A (U+0041).

Fixes #13647