### PR TITLE
fix(ui5-toolbar): fix visual findings in the toolbar

### DIFF
--- a/packages/main/cypress/specs/Toolbar.cy.tsx
+++ b/packages/main/cypress/specs/Toolbar.cy.tsx
@@ -483,10 +483,8 @@ describe("Toolbar general interaction", () => {
 		cy.viewport(800, 1080);
 
 		// Verify the focus shifts to the last interactive element outside the overflow popover
-		cy.get("[ui5-toolbar]")
-			.shadow()
-			.find(".ui5-tb-item")
-			.eq(3)
+		cy.get("[ui5-toolbar-button]")
+			.last()
 			.should("be.focused");
 	});
 

--- a/packages/main/src/Toolbar.ts
+++ b/packages/main/src/Toolbar.ts
@@ -302,7 +302,7 @@ class Toolbar extends UI5Element {
 		this.detachListeners();
 		this.attachListeners();
 		if (getActiveElement() === this.overflowButtonDOM?.getFocusDomRef() && this.hideOverflowButton) {
-			const lastItem = this.interactiveItems.at(-1);
+			const lastItem = this.standardItems.filter(item => item.isInteractive).at(-1);
 			lastItem?.focus();
 		}
 		this.prePopulateAlwaysOverflowItems();

--- a/packages/main/src/themes/Toolbar.css
+++ b/packages/main/src/themes/Toolbar.css
@@ -6,7 +6,7 @@
 	justify-content: flex-end;
 	box-sizing: border-box;
 	border-bottom: var(--sapGroup_TitleBorderWidth) solid var(--sapGroup_TitleBorderColor);
-	padding: 0 var(--_ui5-toolbar-padding-left) 0 var(--_ui5-toolbar-padding-right);
+	padding: 0 var(--_ui5-toolbar-padding-right) 0 var(--_ui5-toolbar-padding-left);
 	background-color: var(--sapToolbar_Background);
 }
 

--- a/packages/main/src/themes/ToolbarItem.css
+++ b/packages/main/src/themes/ToolbarItem.css
@@ -1,5 +1,4 @@
 :host {
-	display: inline-block;
 	height: 100%;
 }
 

--- a/packages/main/src/themes/base/Toolbar-parameters.css
+++ b/packages/main/src/themes/base/Toolbar-parameters.css
@@ -2,5 +2,5 @@
     --_ui5-toolbar-padding-left: 0.5rem;
 	--_ui5-toolbar-padding-right: 0.5rem;
 	--_ui5-toolbar-item-margin-left: 0;
-	--_ui5-toolbar-item-margin-right: 0.25rem;
+	--_ui5-toolbar-item-margin-right: 0.5rem;
 }


### PR DESCRIPTION
Three CSS bugs in `ui5-toolbar` identified via visual spec analysis against the AI test review.

## Changes

- **`Toolbar.css`** — Fix swapped variable names in `padding` shorthand. `padding: 0 right 0 left` was referencing `--_ui5-toolbar-padding-left` for the right slot and vice versa:
  ```css
  /* Before (wrong) */
  padding: 0 var(--_ui5-toolbar-padding-left) 0 var(--_ui5-toolbar-padding-right);

  /* After (correct) */
  padding: 0 var(--_ui5-toolbar-padding-right) 0 var(--_ui5-toolbar-padding-left);
  ```

- **`Toolbar-parameters.css`** — Bump `--_ui5-toolbar-item-margin-right` from `0.25rem` → `0.5rem` to match the visual spec.

- **`ToolbarItem.css`** — Remove `display: inline-block` from `:host`. This was preventing flex-based responsive sizing for slotted content (e.g. `ui5-breadcrumbs`) because inline-block constrains the host to shrink-to-content width rather than participating correctly in the toolbar's flex layout.
Fixes: #13508 