### PR TITLE
perf(base): use queueMicrotask instead of rAF in scheduleRenderTask

### DIFF
--- a/packages/base/src/Render.ts
+++ b/packages/base/src/Render.ts
@@ -74,7 +74,7 @@ const cancelRender = (webComponent: UI5Element) => {
 const scheduleRenderTask = async () => {
 	if (!queuePromise) {
 		queuePromise = new Promise<void>(resolve => {
-			window.requestAnimationFrame(() => {
+			queueMicrotask(() => {
 				// Render all components in the queue
 
 				// console.log(`--------------------RENDER TASK START------------------------------`); // eslint-disable-line


### PR DESCRIPTION
Headless Cypress browsers throttle `requestAnimationFrame`, which can delay test execution. Switch the leading scheduler in `scheduleRenderTask` (`Render.ts:77`) from `window.requestAnimationFrame` to `queueMicrotask` to bypass the rAF throttle.

Goal of this PR: see if CI test durations actually shorten — that is the open question from #13642.

### Context
Follow-up on https://github.com/UI5/webcomponents/pull/13642#issuecomment-4622698441 — the previous attempt (lowering the 200ms mutation-observer settle to 0ms) showed no measurable speedup because that timer is gated behind `renderFinished()` and re-armed per quiet period, not paid per render. The leading rAF was called out there as a better target.

### Risk
- Microtasks run within the same task as the caller, so render now happens before the next paint. Tests/code that implicitly relied on a paint between mutation and render may behave differently.
- `whenDOMUpdated()` (`Render.ts:114`) still uses rAF — left untouched here to keep the diff minimal and isolate the signal.