### PR TITLE
docs(ui5-bar): clarify accessibleRole usage

### DIFF
--- a/packages/main/src/Bar.ts
+++ b/packages/main/src/Bar.ts
@@ -74,9 +74,11 @@ class Bar extends UI5Element {
 	 *
 	 * **Note:**
 	 *
-	 * - Set accessibleRole to "toolbar" only when the component contains two or more active, interactive elements (such as buttons, links, or input fields) within the bar.
+	 * - By default, accessibleRole is set to "Toolbar", which renders the ARIA role "toolbar".
 	 *
-	 * - If there is only one or no active element, it is recommended to avoid using the "toolbar" role, as it implies a grouping of multiple interactive controls.
+	 * - Use the default accessibleRole value "Toolbar" only when the component contains two or more active, interactive elements (such as buttons, links, or input fields) within the bar.
+	 *
+	 * - If there is only one or no active element, set accessibleRole to "None" to avoid rendering the ARIA role "toolbar", as that role implies a grouping of multiple interactive controls.
 	 *
 	 * @public
 	 * @default "Toolbar"

--- a/packages/website/docs/_samples/main/Bar/AccessibleRole/sample.html
+++ b/packages/website/docs/_samples/main/Bar/AccessibleRole/sample.html
@@ -9,14 +9,14 @@
 <body style="background-color: var(--sapBackgroundColor)">
 <!-- playground-fold-end -->
     <ui5-label show-colon>Bar with two or more active items</ui5-label>
-    <ui5-bar design="Header" accessible-role="Toolbar">
+    <ui5-bar design="Header">
         <ui5-button icon="home" tooltip="Go home" design="Transparent" slot="startContent"></ui5-button>
         <ui5-label id="basic-label">Content</ui5-label>
         <ui5-button icon="action-settings" tooltip="Go to settings" slot="endContent"></ui5-button>
     </ui5-bar>
     <br>
     <ui5-label show-colon>Bar with less than two active items</ui5-label>
-    <ui5-bar design="Header">
+    <ui5-bar design="Header" accessible-role="None">
         <ui5-label id="basic-label">Storybook title</ui5-label>
     </ui5-bar>
 <!-- playground-fold -->

--- a/packages/website/docs/_samples/main/Bar/AccessibleRole/sample.tsx
+++ b/packages/website/docs/_samples/main/Bar/AccessibleRole/sample.tsx
@@ -13,7 +13,7 @@ function App() {
   return (
     <>
       <Label showColon={true}>Bar with two or more active items</Label>
-      <Bar design="Header" accessibleRole="Toolbar">
+      <Bar design="Header">
         <Button
           icon="home"
           tooltip="Go home"
@@ -29,7 +29,7 @@ function App() {
       </Bar>
       <br />
       <Label showColon={true}>Bar with less than two active items</Label>
-      <Bar design="Header">
+      <Bar design="Header" accessibleRole="None">
         <Label id="basic-label">Storybook title</Label>
       </Bar>
     </>


### PR DESCRIPTION
**Issue description:**

The accessibleRole documentation of ui5-bar was ambiguous because the property defaults to Toolbar, while the note suggested that application developers should set it to Toolbar only when the bar contains two or more interactive elements. This made the API usage unclear and also caused the playground sample to demonstrate redundant and incomplete usage.

**Solution:**

Clarify the documentation by explicitly distinguishing the accessibleRole enum values Toolbar and None from the rendered ARIA role toolbar. Document that Toolbar is the default value and that application developers should set accessibleRole to None when the bar contains fewer than two interactive elements. Update the playground sample accordingly by removing the redundant accessible-role=Toolbar from the first example and setting accessible-role=None on the second one.

Related to: #13562