### PR TITLE
docs(ui5-breadcrumbs): correct since tag for accessibleName

### DIFF
--- a/packages/main/src/Breadcrumbs.ts
+++ b/packages/main/src/Breadcrumbs.ts
@@ -139,7 +139,7 @@ class Breadcrumbs extends UI5Element implements IToolbarItemContent {
 	 * Defines the accessible name of the component.
 	 * @default undefined
 	 * @public
-	 * @since 2.22.0
+	 * @since 2.24.0
 	 */
 	@property()
 	accessibleName?: string;


### PR DESCRIPTION
### What

The `accessibleName` property on `ui5-breadcrumbs` was documented as `@since 2.22.0`, which is incorrect — 2.22.0 has already been released and the property was not part of it.

### Evidence

- The property was introduced in commit `9b6fea73654` ("fix(ui5-breadcrumbs): acc findings fixed"), which landed **after** the 2.23.0 release branch was cut.
- Current development version in `package.json` is `2.24.0-rc.1`; the latest released git tag is `v2.23.1`.
- So the first public release containing `accessibleName` will be **2.24.0**.

### Change

Single-line JSDoc fix in `packages/main/src/Breadcrumbs.ts`:

```diff
- * @since 2.22.0
+ * @since 2.24.0
```

Surfaced during the API review ahead of the upcoming 2.24.0 release.