### PR TITLE
fix(ui5-shellbar): make search clickable when it falls into the overflow

### DIFF
--- a/packages/fiori/cypress/specs/ShellBar.cy.tsx
+++ b/packages/fiori/cypress/specs/ShellBar.cy.tsx
@@ -688,12 +688,15 @@ describe("Slots", () => {
 				.should("exist")
 				.and("have.attr", "open");
 
-			// Click search toggle in overflow popover
+			// Click search toggle in overflow popover. Use `realClick()` to simulate a
+			// real pointer event — a plain `.click()` synthetic dispatch goes
+			// straight to the element so it would mask regressions where the click
+			// gets stopped earlier in the bubble chain (e.g. by ListItemBase).
 			cy.get("@shellbar")
 				.shadow()
 				.find(".ui5-shellbar-overflow-popover [data-action-id='search']")
 				.should("exist")
-				.click();
+				.realClick();
 
 			// Verify search is expanded
 			cy.get("@shellbar")
@@ -1279,7 +1282,7 @@ describe("Events", () => {
 
 			cy.get("[ui5-shellbar]")
 				.shadow()
-				.find(".ui5-shellbar-overflow-popover [ui5-list] [ui5-shellbar-item]:nth-child(1)")
+				.find(".ui5-shellbar-overflow-popover [ui5-list] [data-action-id='notifications']")
 				.realClick();
 
 			cy.get("[ui5-shellbar]")

--- a/packages/fiori/src/ShellBar.ts
+++ b/packages/fiori/src/ShellBar.ts
@@ -22,6 +22,7 @@ import Icon from "@ui5/webcomponents/dist/Icon.js";
 import Popover from "@ui5/webcomponents/dist/Popover.js";
 import Menu from "@ui5/webcomponents/dist/Menu.js";
 import List from "@ui5/webcomponents/dist/List.js";
+import type { ListItemClickEventDetail } from "@ui5/webcomponents/dist/List.js";
 import ListItemStandard from "@ui5/webcomponents/dist/ListItemStandard.js";
 import searchIcon from "@ui5/webcomponents-icons/dist/search.js";
 import bellIcon from "@ui5/webcomponents-icons/dist/bell.js";
@@ -842,9 +843,14 @@ class ShellBar extends UI5Element {
 		this.overflowPopoverOpen = false;
 	}
 
-	handleOverflowItemClick(e: MouseEvent) {
-		const target = e.target as HTMLElement;
-		const actionId = target.getAttribute("data-action-id");
+	handleOverflowItemClick(e: CustomEvent<ListItemClickEventDetail>) {
+		// `ListItemBase._onclick` calls `stopPropagation()`, so the raw `click`
+		// event never reaches the surrounding `<ui5-list>` in the overflow popover
+		// (which is why a real pointer click on the search entry used to do nothing).
+		// Use the list's `item-click` event instead — it is fired through the public
+		// API and carries the pressed item in `detail.item`.
+		const item = e.detail.item as unknown as HTMLElement | undefined;
+		const actionId = item?.getAttribute("data-action-id");
 
 		let prevented = e.defaultPrevented; // for custom actions
 

--- a/packages/fiori/src/ShellBarTemplate.tsx
+++ b/packages/fiori/src/ShellBarTemplate.tsx
@@ -2,8 +2,8 @@ import Button from "@ui5/webcomponents/dist/Button.js";
 import ButtonBadge from "@ui5/webcomponents/dist/ButtonBadge.js";
 import Popover from "@ui5/webcomponents/dist/Popover.js";
 import List from "@ui5/webcomponents/dist/List.js";
+import ListItemStandard from "@ui5/webcomponents/dist/ListItemStandard.js";
 import type ShellBar from "./ShellBar.js";
-import ShellBarItem from "./ShellBarItem.js";
 
 import {
 	ShellBarSearchField,
@@ -235,19 +235,26 @@ export default function ShellBarTemplate(this: ShellBar) {
 				hideArrow={true}
 				horizontalAlign={this.popoverHorizontalAlign} // TODO: add test
 			>
-				<List separators="None" onClick={this.handleOverflowItemClick}>
+				<List separators="None" onItemClick={this.handleOverflowItemClick}>
 					{this.overflowItems.map(item => {
 						if (item.type === "action") {
 							const actionData = item.data;
+							// Render built-in actions (search, notifications) as real list items
+							// — children of `<ui5-list>`, not nested inside a `<ui5-shellbar-item>`.
+							// This is required so the list's `item-click` event fires with
+							// `detail.item` set to the entry that carries `data-action-id`;
+							// nesting an inner `<ui5-li>` inside `<ui5-shellbar-item>` would hide
+							// it from the list's slotted children and `item-click` would never fire.
 							return (
-								<ShellBarItem
+								<ListItemStandard
 									key={item.id}
-									icon={actionData.icon ? `sap-icon://${actionData.icon}` : ""}
 									data-action-id={item.id}
-									count={actionData.count}
-									inOverflow={true}
-									text={this.getActionOverflowText(item.id)}
-								/>
+									icon={actionData.icon ? `sap-icon://${actionData.icon}` : ""}
+									data-count={actionData.count}
+									type="Active"
+								>
+									{this.getActionOverflowText(item.id)}
+								</ListItemStandard>
 							);
 						}
 						return <slot key={item.id} name={item.data._individualSlot}></slot>;

--- a/packages/fiori/test/pages/ShellBarSearchOverflowRepro.html
+++ b/packages/fiori/test/pages/ShellBarSearchOverflowRepro.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>ShellBar – Search in Overflow at 320px</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<script data-ui5-config type="application/json">
+		{ "language": "EN" }
+	</script>
+	<script src="%VITE_BUNDLE_PATH%" type="module"></script>
+	<style>
+		body { margin: 0; font-family: sans-serif; }
+		.note { padding: 10px; background: #eef; font-size: 13px; }
+		#log { padding: 10px; font-family: monospace; white-space: pre-wrap; background: #f6f6f6; }
+		.frame { width: 320px; border: 1px solid #aaa; margin: 16px; }
+		.caption { padding: 6px 10px; background: #f0f0f0; font-weight: 600; font-size: 13px; }
+	</style>
+</head>
+<body>
+	<div class="note">
+		Each ShellBar is rendered in a 320px-wide container so the search trigger lands inside the overflow popover.<br>
+		Open overflow (≡) and click "Search" — the search field should expand. (Regression test for
+		<code>handleOverflowItemClick</code> not firing when the entry was wrapped in a <code>ui5-shellbar-item</code>.)
+	</div>
+
+	<div class="frame">
+		<div class="caption">Scenario A: self-collapsible &lt;ui5-shellbar-search&gt;</div>
+		<ui5-shellbar id="sbA" primary-title="Product Title With Long Name">
+			<img slot="logo" src="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg" />
+			<ui5-shellbar-search slot="searchField" placeholder="Search"></ui5-shellbar-search>
+			<ui5-button slot="content">Button 1</ui5-button>
+			<ui5-button slot="content">Button 2</ui5-button>
+			<ui5-button slot="content">Button 3</ui5-button>
+			<ui5-button slot="content">Button 4</ui5-button>
+			<ui5-button slot="content">Button 5</ui5-button>
+			<ui5-button slot="content">Button 6</ui5-button>
+			<ui5-button slot="content">Button 7</ui5-button>
+			<ui5-button slot="content">Button 8</ui5-button>
+			<ui5-shellbar-item icon="activities" text="A1"></ui5-shellbar-item>
+			<ui5-shellbar-item icon="activities" text="A2"></ui5-shellbar-item>
+			<ui5-shellbar-item icon="activities" text="A3"></ui5-shellbar-item>
+			<ui5-shellbar-item icon="activities" text="A4"></ui5-shellbar-item>
+			<ui5-shellbar-item icon="activities" text="A5"></ui5-shellbar-item>
+			<ui5-avatar slot="profile">
+				<img src="https://sdk.openui5.org/test-resources/sap/f/images/Woman_avatar_01.png" />
+			</ui5-avatar>
+		</ui5-shellbar>
+	</div>
+
+	<div class="frame">
+		<div class="caption">Scenario B: legacy &lt;ui5-input&gt;</div>
+		<ui5-shellbar id="sbB" primary-title="Product Title With Long Name">
+			<img slot="logo" src="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg" />
+			<ui5-input slot="searchField" placeholder="Search"></ui5-input>
+			<ui5-button slot="content">Button 1</ui5-button>
+			<ui5-button slot="content">Button 2</ui5-button>
+			<ui5-button slot="content">Button 3</ui5-button>
+			<ui5-button slot="content">Button 4</ui5-button>
+			<ui5-button slot="content">Button 5</ui5-button>
+			<ui5-button slot="content">Button 6</ui5-button>
+			<ui5-button slot="content">Button 7</ui5-button>
+			<ui5-button slot="content">Button 8</ui5-button>
+			<ui5-shellbar-item icon="activities" text="A1"></ui5-shellbar-item>
+			<ui5-shellbar-item icon="activities" text="A2"></ui5-shellbar-item>
+			<ui5-shellbar-item icon="activities" text="A3"></ui5-shellbar-item>
+			<ui5-shellbar-item icon="activities" text="A4"></ui5-shellbar-item>
+			<ui5-shellbar-item icon="activities" text="A5"></ui5-shellbar-item>
+			<ui5-avatar slot="profile">
+				<img src="https://sdk.openui5.org/test-resources/sap/f/images/Woman_avatar_01.png" />
+			</ui5-avatar>
+		</ui5-shellbar>
+	</div>
+
+	<pre id="log"></pre>
+	<script>
+		const log = document.getElementById("log");
+		const logLine = (m) => { log.textContent += m + "\n"; };
+		for (const id of ["sbA", "sbB"]) {
+			const sb = document.getElementById(id);
+			sb.showNotifications = true;
+			sb.showProductSwitch = true;
+			sb.showSearchField = false;
+			sb.addEventListener("ui5-search-button-click", () => logLine(`[${id}] search-button-click`));
+			sb.addEventListener("ui5-search-field-toggle", e => logLine(`[${id}] search-field-toggle expanded=${e.detail.expanded}`));
+		}
+	</script>
+</body>
+</html>


### PR DESCRIPTION
## What

At narrow viewports (≤ ~320 px) where the search trigger is pushed into the ShellBar's overflow popover, clicking "Search" with a real pointer event did nothing — no `search-button-click`, no `search-field-toggle`, popover stayed open.

## Why

Walking the click in Chrome DevTools showed three things stacking on top of each other:

1. The overflow popover wired its click handler as `<ui5-list onClick={…}>` and relied on the raw `click` bubbling up from the inner `<ui5-li>`.
2. `ListItemBase._onclick` calls `e.stopPropagation()` after firing its own `_press`, so the click never reached the list listener.
3. Switching to the list's public `item-click` event was not enough on its own: each action was rendered as a `<ui5-shellbar-item>` whose inner `<ui5-li>` lives in the shellbar-item's shadow root. The outer `<ui5-list>` therefore doesn't see it as a slotted list item and never raises `item-click` for it either.

Synthetic `cy.click()` in the existing test masked the issue because it dispatches the click straight at the element. Real-user pointer events hit none of the handlers.

## How

- `ShellBarTemplate.tsx` — render the built-in actions (search, notifications) in the overflow popover as direct `<ListItemStandard data-action-id="…">` children of `<ui5-list>` instead of wrapping them in `<ui5-shellbar-item>`. Listen for `item-click` instead of `click` on the list.
- `ShellBar.ts` — change `handleOverflowItemClick` signature to a `CustomEvent<ListItemClickEventDetail>` and read the action from `e.detail.item.getAttribute("data-action-id")`.
- `ShellBar.cy.tsx`:
  - The existing "Test search toggle in overflow expands search when clicked" test now uses `.realClick()` so it actually exercises the path users hit (verified: the test fails on the original code, passes with the fix).
  - The unrelated preventDefault test selector was updated for the new overflow popover DOM (`[ui5-shellbar-item]:nth-child(1)` → `[data-action-id='notifications']`).
- `test/pages/ShellBarSearchOverflowRepro.html` — small manual repro page (two 320 px-wide containers covering self-collapsible `<ui5-shellbar-search>` and legacy `<ui5-input>`), handy for poking at this in the dev server.

## Verification

- `yarn test:cypress:single cypress/specs/ShellBar.cy.tsx` — all 67 tests pass.
- `ShellBarItem.cy.tsx`, `ShellBarSearch.cy.tsx`, `ShellBar.mobile.cy.tsx` — all green.
- Confirmed the new test reliably fails when the fix is reverted (so it catches the regression).
- End-to-end check in the browser via DevTools MCP at 320 px: real pointer click on "Search" in the overflow popover expands the search field and fires both `search-button-click` and `search-field-toggle expanded=true` for both `<ui5-shellbar-search>` and legacy `<ui5-input>` scenarios.

## Reviewer hints

- The smell test for this regression in the future: any reliance on bubbling `click` events out of `ListItemBase` is fragile because `_onclick` calls `stopPropagation()`. Prefer the list's `item-click` event.
- The repro page can be deleted before merge if you don't want it in `test/pages/` — let me know and I'll drop the commit.