### PR TITLE
ci: update dev-close window for v2.24 (24.06 → 09.07)

### DIFF
--- a/.github/workflows/pr-dev-close-notice.yaml
+++ b/.github/workflows/pr-dev-close-notice.yaml
@@ -45,7 +45,7 @@ jobs:
           script: |
             // Add new entries here when the release schedule is known.
             const DEV_CLOSE_PERIODS = [
-              { release: "next", devCloseStart: "2026-06-25", releaseDate: "2026-07-06" },
+              { release: "next", devCloseStart: "2026-06-24", releaseDate: "2026-07-09" },
             ];
 
             const today = new Date();


### PR DESCRIPTION
Updates the dev-close notice workflow with the corrected v2.24 schedule:

- `devCloseStart`: 2026-06-25 → **2026-06-24**
- `releaseDate`: 2026-07-06 → **2026-07-09**

Aligns with the schedule in #10568.