### PR TITLE
fix(OpenUI5Support): move popover to top of top layer

### DIFF
--- a/packages/base/src/features/patchPopup.ts
+++ b/packages/base/src/features/patchPopup.ts
@@ -131,6 +131,7 @@ const openNativePopoverForOpenUI5 = (popup: OpenUI5Popup) => {
 	}
 
 	domRef.setAttribute("popover", "manual");
+	domRef.hidePopover();
 	domRef.showPopover();
 };
 

--- a/packages/main/cypress/specs/OpenUI5andWebCPopups.webCPopoverOpenUI5Dialog.cy.tsx
+++ b/packages/main/cypress/specs/OpenUI5andWebCPopups.webCPopoverOpenUI5Dialog.cy.tsx
@@ -52,16 +52,20 @@ function onOpenUI5InitMethod(win: any) {
 }
 
 function mountFixtures() {
-	cy.document().then((doc) => {
-		doc.body.innerHTML = `
+	cy.mount(
+		<>
 			<div id="content"></div>
+			{/* @ts-ignore */}
 			<ui5-button id="btnPopup">Open Popover web component</ui5-button>
+			{/* @ts-ignore */}
 			<ui5-popover id="popup" header-text="Popover">
 				<div>2. Click the button</div>
+				{/* @ts-ignore */}
 				<ui5-button id="nestedOpener">Open Dialog OpenUI5</ui5-button>
+				{/* @ts-ignore */}
 			</ui5-popover>
-		`;
-	});
+		</>
+	);
 
 	cy.window().then((win) => {
 		if (!(win as any).sap?.ui) {

--- a/packages/main/cypress/specs/OpenUI5andWebCPopups.webCPopoverOpenUI5Dialog.cy.tsx
+++ b/packages/main/cypress/specs/OpenUI5andWebCPopups.webCPopoverOpenUI5Dialog.cy.tsx
@@ -1,0 +1,145 @@
+// Popover is intentionally imported dynamically inside onOpenUI5InitMethod
+// to reproduce the problematic import order:
+//   1. OpenUI5 initializes and places an OpenUI5-wrapped web component in DOM
+//   2. After a delay, a separate script loads OpenUI5Support + native web components
+//   3. OpenUI5Support.init() patches Popup
+//   4. Popover and Button are registered
+// Without the fix, opening an OpenUI5 Dialog on top of a WebC Popover would
+// not move the dialog to the top of the top layer.
+
+function onOpenUI5InitMethod(win: any) {
+	// Step 1: place the OpenUI5-wrapped web component (triggers OpenUI5's own WC runtime)
+	(win as any).sap.ui.require(
+		["sap/f/gen/ui5/webcomponents/dist/Button"],
+		(WrappedButton: any) => {
+			new WrappedButton({
+				text: `Web Component via OpenUI5 ${(win as any).sap.ui.getVersionInfo().version}`,
+			}).placeAt("content");
+		}
+	);
+
+	// Step 2: after a delay, load the native web components (simulates a separate app script)
+	setTimeout(async () => {
+		const OpenUI5Support = (await import("@ui5/webcomponents-base/dist/features/OpenUI5Support.js")).default;
+
+		await (OpenUI5Support as any).init();
+
+		await import("../../src/Popover.js");
+		await import("../../src/Button.js");
+
+		const btnPopup = document.getElementById("btnPopup");
+		const popup = document.getElementById("popup") as any;
+
+		btnPopup?.addEventListener("click", () => {
+			popup.opener = btnPopup;
+			popup.open = true;
+		});
+
+		document.getElementById("nestedOpener")?.addEventListener("click", () => {
+			(win as any).sap.ui.require(["sap/m/Dialog", "sap/m/Text"], (Dialog: any, Text: any) => {
+				new Dialog("openUI5Dialog", {
+					content: new Text({ text: "Observe the backdrop" }),
+					afterClose: function () {
+						this.destroy();
+					}
+				}).open();
+				popup.open = false;
+			});
+		});
+
+		(win as any).openUI5InitDone = true;
+	}, 1000);
+}
+
+function mountFixtures() {
+	cy.document().then((doc) => {
+		doc.body.innerHTML = `
+			<div id="content"></div>
+			<ui5-button id="btnPopup">Open Popover web component</ui5-button>
+			<ui5-popover id="popup" header-text="Popover">
+				<div>2. Click the button</div>
+				<ui5-button id="nestedOpener">Open Dialog OpenUI5</ui5-button>
+			</ui5-popover>
+		`;
+	});
+
+	cy.window().then((win) => {
+		if (!(win as any).sap?.ui) {
+			(win as any).onOpenUI5Init = function () {
+				onOpenUI5InitMethod(win);
+			};
+		} else {
+			onOpenUI5InitMethod(win);
+		}
+	});
+
+	cy.document().then((doc) => {
+		const ui5Script = doc.createElement("script");
+		ui5Script.src = "https://ui5.sap.com/resources/sap-ui-core.js";
+		ui5Script.id = "sap-ui-bootstrap";
+		ui5Script.setAttribute("data-sap-ui-libs", "sap.m, sap.f");
+		ui5Script.setAttribute("data-sap-ui-oninit", "onOpenUI5Init");
+		doc.head.appendChild(ui5Script);
+	});
+}
+
+function cleanupFixtures() {
+	cy.window().then((win) => {
+		delete (win as any).openUI5InitDone;
+		const sap = (win as any).sap;
+		if (sap?.ui?.require) {
+			sap.ui.require(["sap/ui/core/Element"], (Element: any) => {
+				const el = Element.getElementById("openUI5Dialog");
+				if (el) {
+					el.destroy();
+				}
+			});
+		}
+	});
+
+	cy.document().then((doc) => {
+		const ui5Script = doc.head.querySelector("[data-sap-ui-oninit]") as HTMLScriptElement;
+		if (ui5Script) {
+			ui5Script.remove();
+		}
+	});
+}
+
+describe("WebC Popover + OpenUI5 Dialog integration", () => {
+	beforeEach(() => { mountFixtures(); });
+	afterEach(() => { cleanupFixtures(); });
+
+	it("Opening OpenUI5 Dialog from inside WebC Popover moves the dialog to the top of the top layer", () => {
+		// Wait for OpenUI5 to initialize, OpenUI5Support to patch Popup, and Popover to be registered
+		cy.window({ timeout: 15000 }).should((win) => {
+			expect((win as any).openUI5InitDone).to.be.true;
+		});
+
+		cy.get("#btnPopup")
+			.should("be.visible")
+			.realClick();
+
+		cy.get("#popup").should("be.visible");
+
+		cy.get("#nestedOpener")
+			.should("be.visible")
+			.realClick();
+
+		// The popover should close
+		cy.get("#popup")
+			.should("not.be.visible");
+
+		// The OpenUI5 Dialog should be visible
+		cy.get("#openUI5Dialog")
+			.should("be.visible");
+
+		// The dialog DOM element should be promoted to the native top layer
+		cy.get("#openUI5Dialog").then(($dialog) => {
+			expect($dialog[0].matches(":popover-open")).to.be.true;
+		});
+
+		cy.get("#sap-ui-blocklayer-popup").then(($blockLayer) => {
+			expect($blockLayer[0].matches(":popover-open")).to.exist;
+		});
+	});
+});

--- a/packages/main/test/pages/PopoverAndOpenUI5Dialog.html
+++ b/packages/main/test/pages/PopoverAndOpenUI5Dialog.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+	<meta charset="UTF-8" />
+	<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+	<title>Vite + JS</title>
+
+	<script id="sap-ui-bootstrap" src="https://ui5.sap.com/resources/sap-ui-core.js"
+		data-sap-ui-libs="sap.m, sap.ui.core, sap.f" data-sap-ui-preload="async"></script>
+
+	<script>
+		sap.ui.getCore().attachInit(function () {
+			sap.ui.require(
+				['sap/f/gen/ui5/webcomponents/dist/Button'],
+				(Button) => {
+					new Button({
+						text: `Web Component via OpenUI5 ${sap.ui.getVersionInfo().version
+							}`,
+					}).placeAt('content');
+				}
+			);
+
+			setTimeout(async () => {
+				const OpenUI5Support = (await import("../../../base/src/features/OpenUI5Support.ts")).default;
+				await OpenUI5Support.init();
+
+				await import("../../src/Popover.ts");
+				await import("../../src/Button.ts");
+			}, 1000);
+		});
+	</script>
+</head>
+
+<body class="openui51auto">
+	<div id="content"></div>
+	<br />
+	<div>1. Click the button</div>
+	<br />
+	<ui5-button id="btnPopup">Open Popover web component</ui5-button>
+	<ui5-popover id="popup" header-text="Popover">
+		<div>2. Click the button</div>
+		<ui5-button id="nestedOpener">Open Dialog OpenUI5</ui5-button>
+	</ui5-popover>
+
+	<script>
+		btnPopup.addEventListener('click', () => {
+			popup.opener = btnPopup;
+			popup.open = true;
+		});
+		nestedOpener.addEventListener('click', () => {
+			const dialog = new sap.m.Dialog({
+				content: new sap.m.Text({ text: 'Observe the backdrop' }),
+			});
+			dialog.open();
+			popup.open = false;
+		});
+	</script>
+</body>
+
+</html>


### PR DESCRIPTION
On every call, the block layer is hidden and shown again, which moves it to the top of the top layer. The popover is then shown, but since showPopover() does not move an already open popover, it stays below the block layer. Calling hidePopover() before showPopover() ensures the popover is always added on top.

Fixes: https://github.com/UI5/webcomponents/issues/13635