### PR TITLE
docs: pre-release docs clean-up

### DIFF
--- a/packages/fiori/cypress/specs/NotificationList.cy.tsx
+++ b/packages/fiori/cypress/specs/NotificationList.cy.tsx
@@ -1150,7 +1150,7 @@ describe("NotificationListItem semantic click event", () => {
 		cy.get("@clickStub").should((stub: any) => {
 			const event = stub.firstCall.args[0];
 			expect(event).to.be.instanceOf(CustomEvent);
-			expect(event.detail.item).to.exist;
+			expect(event.target).to.have.property("id", "nli1");
 			expect(event.detail.originalEvent).to.be.instanceOf(MouseEvent);
 		});
 	});

--- a/packages/fiori/src/NotificationListItem.ts
+++ b/packages/fiori/src/NotificationListItem.ts
@@ -59,7 +59,6 @@ type NotificationListItemPressEventDetail = {
 };
 
 type NotificationListItemClickEventDetail = {
-	item: NotificationListItem,
 	originalEvent: Event,
 };
 
@@ -149,9 +148,8 @@ const ICON_PER_STATUS_DESIGN = {
 /**
  * Fired when the component is activated either with a mouse/tap or by using the Enter or Space key.
  *
- * @since 2.22.0
+ * @since 2.23.0
  * @public
- * @param {NotificationListItem} item The activated item.
  * @param {Event} originalEvent The original event from the user interaction.
  */
 @event("click", {
@@ -576,7 +574,7 @@ class NotificationListItem extends NotificationListItemBase {
 		// NotificationListItem will never be assigned to a variable of type ListItemBase
 		// typescipt complains here, if that is the case, the parameter to the _press event handler could be a ListItemBase item,
 		// but this is never the case, all components are used by their class and never assigned to a variable with a type of ListItemBase
-		this.fireDecoratorEvent("click", { item: this, originalEvent: e });
+		this.fireDecoratorEvent("click", { originalEvent: e });
 		this.fireDecoratorEvent("_press", { item: this });
 	}
 

--- a/packages/fiori/src/NotificationListItemBase.ts
+++ b/packages/fiori/src/NotificationListItemBase.ts
@@ -22,7 +22,6 @@ import {
  * @since 1.0.0-rc.8
  * @public
  */
-@customElement({})
 class NotificationListItemBase extends ListItemBase {
 	eventDetails!: ListItemBase["eventDetails"];
 	/**

--- a/packages/fiori/src/NotificationListItemBase.ts
+++ b/packages/fiori/src/NotificationListItemBase.ts
@@ -22,6 +22,7 @@ import {
  * @since 1.0.0-rc.8
  * @public
  */
+@customElement({})
 class NotificationListItemBase extends ListItemBase {
 	eventDetails!: ListItemBase["eventDetails"];
 	/**

--- a/packages/main/cypress/specs/TabContainer.cy.tsx
+++ b/packages/main/cypress/specs/TabContainer.cy.tsx
@@ -1312,7 +1312,7 @@ describe("Tab semantic click event", () => {
 		cy.get("@clickStub").should((stub: any) => {
 			const event = stub.firstCall.args[0];
 			expect(event).to.be.instanceOf(CustomEvent);
-			expect(event.detail.tab).to.exist;
+			expect(event.target).to.have.property("id", "tab1");
 			expect(event.detail.originalEvent).to.be.instanceOf(MouseEvent);
 		});
 	});

--- a/packages/main/src/ListBoxItemGroupTemplate.tsx
+++ b/packages/main/src/ListBoxItemGroupTemplate.tsx
@@ -1,7 +1,6 @@
 import type ListItemGroup from "./ListItemGroup.js";
 import ListItemGroupHeader from "./ListItemGroupHeader.js";
 import DropIndicator from "./DropIndicator.js";
-import ListItemAccessibleRole from "./types/ListItemAccessibleRole.js";
 
 export default function ListItemGroupTemplate(this: ListItemGroup, hooks?: { items: () => void }) {
 	const items = hooks?.items || defaultItems;

--- a/packages/main/src/ListBoxItemGroupTemplate.tsx
+++ b/packages/main/src/ListBoxItemGroupTemplate.tsx
@@ -16,7 +16,7 @@ export default function ListItemGroupTemplate(this: ListItemGroup, hooks?: { ite
 			onDragLeave={this._ondragleave}
 		>
 			{this.hasHeader &&
-				<ListItemGroupHeader focused={this.focused} part="header" accessibleRole={ListItemAccessibleRole.Group} wrappingType={this.getGroupHeaderWrapping()} >
+				<ListItemGroupHeader focused={this.focused} part="header" accessibleRole="Group" wrappingType={this.getGroupHeaderWrapping()} >
 					{ this.hasFormattedHeader ? <slot name="header"></slot> : this.headerText }
 				</ListItemGroupHeader>
 			}

--- a/packages/main/src/ListItem.ts
+++ b/packages/main/src/ListItem.ts
@@ -186,10 +186,10 @@ abstract class ListItem extends ListItemBase {
 	 * An explicitly set `accessible-role` on the list item takes precedence over the inherited role.
 	 * @default undefined
 	 * @public
-	 * @since 1.3.0
+	 * @since 2.23.0
 	 */
 	@property()
-	accessibleRole?: `${Exclude<ListItemAccessibleRole, ListItemAccessibleRole.Group>}`;
+	accessibleRole?: `${ListItemAccessibleRole}`;
 
 	@property()
 	_forcedAccessibleRole?: string;

--- a/packages/main/src/ListItemGroupHeader.ts
+++ b/packages/main/src/ListItemGroupHeader.ts
@@ -61,7 +61,7 @@ class ListItemGroupHeader extends ListItemBase {
 	accessibleName?: string;
 
 	@property()
-	accessibleRole: `${ListItemAccessibleRole}` = ListItemAccessibleRole.ListItem;
+	accessibleRole: `${ListItemAccessibleRole}` | "Group" = ListItemAccessibleRole.ListItem;
 
 	/**
 	 * Defines if the text of the component should wrap when it's too long.

--- a/packages/main/src/Tab.ts
+++ b/packages/main/src/Tab.ts
@@ -50,7 +50,6 @@ const DESIGN_DESCRIPTIONS = {
 };
 
 type TabClickEventDetail = {
-	tab: Tab,
 	originalEvent: Event,
 };
 
@@ -83,9 +82,8 @@ interface TabInOverflow extends ListItemCustom {
 /**
  * Fired when the tab is selected either with a mouse/tap or by using the Enter or Space key.
  *
- * @since 2.22.0
+ * @since 2.23.0
  * @public
- * @param {Tab} tab The selected tab.
  * @param {Event} originalEvent The original event from the user interaction.
  */
 @event("click", {

--- a/packages/main/src/TabContainer.ts
+++ b/packages/main/src/TabContainer.ts
@@ -912,7 +912,7 @@ class TabContainer extends UI5Element {
 		}
 
 		if (originalEvent) {
-			selectedTab.fireDecoratorEvent("click", { tab: selectedTab, originalEvent });
+			selectedTab.fireDecoratorEvent("click", { originalEvent });
 		}
 
 		// update selected property on all items

--- a/packages/main/src/TableGroupRow.ts
+++ b/packages/main/src/TableGroupRow.ts
@@ -55,7 +55,7 @@ const EMPTY_ACTIONS = [] as unknown as Slot<TableRowActionBase>;
  *
  * @constructor
  * @extends TableRow
- * @since 2.22.0
+ * @since 2.23.0
  * @public
  */
 @customElement({

--- a/packages/main/src/types/ListItemAccessibleRole.ts
+++ b/packages/main/src/types/ListItemAccessibleRole.ts
@@ -4,13 +4,6 @@
  * @since 2.0.0
  */
 enum ListItemAccessibleRole {
-
-	/**
-	 * Represents the ARIA role "group".
-	 * @private
-	 */
-	Group = "Group",
-
 	/**
 	 * Represents the ARIA role "listitem". (by default)
 	 * @public

--- a/packages/website/docs/_components_pages/ai/Button/Button.mdx
+++ b/packages/website/docs/_components_pages/ai/Button/Button.mdx
@@ -1,6 +1,5 @@
 ---
 slug: ../Button
-sidebar_class_name: newComponentBadge
 ---
 
 import ButtonMenu from "../../../_samples/ai/Button/ButtonMenu/ButtonMenu.md";

--- a/packages/website/docs/_components_pages/ai/Button/ButtonState.mdx
+++ b/packages/website/docs/_components_pages/ai/Button/ButtonState.mdx
@@ -1,6 +1,5 @@
 ---
 slug: ../ButtonState
-sidebar_class_name: newComponentBadge
 ---
 
 <%COMPONENT_OVERVIEW%>

--- a/packages/website/docs/_components_pages/ai/Input.mdx
+++ b/packages/website/docs/_components_pages/ai/Input.mdx
@@ -1,6 +1,3 @@
----
-sidebar_class_name: newComponentBadge
----
 
 import Basic from "../../_samples/ai/Input/Basic/Basic.md";
 

--- a/packages/website/docs/_components_pages/ai/PromptInput.mdx
+++ b/packages/website/docs/_components_pages/ai/PromptInput.mdx
@@ -1,7 +1,3 @@
----
-sidebar_class_name: newComponentBadge
----
-
 import Basic from "../../_samples/ai/PromptInput/Basic/Basic.md";
 
 <%COMPONENT_OVERVIEW%>

--- a/packages/website/docs/_components_pages/ai/TextArea.mdx
+++ b/packages/website/docs/_components_pages/ai/TextArea.mdx
@@ -1,7 +1,3 @@
----
-sidebar_class_name: newComponentBadge
----
-
 import Basic from "../../_samples/ai/TextArea/Basic/Basic.md";
 import Extended from "../../_samples/ai/TextArea/Extended/Extended.md";
 

--- a/packages/website/docs/_components_pages/fiori/NavigationLayout.mdx
+++ b/packages/website/docs/_components_pages/fiori/NavigationLayout.mdx
@@ -1,7 +1,3 @@
----
-sidebar_class_name: newComponentBadge
----
-
 import Basic from "../../_samples/fiori/NavigationLayout/Basic/Basic.md";
 
 <%COMPONENT_OVERVIEW%>

--- a/packages/website/docs/_components_pages/fiori/NotificationList/NotificationList.mdx
+++ b/packages/website/docs/_components_pages/fiori/NotificationList/NotificationList.mdx
@@ -1,7 +1,3 @@
----
-sidebar_class_name: newComponentBadge
----
-
 import Basic from "../../../_samples/fiori/NotificationList/Basic/Basic.md";
 import GroupItems from "../../../_samples/fiori/NotificationList/GroupItems/Basic.md";
 import InShellBar from "../../../_samples/fiori/NotificationList/InShellBar/InShellBar.md";

--- a/packages/website/docs/_components_pages/fiori/Search/Search.mdx
+++ b/packages/website/docs/_components_pages/fiori/Search/Search.mdx
@@ -1,7 +1,3 @@
----
-sidebar_class_name: newComponentBadge
----
-
 import Basic from "../../../_samples/fiori/Search/Basic/Basic.md";
 import Advanced from "../../../_samples/fiori/Search/Advanced/Advanced.md";
 import Byline from "../../../_samples/fiori/Search/Byline/Byline.md";

--- a/packages/website/docs/_components_pages/fiori/Search/SearchItem.mdx
+++ b/packages/website/docs/_components_pages/fiori/Search/SearchItem.mdx
@@ -1,6 +1,5 @@
 ---
 slug: ../SearchItem
-sidebar_class_name: newComponentBadge
 ---
 
 <%COMPONENT_OVERVIEW%>

--- a/packages/website/docs/_components_pages/fiori/Search/SearchItemGroup.mdx
+++ b/packages/website/docs/_components_pages/fiori/Search/SearchItemGroup.mdx
@@ -1,6 +1,5 @@
 ---
 slug: ../SearchItemGroup
-sidebar_class_name: newComponentBadge
 ---
 
 <%COMPONENT_OVERVIEW%>

--- a/packages/website/docs/_components_pages/fiori/Search/SearchMessageArea.mdx
+++ b/packages/website/docs/_components_pages/fiori/Search/SearchMessageArea.mdx
@@ -1,6 +1,5 @@
 ---
 slug: ../SearchMessageArea
-sidebar_class_name: newComponentBadge
 ---
 
 <%COMPONENT_OVERVIEW%>

--- a/packages/website/docs/_components_pages/fiori/Search/SearchScope.mdx
+++ b/packages/website/docs/_components_pages/fiori/Search/SearchScope.mdx
@@ -1,6 +1,5 @@
 ---
 slug: ../SearchScope
-sidebar_class_name: newComponentBadge
 ---
 
 <%COMPONENT_OVERVIEW%>

--- a/packages/website/docs/_components_pages/fiori/ShellBar/ShellBarBranding.mdx
+++ b/packages/website/docs/_components_pages/fiori/ShellBar/ShellBarBranding.mdx
@@ -1,6 +1,5 @@
 ---
 slug: ../ShellBarBranding
-sidebar_class_name: newComponentBadge
 ---
 
 <%COMPONENT_OVERVIEW%>

--- a/packages/website/docs/_components_pages/fiori/ShellBar/ShellBarSpacer.mdx
+++ b/packages/website/docs/_components_pages/fiori/ShellBar/ShellBarSpacer.mdx
@@ -1,6 +1,5 @@
 ---
 slug: ../ShellBarSpacer
-sidebar_class_name: newComponentBadge
 ---
 
 <%COMPONENT_OVERVIEW%>

--- a/packages/website/docs/_components_pages/fiori/UserMenu/UserMenu.mdx
+++ b/packages/website/docs/_components_pages/fiori/UserMenu/UserMenu.mdx
@@ -1,6 +1,5 @@
 ---
 slug: ../UserMenu
-sidebar_class_name: newComponentBadge
 ---
 
 import Basic from "../../../_samples/fiori/UserMenu/Basic/Basic.md";

--- a/packages/website/docs/_components_pages/fiori/UserMenu/UserMenuAccount.mdx
+++ b/packages/website/docs/_components_pages/fiori/UserMenu/UserMenuAccount.mdx
@@ -1,6 +1,5 @@
 ---
 slug: ../UserMenuAccount
-sidebar_class_name: newComponentBadge
 ---
 
 <%COMPONENT_OVERVIEW%>

--- a/packages/website/docs/_components_pages/fiori/UserMenu/UserMenuItem.mdx
+++ b/packages/website/docs/_components_pages/fiori/UserMenu/UserMenuItem.mdx
@@ -1,6 +1,5 @@
 ---
 slug: ../UserMenuItem
-sidebar_class_name: newComponentBadge
 ---
 
 <%COMPONENT_OVERVIEW%>

--- a/packages/website/docs/_components_pages/fiori/UserMenu/UserMenuItemGroup.mdx
+++ b/packages/website/docs/_components_pages/fiori/UserMenu/UserMenuItemGroup.mdx
@@ -1,6 +1,5 @@
 ---
 slug: ../UserMenuItemGroup
-sidebar_class_name: newComponentBadge
 ---
 
 <%COMPONENT_OVERVIEW%>

--- a/packages/website/docs/_components_pages/fiori/UserSettingsDialog/UserSettingsAccountView.mdx
+++ b/packages/website/docs/_components_pages/fiori/UserSettingsDialog/UserSettingsAccountView.mdx
@@ -1,6 +1,5 @@
 ---
 slug: ../UserSettingsAccountView
-sidebar_class_name: newComponentBadge
 ---
 
 <%COMPONENT_OVERVIEW%>

--- a/packages/website/docs/_components_pages/fiori/UserSettingsDialog/UserSettingsAppearanceView.mdx
+++ b/packages/website/docs/_components_pages/fiori/UserSettingsDialog/UserSettingsAppearanceView.mdx
@@ -1,6 +1,5 @@
 ---
 slug: ../UserSettingsAppearanceView
-sidebar_class_name: newComponentBadge
 ---
 
 <%COMPONENT_OVERVIEW%>

--- a/packages/website/docs/_components_pages/fiori/UserSettingsDialog/UserSettingsAppearanceViewGroup.mdx
+++ b/packages/website/docs/_components_pages/fiori/UserSettingsDialog/UserSettingsAppearanceViewGroup.mdx
@@ -1,6 +1,5 @@
 ---
 slug: ../UserSettingsAppearanceViewGroup
-sidebar_class_name: newComponentBadge
 ---
 
 <%COMPONENT_OVERVIEW%>

--- a/packages/website/docs/_components_pages/fiori/UserSettingsDialog/UserSettingsAppearanceViewItem.mdx
+++ b/packages/website/docs/_components_pages/fiori/UserSettingsDialog/UserSettingsAppearanceViewItem.mdx
@@ -1,6 +1,5 @@
 ---
 slug: ../UserSettingsAppearanceViewItem
-sidebar_class_name: newComponentBadge
 ---
 
 <%COMPONENT_OVERVIEW%>

--- a/packages/website/docs/_components_pages/fiori/UserSettingsDialog/UserSettingsDialog.mdx
+++ b/packages/website/docs/_components_pages/fiori/UserSettingsDialog/UserSettingsDialog.mdx
@@ -1,6 +1,5 @@
 ---
 slug: ../UserSettingsDialog
-sidebar_class_name: newComponentBadge
 ---
 
 import Basic from "../../../_samples/fiori/UserSettingsDialog/Basic/Basic.md";

--- a/packages/website/docs/_components_pages/fiori/UserSettingsDialog/UserSettingsItem.mdx
+++ b/packages/website/docs/_components_pages/fiori/UserSettingsDialog/UserSettingsItem.mdx
@@ -1,6 +1,5 @@
 ---
 slug: ../UserSettingsItem
-sidebar_class_name: newComponentBadge
 ---
 
 <%COMPONENT_OVERVIEW%>

--- a/packages/website/docs/_components_pages/fiori/UserSettingsDialog/UserSettingsView.mdx
+++ b/packages/website/docs/_components_pages/fiori/UserSettingsDialog/UserSettingsView.mdx
@@ -1,6 +1,5 @@
 ---
 slug: ../UserSettingsView
-sidebar_class_name: newComponentBadge
 ---
 
 <%COMPONENT_OVERVIEW%>

--- a/packages/website/docs/_components_pages/fiori/ViewSettingsDialog/ViewSettingsDialogCustomTab.mdx
+++ b/packages/website/docs/_components_pages/fiori/ViewSettingsDialog/ViewSettingsDialogCustomTab.mdx
@@ -1,6 +1,5 @@
 ---
 slug: ../ViewSettingsDialogCustomTab
-sidebar_class_name: newComponentBadge
 ---
 
 <%COMPONENT_OVERVIEW%>

--- a/packages/website/docs/_components_pages/main/Avatar/AvatarBadge.mdx
+++ b/packages/website/docs/_components_pages/main/Avatar/AvatarBadge.mdx
@@ -1,6 +1,5 @@
 ---
 slug: ../../AvatarBadge
-sidebar_class_name: newComponentBadge
 ---
 
 import Basic from "../../../_samples/main/AvatarBadge/Basic/Basic.md";

--- a/packages/website/docs/_components_pages/main/Button/ButtonBadge.mdx
+++ b/packages/website/docs/_components_pages/main/Button/ButtonBadge.mdx
@@ -1,6 +1,5 @@
 ---
 slug: ../../ButtonBadge
-sidebar_class_name: newComponentBadge
 ---
 
 <%COMPONENT_OVERVIEW%>

--- a/packages/website/docs/_components_pages/main/DynamicDateRange.mdx
+++ b/packages/website/docs/_components_pages/main/DynamicDateRange.mdx
@@ -1,7 +1,3 @@
----
-sidebar_class_name: newComponentBadge
----
-
 import Basic from "../../_samples/main/DynamicDateRange/Basic/Basic.md";
 import DynamicDateRangeValueSample from "../../_samples/main/DynamicDateRange/DynamicDateRangeValueSample/DynamicDateRangeValueSample.md";
 

--- a/packages/website/docs/_components_pages/main/ExpandableText.mdx
+++ b/packages/website/docs/_components_pages/main/ExpandableText.mdx
@@ -1,6 +1,5 @@
 ---
 slug: ../ExpandableText
-sidebar_class_name: newComponentBadge
 ---
 
 import Basic from "../../_samples/main/ExpandableText/Basic/Basic.md";

--- a/packages/website/docs/_components_pages/main/Menu/MenuItemGroup.mdx
+++ b/packages/website/docs/_components_pages/main/Menu/MenuItemGroup.mdx
@@ -1,6 +1,5 @@
 ---
 slug: ../../MenuItemGroup
-sidebar_class_name: newComponentBadge
 ---
 
 <%COMPONENT_OVERVIEW%>

--- a/packages/website/docs/_components_pages/main/Toolbar/ToolbarItem.mdx
+++ b/packages/website/docs/_components_pages/main/Toolbar/ToolbarItem.mdx
@@ -1,6 +1,5 @@
 ---
 slug: ../../ToolbarItem
-sidebar_class_name: newComponentBadge
 ---
 
 <%COMPONENT_OVERVIEW%>

--- a/packages/website/docs/components/patterns/AI Acknowledgement.mdx
+++ b/packages/website/docs/components/patterns/AI Acknowledgement.mdx
@@ -1,7 +1,3 @@
----
-sidebar_class_name: newComponentBadge
----
-
 import StandardAcknowledgement from "../../_samples/patterns/AIAcknowledgement/StandardAcknowledgement/StandardAcknowledgement.md";
 import ScrollToAccept from "../../_samples/patterns/AIAcknowledgement/ScrollToAccept/ScrollToAccept.md";
 

--- a/packages/website/docs/components/patterns/AI CustomPrompt/AI CustomPrompt.mdx
+++ b/packages/website/docs/components/patterns/AI CustomPrompt/AI CustomPrompt.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_class_name: newComponentBadge expComponentBadge
+sidebar_class_name: expComponentBadge
 ---
 
 :::info

--- a/packages/website/docs/components/patterns/AI CustomPrompt/Level 1.mdx
+++ b/packages/website/docs/components/patterns/AI CustomPrompt/Level 1.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_class_name: newComponentBadge expComponentBadge
+sidebar_class_name: expComponentBadge
 ---
 
 import html from '!!raw-loader!./Level 1/sample.html';

--- a/packages/website/docs/components/patterns/AI CustomPrompt/Level 2.mdx
+++ b/packages/website/docs/components/patterns/AI CustomPrompt/Level 2.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_class_name: newComponentBadge expComponentBadge
+sidebar_class_name: expComponentBadge
 ---
 
 import html from '!!raw-loader!./Level 2/sample.html';

--- a/packages/website/docs/components/patterns/AI CustomPrompt/Level 3.mdx
+++ b/packages/website/docs/components/patterns/AI CustomPrompt/Level 3.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_class_name: newComponentBadge expComponentBadge
+sidebar_class_name: expComponentBadge
 ---
 
 import html from '!!raw-loader!./Level 3/sample.html';

--- a/packages/website/docs/components/patterns/AI CustomPrompt/Level 4.mdx
+++ b/packages/website/docs/components/patterns/AI CustomPrompt/Level 4.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_class_name: newComponentBadge expComponentBadge
+sidebar_class_name: expComponentBadge
 ---
 
 import html from '!!raw-loader!./Level 4/sample.html';

--- a/packages/website/docs/components/patterns/AI GuidedPrompt.mdx
+++ b/packages/website/docs/components/patterns/AI GuidedPrompt.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_class_name: newComponentBadge expComponentBadge
+sidebar_class_name: expComponentBadge
 ---
 
 import Dialog from "../../_samples/patterns/AIGuidedPrompt/Dialog/Dialog.md";

--- a/packages/website/docs/components/patterns/AI QuickPrompt.mdx
+++ b/packages/website/docs/components/patterns/AI QuickPrompt.mdx
@@ -1,7 +1,3 @@
----
-sidebar_class_name: newComponentBadge
----
-
 import Basic from "../../_samples/patterns/AIQuickPrompt/Basic.md";
 
 ### Overview

--- a/packages/website/docs/components/patterns/AI Regenerate.mdx
+++ b/packages/website/docs/components/patterns/AI Regenerate.mdx
@@ -1,7 +1,3 @@
----
-sidebar_class_name: newComponentBadge
----
-
 import Basic from "../../_samples/patterns/AIRegenerate/Basic/Basic.md";
 
 ### Overview

--- a/packages/website/docs/components/patterns/SelectionAssistant/Selection Assistant.mdx
+++ b/packages/website/docs/components/patterns/SelectionAssistant/Selection Assistant.mdx
@@ -1,7 +1,3 @@
----
-sidebar_class_name: newComponentBadge
----
-
 import Input from "../../../components/patterns/SelectionAssistant/InputSelectionAssistant/Basic/Basic.md";
 import TextArea from "../../../components/patterns/SelectionAssistant/TextAreaSelectionAssistant/Basic/Basic.md";
 

--- a/packages/website/docs/components/patterns/UXC Integration.mdx
+++ b/packages/website/docs/components/patterns/UXC Integration.mdx
@@ -1,7 +1,3 @@
----
-sidebar_class_name: newComponentBadge
----
-
 import Basic from "../../_samples/patterns/UXCIntegration/Basic/Basic.md";
 
 ### Overview


### PR DESCRIPTION
## Summary

Two related cleanups bundled together.

### 1. Remove private `Group` from `ListItemAccessibleRole` enum

The `Group` entry was marked `@private` and excluded from `ListItem`'s public `accessibleRole` type via `Exclude<...>`. Drop it from the enum entirely and inline `"Group"` as a string-literal union on `ListItemGroupHeader` — the only consumer that needed it.

- **`ListItemAccessibleRole`** — remove the private `Group` entry
- **`ListItem`** — drop the `Exclude<…, Group>` wrapper (now redundant); bump `@since` to `2.23.0`
- **`ListItemGroupHeader`** — keep `"Group"` as a string-literal in the property type

### 2. Drop `item` / `tab` from click event detail on `ui5-tab` and `ui5-li-notification`

The click event detail carried an `item`/`tab` reference that duplicated `event.target`. Remove the redundant field — consumers can read the source from `event.target` instead.

- **`Tab`** — remove `tab` from `TabClickEventDetail` and the JSDoc `@param tab`
- **`TabContainer`** — stop passing `tab` when firing click on the selected tab
- **`NotificationListItem`** — remove `item` from `NotificationListItemClickEventDetail` and the JSDoc `@param item`; stop passing `item` when firing click

## Test

No behavior change for the enum cleanup. For the click events, source resolution is identical via `event.target`.