### PR TITLE
feat(ui5-barcode-scanner-dialog): add format to scan-success event payload

### DIFF
--- a/packages/fiori/cypress/specs/BarcodeScannerDialog.cy.tsx
+++ b/packages/fiori/cypress/specs/BarcodeScannerDialog.cy.tsx
@@ -279,11 +279,55 @@ describe("BarcodeScannerDialog", () => {
 			dlgScan.fireDecoratorEvent("scan-success", {
 				text: "mocked-scan-result",
 				rawBytes: new Uint8Array(),
+				format: "QR_CODE",
 			});
 		});
 
 		// Check that the scan result is displayed
 		cy.get("@scanResult").should("have.text", "mocked-scan-result");
+	});
+
+	it("includes barcode format string in scan-success event detail", () => {
+		let capturedDetail: { text: string; rawBytes: Uint8Array; format: string } | undefined;
+
+		handleScanSuccess = (event: CustomEvent) => {
+			capturedDetail = event.detail;
+		};
+
+		cy.get("@dialog").then($dialog => {
+			const dlgScan = $dialog.get(0) as BarcodeScannerDialog;
+			dlgScan.addEventListener("scan-success", handleScanSuccess as EventListener);
+		});
+
+		cy.get("@button").realClick();
+
+		// Wait for video to be ready (scan interval has started)
+		cy.get("@videoElement").should($video => {
+			const videoEl = $video[0] as HTMLVideoElement;
+			expect(videoEl.readyState, "Video readyState should be >= 1").to.be.at.least(1);
+		});
+
+		// Now stub _processFrame to call _handleScanSuccess with a mock Result returning QR_CODE format (11)
+		cy.get("@dialog").then($dialog => {
+			const dlgScan = $dialog.get(0) as BarcodeScannerDialog;
+			const stub = cy.stub(dlgScan, "_processFrame").callsFake(() => {
+				dlgScan._handleScanSuccess({
+					getText: () => "mock-value",
+					getRawBytes: () => new Uint8Array(),
+					getBarcodeFormat: () => 11, // BarcodeFormat.QR_CODE
+				} as any);
+			});
+			cy.wrap(stub).as("processFrameStub");
+		});
+
+		// Wait for the stub to be called at least once (scan interval is 200ms)
+		cy.get("@processFrameStub").should("have.been.called");
+
+		cy.then(() => {
+			expect(capturedDetail).to.not.be.undefined;
+			expect(capturedDetail!.text).to.equal("mock-value");
+			expect(capturedDetail!.format).to.equal("QR_CODE");
+		});
 	});
 
 	it("handles scan error event", () => {

--- a/packages/fiori/src/BarcodeScannerDialog-zxing.d.ts
+++ b/packages/fiori/src/BarcodeScannerDialog-zxing.d.ts
@@ -1,6 +1,7 @@
 declare module "@zxing/library/umd/index.min.js" {
-	import type { BrowserMultiFormatReader as BrowserMultiFormatReaderT, NotFoundException as NotFoundExceptionT } from "@zxing/library";
+	import type { BrowserMultiFormatReader as BrowserMultiFormatReaderT, NotFoundException as NotFoundExceptionT, BarcodeFormat as BarcodeFormatT } from "@zxing/library";
 
 	export const BrowserMultiFormatReader: typeof BrowserMultiFormatReaderT;
 	export const NotFoundException: typeof NotFoundExceptionT;
+	export const BarcodeFormat: typeof BarcodeFormatT;
 }

--- a/packages/fiori/src/BarcodeScannerDialog.ts
+++ b/packages/fiori/src/BarcodeScannerDialog.ts
@@ -44,24 +44,7 @@ const defaultMediaConstraints = {
 	},
 };
 
-type BarcodeFormatString =
-	| "AZTEC"
-	| "CODABAR"
-	| "CODE_39"
-	| "CODE_93"
-	| "CODE_128"
-	| "DATA_MATRIX"
-	| "EAN_8"
-	| "EAN_13"
-	| "ITF"
-	| "MAXICODE"
-	| "PDF_417"
-	| "QR_CODE"
-	| "RSS_14"
-	| "RSS_EXPANDED"
-	| "UPC_A"
-	| "UPC_E"
-	| "UPC_EAN_EXTENSION";
+type BarcodeFormatString = keyof typeof BarcodeFormat;
 
 type BarcodeScannerDialogScanSuccessEventDetail = {
 	text: string,

--- a/packages/fiori/src/BarcodeScannerDialog.ts
+++ b/packages/fiori/src/BarcodeScannerDialog.ts
@@ -29,7 +29,7 @@ import BarcodeScannerDialogCss from "./generated/themes/BarcodeScannerDialog.css
 // other tools do not handle named exports (they are undefined after the import), but the window global is assigned and can be used (web dev server)
 const windowZXing = typeof window === "undefined" ? {} : window.ZXing;
 const effectiveZXing = { ...ZXing, ...windowZXing };
-const { BrowserMultiFormatReader, NotFoundException } = effectiveZXing;
+const { BrowserMultiFormatReader, NotFoundException, BarcodeFormat } = effectiveZXing;
 
 const defaultMediaConstraints = {
 	audio: false,
@@ -44,9 +44,29 @@ const defaultMediaConstraints = {
 	},
 };
 
+type BarcodeFormatString =
+	| "AZTEC"
+	| "CODABAR"
+	| "CODE_39"
+	| "CODE_93"
+	| "CODE_128"
+	| "DATA_MATRIX"
+	| "EAN_8"
+	| "EAN_13"
+	| "ITF"
+	| "MAXICODE"
+	| "PDF_417"
+	| "QR_CODE"
+	| "RSS_14"
+	| "RSS_EXPANDED"
+	| "UPC_A"
+	| "UPC_E"
+	| "UPC_EAN_EXTENSION";
+
 type BarcodeScannerDialogScanSuccessEventDetail = {
 	text: string,
 	rawBytes: Uint8Array,
+	format: BarcodeFormatString,
 };
 
 type BarcodeScannerDialogScanErrorEventDetail = {
@@ -90,9 +110,10 @@ type BarcodeScannerDialogScanErrorEventDetail = {
 })
 
 /**
- * Fires when the scan is completed successfuuly.
+ * Fires when the scan is completed successfully.
  * @param {string} text the scan result as string
  * @param {Object} rawBytes the scan result as a Uint8Array
+ * @param {string} format the format of the scanned barcode (e.g. "QR_CODE", "EAN_13", "CODE_128")
  * @public
  */
 @event("scan-success", {
@@ -393,6 +414,7 @@ class BarcodeScannerDialog extends UI5Element {
 		this.fireDecoratorEvent("scan-success", {
 			text: result.getText(),
 			rawBytes: result.getRawBytes(),
+			format: BarcodeFormat[result.getBarcodeFormat()] as BarcodeFormatString,
 		});
 	}
 
@@ -471,4 +493,5 @@ export default BarcodeScannerDialog;
 export type {
 	BarcodeScannerDialogScanErrorEventDetail,
 	BarcodeScannerDialogScanSuccessEventDetail,
+	BarcodeFormatString,
 };


### PR DESCRIPTION
The `scan-success` event now includes a `format` field containing the barcode format string (e.g. `"QR_CODE"`, `"EAN_13"`, `"CODE_128"`) alongside the existing `text` and `rawBytes` fields.

The format is derived from ZXing's `BarcodeFormat` reverse-mapped enum, exposed as a typed string union (`BarcodeFormatString`) so consumers can do format-specific branching without depending on ZXing internals.

`BarcodeFormatString` is exported for consumer type safety.

Related to: #13490