### PR TITLE
fix(ui5-flexible-column-layout): add aria-orientation=vertical to separator

### DIFF
--- a/packages/fiori/cypress/specs/FCL.cy.tsx
+++ b/packages/fiori/cypress/specs/FCL.cy.tsx
@@ -179,6 +179,29 @@ describe("ACC", () => {
 			.find(".ui5-fcl-separator-end")
 			.should("have.attr", "aria-valuenow");
 	});
+
+	it("verifies that aria-orientation is set to vertical on separators", () => {
+		cy.mount(
+			<FlexibleColumnLayout id="fcl" layout="ThreeColumnsMidExpanded">
+				<div class="column" id="startColumn" slot="startColumn">some content</div>
+				<div class="column" id="midColumn" slot="midColumn">some content</div>
+				<div class="column" id="endColumn" slot="endColumn">some content</div>
+			</FlexibleColumnLayout>
+		);
+
+		cy.get("[ui5-flexible-column-layout]")
+			.as("fcl");
+
+		cy.get("@fcl")
+			.shadow()
+			.find(".ui5-fcl-separator-start")
+			.should("have.attr", "aria-orientation", "vertical");
+
+		cy.get("@fcl")
+			.shadow()
+			.find(".ui5-fcl-separator-end")
+			.should("have.attr", "aria-orientation", "vertical");
+	});
 });
 
 before(() => {

--- a/packages/fiori/src/FlexibleColumnLayoutTemplate.tsx
+++ b/packages/fiori/src/FlexibleColumnLayoutTemplate.tsx
@@ -34,6 +34,7 @@ export default function FlexibleColumnLayoutTemplate(this: FlexibleColumnLayout)
 				style={{ display: this.showStartSeparator ? "flex" : "none" }}
 				tabindex={this.startSeparatorTabIndex}
 				aria-valuenow={this.startSeparatorValue}
+				aria-orientation="vertical"
 				onMouseDown={this.onSeparatorPress}
 				onTouchStart={this.onSeparatorPress}
 				onKeyDown={this._onSeparatorKeydown}
@@ -65,6 +66,7 @@ export default function FlexibleColumnLayoutTemplate(this: FlexibleColumnLayout)
 				style={{ display: this.showEndSeparator ? "flex" : "none" }}
 				tabindex={this.endSeparatorTabIndex}
 				aria-valuenow={this.endSeparatorValue}
+				aria-orientation="vertical"
 				onMouseDown={this.onSeparatorPress}
 				onTouchStart={this.onSeparatorPress}
 				onKeyDown={this._onSeparatorKeydown}


### PR DESCRIPTION
Screen readers were announcing the column separators as "horizontal splitter"
because the separator role defaults to horizontal per the ARIA spec.

Added `aria-orientation="vertical"` to both start and end separator elements.

Fixes #13702