### PR TITLE
fix(ui5-form): incorrect labelSpan behavior when width is close to layout breakpoint

### DIFF
--- a/packages/main/src/themes/FormItemSpan.css
+++ b/packages/main/src/themes/FormItemSpan.css
@@ -11,7 +11,7 @@
 	--ui5-form-item-label-padding-internal: 0.625rem 0.25rem 0 0.25rem;
 }
 
-@container (max-width: 599px) {
+@container (width < 600px) {
 	.ui5-form-item,
 	.ui5-form-group {
 		--ui5-form-item-layout: var(--ui5-form-item-layout-S);
@@ -24,7 +24,7 @@
 	}
 }
 
-@container (min-width: 600px) and (max-width: 1023px) {
+@container (600px <= width < 1024px) {
 	.ui5-form-item,
 	.ui5-form-group {
 		--ui5-form-item-layout: var(--ui5-form-item-layout-M);
@@ -37,7 +37,7 @@
 	}
 }
 
-@container (min-width: 1024px) and (max-width: 1439px) {
+@container (1024px <= width < 1440px) {
 	.ui5-form-item,
 	.ui5-form-group {
 		--ui5-form-item-layout: var(--ui5-form-item-layout-L);
@@ -50,7 +50,7 @@
 	}
 }
 
-@container (min-width: 1440px) {
+@container (width >= 1440px) {
 	.ui5-form-item,
 	.ui5-form-group {
 		--ui5-form-item-layout: var(--ui5-form-item-layout-XL);

--- a/packages/main/src/themes/FormLayout.css
+++ b/packages/main/src/themes/FormLayout.css
@@ -7,7 +7,7 @@
 */
 
 /* S - 1 column */
-@container (max-width: 599px) {
+@container (width < 600px) {
 	.ui5-form-layout {
 		grid-template-columns: repeat(var(--ui5-form-columns-s), 1fr);
 	}
@@ -30,7 +30,7 @@
 }
 
 /* M  - 1 column by default, up to 2 columns */
-@container (min-width: 600px) and (max-width: 1023px) {
+@container (600px <= width < 1024px) {
 	.ui5-form-layout {
 		grid-template-columns: repeat(var(--ui5-form-columns-m), 1fr);
 	}
@@ -45,7 +45,7 @@
 }
 
 /* L - 2 columns by default, up to 3 columns */
-@container (min-width: 1024px) and (max-width: 1439px) {
+@container (1024px <= width < 1440px) {
 
 	.ui5-form-layout {
 		grid-template-columns: repeat(var(--ui5-form-columns-l), 1fr);
@@ -61,7 +61,7 @@
 }
 
 /* XL - 3 columns by default, up to 6 */
-@container (min-width: 1440px) {
+@container (width >= 1440px) {
 	.ui5-form-layout {
 		grid-template-columns: repeat(var(--ui5-form-columns-xl), 1fr);
 	}


### PR DESCRIPTION
The old min/max-width container queries left gaps at exact breakpoint values (e.g. a width of exactly 600px matched neither the S nor M query), causing incorrect layout and labelSpan behavior. Replace with CSS range syntax which produces contiguous, non-overlapping ranges with no gaps.

Fixes #13723