### PR TITLE
fix: defer native popover patching to microtask

### DIFF
--- a/packages/base/src/features/patchPopup.ts
+++ b/packages/base/src/features/patchPopup.ts
@@ -122,17 +122,19 @@ const openNativePopoverForOpenUI5 = (popup: OpenUI5Popup) => {
 		return;
 	}
 
-	const openUI5BlockLayer = document.getElementById("sap-ui-blocklayer-popup");
+	queueMicrotask(() => {
+		const openUI5BlockLayer = document.getElementById("sap-ui-blocklayer-popup");
 
-	if (popup.getModal() && openUI5BlockLayer) {
-		openUI5BlockLayer.setAttribute("popover", "manual");
-		openUI5BlockLayer.hidePopover();
-		openUI5BlockLayer.showPopover();
-	}
+		if (popup.getModal() && openUI5BlockLayer) {
+			openUI5BlockLayer.setAttribute("popover", "manual");
+			openUI5BlockLayer.hidePopover();
+			openUI5BlockLayer.showPopover();
+		}
 
-	domRef.setAttribute("popover", "manual");
-	domRef.hidePopover();
-	domRef.showPopover();
+		domRef.setAttribute("popover", "manual");
+		domRef.hidePopover();
+		domRef.showPopover();
+	});
 };
 
 const closeNativePopoverForOpenUI5 = (popup: OpenUI5Popup) => {


### PR DESCRIPTION
Wraps the popover show/hide logic in queueMicrotask so it runs after all synchronous patches have completed, ensuring correct stacking order when multiple patches modify the same popup.