### PR TITLE
fix(ui5-color-palette): stop stealing focus after keyboard navigation

### DIFF
--- a/packages/main/cypress/specs/ColorPalettePopover.cy.tsx
+++ b/packages/main/cypress/specs/ColorPalettePopover.cy.tsx
@@ -543,7 +543,7 @@ describe("Color Popover Palette arrow keys navigation", () => {
 });
 
 describe("Color Popover Palette Home and End keyboard navigation", () => {
-    it.skip("should navigate with Home/End when showDefaultColor is set", () => {
+    it("should navigate with Home/End when showDefaultColor is set", () => {
         cy.mount(
             <SimplePalettePopover showDefaultColor={true} />
         );
@@ -640,7 +640,7 @@ describe("Color Popover Palette Home and End keyboard navigation", () => {
             .should("have.attr", "aria-label", "More Colors...");
     });
 
-    it.skip("should navigate with Home/End when showDefaultColor & showMoreColors are set", () => {
+    it("should navigate with Home/End when showDefaultColor & showMoreColors are set", () => {
         cy.mount(
             <SimplePalettePopover showDefaultColor={true} showMoreColors={true} />
         );

--- a/packages/main/src/ColorPalette.ts
+++ b/packages/main/src/ColorPalette.ts
@@ -507,8 +507,9 @@ class ColorPalette extends UI5Element {
 	}
 
 	_onColorContainerKeyDown(e: KeyboardEvent) {
-		const target = e.target as ColorPaletteItem;
-		const isLastSwatchInSingleRow = this._isSingleRow() && this._isLastSwatch(target, this.displayedColors);
+		const eventTarget = e.target as ColorPaletteItem;
+		const swatchTarget = this._getColorPaletteItemFromEvent(e, this.displayedColors);
+		const isLastSwatchInSingleRow = this._isSingleRow() && swatchTarget && this._isLastSwatch(swatchTarget, this.displayedColors);
 
 		// Prevent Home/End keys from working in embedded mode - they only work in popup mode as per design
 		if (this._shouldPreventHomeEnd(e)) {
@@ -523,10 +524,10 @@ class ColorPalette extends UI5Element {
 
 		if (isTabNext(e) && this.popupMode) {
 			e.preventDefault();
-			this.selectColor(target);
+			this.selectColor(swatchTarget || eventTarget);
 		}
 
-		if (this._isPrevious(e) && this._isFirstSwatch(target, this.displayedColors)) {
+		if (this._isPrevious(e) && swatchTarget && this._isFirstSwatch(swatchTarget, this.displayedColors)) {
 			e.preventDefault();
 			e.stopPropagation();
 			this._focusFirstAvailable(
@@ -536,8 +537,8 @@ class ColorPalette extends UI5Element {
 				() => this._focusLastSwatchOfLastFullRow(),
 				() => this._focusLastDisplayedColor(),
 			);
-		} else if ((isRight(e) && this._isLastSwatch(target, this.displayedColors))
-			|| (isDown(e) && (this._isLastSwatchOfLastFullRow(target) || isLastSwatchInSingleRow))
+		} else if ((isRight(e) && swatchTarget && this._isLastSwatch(swatchTarget, this.displayedColors))
+			|| (isDown(e) && swatchTarget && (this._isLastSwatchOfLastFullRow(swatchTarget) || isLastSwatchInSingleRow))
 		) {
 			e.preventDefault();
 			e.stopPropagation();
@@ -547,7 +548,7 @@ class ColorPalette extends UI5Element {
 				() => this._focusDefaultColor(),
 				() => this._focusFirstDisplayedColor(),
 			);
-		} else if (isHome(e) && this._isFirstSwatchInRow(target)) {
+		} else if (swatchTarget && isHome(e) && this._isFirstSwatchInRow(swatchTarget)) {
 			e.preventDefault();
 			e.stopPropagation();
 			this._focusFirstAvailable(
@@ -555,7 +556,7 @@ class ColorPalette extends UI5Element {
 				() => this._focusMoreColors(),
 				() => this._focusFirstDisplayedColor(),
 			);
-		} else if (isEnd(e) && this._isLastSwatchInRow(target)) {
+		} else if (swatchTarget && isEnd(e) && this._isLastSwatchInRow(swatchTarget)) {
 			e.preventDefault();
 			e.stopPropagation();
 			this._focusFirstAvailable(
@@ -563,7 +564,7 @@ class ColorPalette extends UI5Element {
 				() => this._focusDefaultColor(),
 				() => this._focusLastDisplayedColor(),
 			);
-		} else if (isEnd(e) && this._isSwatchInLastRow(target)) {
+		} else if (swatchTarget && isEnd(e) && this._isSwatchInLastRow(swatchTarget)) {
 			e.preventDefault();
 			e.stopPropagation();
 			this._focusLastDisplayedColor();
@@ -571,7 +572,8 @@ class ColorPalette extends UI5Element {
 	}
 
 	_onRecentColorsContainerKeyDown(e: KeyboardEvent) {
-		const target = e.target as ColorPaletteItem;
+		const eventTarget = e.target as ColorPaletteItem;
+		const swatchTarget = this._getColorPaletteItemFromEvent(e, this.recentColorsElements);
 
 		// Prevent Home/End keys from working in embedded mode - they only work in popup mode as per design
 		if (this._shouldPreventHomeEnd(e)) {
@@ -584,7 +586,7 @@ class ColorPalette extends UI5Element {
 			this._currentlySelected = undefined;
 		}
 
-		if (this._isNext(e) && this._isLastSwatch(target, this.recentColorsElements)) {
+		if (this._isNext(e) && swatchTarget && this._isLastSwatch(swatchTarget, this.recentColorsElements)) {
 			e.preventDefault();
 			e.stopPropagation();
 			this._focusFirstAvailable(
@@ -592,7 +594,7 @@ class ColorPalette extends UI5Element {
 				() => this._focusMoreColors(),
 				() => this._focusFirstDisplayedColor(),
 			);
-		} else if (this._isPrevious(e) && this._isFirstSwatch(target, this.recentColorsElements)) {
+		} else if (this._isPrevious(e) && swatchTarget && this._isFirstSwatch(swatchTarget, this.recentColorsElements)) {
 			e.preventDefault();
 			e.stopPropagation();
 			this._focusFirstAvailable(
@@ -601,7 +603,7 @@ class ColorPalette extends UI5Element {
 				() => this._focusLastDisplayedColor(),
 				() => this._focusDefaultColor(),
 			);
-		} else if (isEnd(e)) {
+		} else if (swatchTarget && isEnd(e)) {
 			e.preventDefault();
 			e.stopPropagation();
 			this._focusLastRecentColor();
@@ -631,6 +633,11 @@ class ColorPalette extends UI5Element {
 
 	_isFirstSwatch(target: ColorPaletteItem, swatches: Array<ColorPaletteItem>): boolean {
 		return swatches && Boolean(swatches.length) && swatches[0] === (target);
+	}
+
+	_getColorPaletteItemFromEvent(e: KeyboardEvent, swatches: Array<ColorPaletteItem>): ColorPaletteItem | undefined {
+		const path = e.composedPath();
+		return swatches.find(swatch => path.includes(swatch));
 	}
 
 	_isLastSwatch(target: ColorPaletteItem, swatches: Array<ColorPaletteItem>): boolean {
@@ -717,7 +724,17 @@ class ColorPalette extends UI5Element {
 	 * @returns True if any candidate successfully focused an element, false if all failed.
 	 */
 	_focusFirstAvailable(...candidates: Array<() => boolean>): boolean {
-		return candidates.some(focusAction => focusAction());
+		if (!candidates.length) {
+			return false;
+		}
+
+		const [focusAction, ...remainingCandidates] = candidates;
+
+		if (focusAction()) {
+			return true;
+		}
+
+		return this._focusFirstAvailable(...remainingCandidates);
 	}
 
 	/**

--- a/packages/main/src/ColorPalette.ts
+++ b/packages/main/src/ColorPalette.ts
@@ -509,7 +509,6 @@ class ColorPalette extends UI5Element {
 	_onColorContainerKeyDown(e: KeyboardEvent) {
 		const eventTarget = e.target as ColorPaletteItem;
 		const swatchTarget = this._getColorPaletteItemFromEvent(e, this.displayedColors);
-		const isLastSwatchInSingleRow = this._isSingleRow() && swatchTarget && this._isLastSwatch(swatchTarget, this.displayedColors);
 
 		// Prevent Home/End keys from working in embedded mode - they only work in popup mode as per design
 		if (this._shouldPreventHomeEnd(e)) {
@@ -527,7 +526,13 @@ class ColorPalette extends UI5Element {
 			this.selectColor(swatchTarget || eventTarget);
 		}
 
-		if (this._isPrevious(e) && swatchTarget && this._isFirstSwatch(swatchTarget, this.displayedColors)) {
+		if (!swatchTarget) {
+			return;
+		}
+
+		const isLastSwatchInSingleRow = this._isSingleRow() && this._isLastSwatch(swatchTarget, this.displayedColors);
+
+		if (this._isPrevious(e) && this._isFirstSwatch(swatchTarget, this.displayedColors)) {
 			e.preventDefault();
 			e.stopPropagation();
 			this._focusFirstAvailable(
@@ -537,8 +542,8 @@ class ColorPalette extends UI5Element {
 				() => this._focusLastSwatchOfLastFullRow(),
 				() => this._focusLastDisplayedColor(),
 			);
-		} else if ((isRight(e) && swatchTarget && this._isLastSwatch(swatchTarget, this.displayedColors))
-			|| (isDown(e) && swatchTarget && (this._isLastSwatchOfLastFullRow(swatchTarget) || isLastSwatchInSingleRow))
+		} else if ((isRight(e) && this._isLastSwatch(swatchTarget, this.displayedColors))
+			|| (isDown(e) && (this._isLastSwatchOfLastFullRow(swatchTarget) || isLastSwatchInSingleRow))
 		) {
 			e.preventDefault();
 			e.stopPropagation();
@@ -548,7 +553,7 @@ class ColorPalette extends UI5Element {
 				() => this._focusDefaultColor(),
 				() => this._focusFirstDisplayedColor(),
 			);
-		} else if (swatchTarget && isHome(e) && this._isFirstSwatchInRow(swatchTarget)) {
+		} else if (isHome(e) && this._isFirstSwatchInRow(swatchTarget)) {
 			e.preventDefault();
 			e.stopPropagation();
 			this._focusFirstAvailable(
@@ -556,7 +561,7 @@ class ColorPalette extends UI5Element {
 				() => this._focusMoreColors(),
 				() => this._focusFirstDisplayedColor(),
 			);
-		} else if (swatchTarget && isEnd(e) && this._isLastSwatchInRow(swatchTarget)) {
+		} else if (isEnd(e) && this._isLastSwatchInRow(swatchTarget)) {
 			e.preventDefault();
 			e.stopPropagation();
 			this._focusFirstAvailable(
@@ -564,7 +569,7 @@ class ColorPalette extends UI5Element {
 				() => this._focusDefaultColor(),
 				() => this._focusLastDisplayedColor(),
 			);
-		} else if (swatchTarget && isEnd(e) && this._isSwatchInLastRow(swatchTarget)) {
+		} else if (isEnd(e) && this._isSwatchInLastRow(swatchTarget)) {
 			e.preventDefault();
 			e.stopPropagation();
 			this._focusLastDisplayedColor();
@@ -585,7 +590,11 @@ class ColorPalette extends UI5Element {
 			this._currentlySelected = undefined;
 		}
 
-		if (this._isNext(e) && swatchTarget && this._isLastSwatch(swatchTarget, this.recentColorsElements)) {
+		if (!swatchTarget) {
+			return;
+		}
+
+		if (this._isNext(e) && this._isLastSwatch(swatchTarget, this.recentColorsElements)) {
 			e.preventDefault();
 			e.stopPropagation();
 			this._focusFirstAvailable(
@@ -593,7 +602,7 @@ class ColorPalette extends UI5Element {
 				() => this._focusMoreColors(),
 				() => this._focusFirstDisplayedColor(),
 			);
-		} else if (this._isPrevious(e) && swatchTarget && this._isFirstSwatch(swatchTarget, this.recentColorsElements)) {
+		} else if (this._isPrevious(e) && this._isFirstSwatch(swatchTarget, this.recentColorsElements)) {
 			e.preventDefault();
 			e.stopPropagation();
 			this._focusFirstAvailable(
@@ -602,7 +611,7 @@ class ColorPalette extends UI5Element {
 				() => this._focusLastDisplayedColor(),
 				() => this._focusDefaultColor(),
 			);
-		} else if (swatchTarget && isEnd(e)) {
+		} else if (isEnd(e)) {
 			e.preventDefault();
 			e.stopPropagation();
 			this._focusLastRecentColor();
@@ -723,17 +732,7 @@ class ColorPalette extends UI5Element {
 	 * @returns True if any candidate successfully focused an element, false if all failed.
 	 */
 	_focusFirstAvailable(...candidates: Array<() => boolean>): boolean {
-		if (!candidates.length) {
-			return false;
-		}
-
-		const [focusAction, ...remainingCandidates] = candidates;
-
-		if (focusAction()) {
-			return true;
-		}
-
-		return this._focusFirstAvailable(...remainingCandidates);
+		return candidates.some(focusAction => focusAction());
 	}
 
 	/**

--- a/packages/main/src/ColorPalette.ts
+++ b/packages/main/src/ColorPalette.ts
@@ -572,7 +572,6 @@ class ColorPalette extends UI5Element {
 	}
 
 	_onRecentColorsContainerKeyDown(e: KeyboardEvent) {
-		const eventTarget = e.target as ColorPaletteItem;
 		const swatchTarget = this._getColorPaletteItemFromEvent(e, this.recentColorsElements);
 
 		// Prevent Home/End keys from working in embedded mode - they only work in popup mode as per design

--- a/packages/main/src/ColorPalettePopover.ts
+++ b/packages/main/src/ColorPalettePopover.ts
@@ -195,12 +195,15 @@ class ColorPalettePopover extends UI5Element {
 
 	onAfterOpen() {
 		const colorPalette = this._colorPalette;
+
+		// Focus the last selected color (or first recent color) on reopen. The default color button
+		// and the first swatch are intentionally left to the popover's built-in initial focus: it
+		// already lands on them, and re-focusing those here fires on the "open" event a frame later,
+		// stealing focus back after the user has already started navigating with the keyboard.
 		if (colorPalette._currentlySelected) {
-			colorPalette._currentlySelected?.focus();
+			colorPalette._currentlySelected.getFocusDomRef()?.focus();
 		} else if (colorPalette.showRecentColors && colorPalette.recentColorsElements.length) {
-			colorPalette.recentColorsElements[0].focus();
-		} else if (colorPalette.showDefaultColor) {
-			colorPalette._defaultColorButton?.focus();
+			colorPalette.recentColorsElements[0].getFocusDomRef()?.focus();
 		}
 
 		// since height is dynamically determined by padding-block-start


### PR DESCRIPTION
## Overview

Keyboard focus in the color palette was unstable. Right after the popover opened, the first arrow or Home/End keypress could appear to do nothing and focus snapped back to the element focused on open. Separately, pressing a key after focus had moved out of the color grid (onto More Colors, Default Color, or a recent color) bounced focus back into the grid.

## What We Did

- Remove the redundant initial focus the popover applied on open, relying on its built-in initial focus instead.
- Keep explicit focus only for the recent colors row, which the built-in focus cannot reach.
- Resolve the actual color swatch from the keyboard event before running any grid navigation logic.
- Skip the grid navigation branches when the keystroke did not come from a swatch, while keeping Tab selection working in popup mode.
- Re-enable the previously skipped Home/End navigation tests.

## What This Fixes

- **Flaky navigation,** the first arrow and Home/End keypress after opening now reliably moves focus.
- **Focus stealing,** focus stays on the control the user navigated to instead of snapping back to the grid.
- **Predictable navigation,** arrow, Home, and End keys only act when a swatch is focused.
- **Initial focus,** opening still lands on the default color button, the selected color, or the first swatch as before.
- **Test coverage,** the Home/End keyboard navigation cases now run and pass.**

Fixes: #12346 