### PR TITLE
fix: keep table rows intact when printing and harden createInstanceChecker

### DIFF
--- a/packages/base/cypress/specs/util/createInstanceChecker.cy.tsx
+++ b/packages/base/cypress/specs/util/createInstanceChecker.cy.tsx
@@ -1,0 +1,31 @@
+import createInstanceChecker from "../../../src/util/createInstanceChecker.js";
+
+interface MyItem {
+	isMyItem: boolean;
+}
+
+const isInstanceOfMyItem = createInstanceChecker<MyItem>("isMyItem");
+
+describe("createInstanceChecker", () => {
+	it("returns false for undefined", () => {
+		expect(isInstanceOfMyItem(undefined)).to.equal(false);
+	});
+
+	it("returns false for null", () => {
+		expect(isInstanceOfMyItem(null)).to.equal(false);
+	});
+
+	it("returns false when the marker property is missing", () => {
+		expect(isInstanceOfMyItem({})).to.equal(false);
+	});
+
+	it("returns false when the marker property is not strictly true", () => {
+		expect(isInstanceOfMyItem({ isMyItem: false })).to.equal(false);
+		expect(isInstanceOfMyItem({ isMyItem: 1 })).to.equal(false);
+		expect(isInstanceOfMyItem({ isMyItem: "true" })).to.equal(false);
+	});
+
+	it("returns true when the marker property is strictly true", () => {
+		expect(isInstanceOfMyItem({ isMyItem: true })).to.equal(true);
+	});
+});

--- a/packages/base/src/util/createInstanceChecker.ts
+++ b/packages/base/src/util/createInstanceChecker.ts
@@ -1,7 +1,7 @@
 // createInstanceChecker<A>("isAItem")
 function createChecker<T, P extends keyof T = keyof T>(prop: P) {
 	return (object: any): object is T => {
-		return object !== undefined && prop in object && object[prop] === true;
+		return object !== undefined && object !== null && prop in object && object[prop] === true;
 	};
 }
 

--- a/packages/main/cypress/specs/Table.cy.tsx
+++ b/packages/main/cypress/specs/Table.cy.tsx
@@ -51,6 +51,10 @@ describe("Table - Rendering", () => {
 		cy.get("@innerTable").should("have.attr", "role", "grid");
 		cy.get("@innerTable").should("have.attr", "aria-colcount", "2");
 		cy.get("@innerTable").should("have.attr", "aria-rowcount", "2");
+
+		cy.get("[ui5-table-row]").then($row => {
+			expect(getComputedStyle($row[0]).breakInside).to.equal("avoid");
+		});
 	});
 
 	it("tests if initial empty table renders without errors", () => {

--- a/packages/main/src/themes/TableRowBase.css
+++ b/packages/main/src/themes/TableRowBase.css
@@ -5,6 +5,7 @@
 	min-height: var(--_ui5_list_item_base_height);
 	box-sizing: content-box;
 	overflow: clip;
+	break-inside: avoid;
 }
 
 #selection-cell,


### PR DESCRIPTION
 - Add `break-inside: avoid` to `TableRowBase` so rows are not split across pages when the table is printed.
Fixes:  #13689

 - `createInstanceChecker` now also rejects `null` (previously `prop in null` threw a TypeError); aligns it with
  `createMultiInstanceChecker`.
Fixes: #13684 
