### PR TITLE
fix(framework): re-apply theme on secondary boot to detect OpenUI5 custom themes

### DIFF
--- a/packages/base/src/Boot.ts
+++ b/packages/base/src/Boot.ts
@@ -105,6 +105,7 @@ const secondaryBoot = async (): Promise<void> => {
 	await boot(); // make sure we're not in the middle of boot before re-running the skipped parts
 	await initF6Navigation();
 	attachOpenUI5SupportListeners();
+	await applyTheme(getTheme()); // Re-apply theme to detect external theme from OpenUI5 and clean up
 };
 
 /**


### PR DESCRIPTION
## Summary
- Re-apply theme during secondary boot to properly detect OpenUI5 custom themes

## Problem
When OpenUI5 loads **after** UI5 Web Components has already booted, `secondaryBoot()` is called but the theme was never re-applied. This caused the `data-ui5-theme-properties|@ui5/webcomponents-theming` stylesheet to remain in place, overriding custom themes loaded by OpenUI5.

## Solution
Add `await applyTheme(getTheme())` to `secondaryBoot()`. When this runs:
1. `detectExternalTheme()` will now find OpenUI5's theme (since OpenUI5 is loaded)
2. `deleteThemeBase()` will be called, removing the unnecessary theme properties stylesheet
3. The custom theme from OpenUI5 will be properly respected

## Test plan
- [ ] Test with an app where OpenUI5 loads after UI5 Web Components
- [ ] Verify `data-ui5-theme-properties|@ui5/webcomponents-theming` stylesheet is removed after OpenUI5 loads with a custom theme
- [ ] Verify custom theme CSS variables from OpenUI5 are applied correctly