### PR TITLE
fix(ui5-shellbar-item): fire click event when item is clicked in overflow popover

### DIFF
--- a/packages/fiori/cypress/specs/ShellBar.cy.tsx
+++ b/packages/fiori/cypress/specs/ShellBar.cy.tsx
@@ -631,7 +631,7 @@ describe("Slots", () => {
 			cy.get("@shellbar").invoke("prop", "showSearchField").should("equal", true);
 		});
 
-		it.skip("Test search toggle in overflow expands search when clicked", () => {
+		it("Test search toggle in overflow expands search when clicked", () => {
 			cy.mount(
 				<ShellBar
 					id="shellbar"
@@ -693,7 +693,7 @@ describe("Slots", () => {
 				.shadow()
 				.find(".ui5-shellbar-overflow-popover [data-action-id='search']")
 				.should("exist")
-				.click();
+				.realClick();
 
 			// Verify search is expanded
 			cy.get("@shellbar")

--- a/packages/fiori/cypress/specs/ShellBar.cy.tsx
+++ b/packages/fiori/cypress/specs/ShellBar.cy.tsx
@@ -1815,6 +1815,70 @@ describe("Component Behavior", () => {
 				.should("have.been.calledOnce");
 		});
 
+		it("tests 'click' on custom action in overflow popover", () => {
+			cy.viewport(320, 800);
+
+			cy.mount(
+				<ShellBar
+					primaryTitle="Product Title"
+					showNotifications
+					showProductSwitch
+				>
+					<ShellBarBranding slot="branding">
+						Product Title
+						<img src="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg" slot="logo" />
+					</ShellBarBranding>
+					<Button icon="nav-back" slot="startButton" />
+					<ShellBarItem id="overflow-accept" icon="accept" text="Accept" />
+					<ShellBarItem id="overflow-alert" icon="alert" text="Alert" />
+				</ShellBar>
+			);
+
+			cy.get("#overflow-accept").then($item => {
+				$item[0].addEventListener("click", cy.stub().as("acceptClick"));
+			});
+			cy.get("#overflow-alert").then($item => {
+				$item[0].addEventListener("click", cy.stub().as("alertClick"));
+			});
+
+			cy.get("[ui5-shellbar]")
+				.shadow()
+				.find(".ui5-shellbar-overflow-button")
+				.should("be.visible")
+				.click();
+
+			cy.get("[ui5-shellbar]")
+				.shadow()
+				.find(".ui5-shellbar-overflow-popover")
+				.should("have.attr", "open");
+
+			cy.get("#overflow-accept")
+				.shadow()
+				.find("[ui5-li]")
+				.realClick();
+
+			cy.get("@acceptClick")
+				.should("have.been.calledOnce");
+
+			cy.get("[ui5-shellbar]")
+				.shadow()
+				.find(".ui5-shellbar-overflow-button")
+				.click();
+
+			cy.get("[ui5-shellbar]")
+				.shadow()
+				.find(".ui5-shellbar-overflow-popover")
+				.should("have.attr", "open");
+
+			cy.get("#overflow-alert")
+				.shadow()
+				.find("[ui5-li]")
+				.realClick();
+
+			cy.get("@alertClick")
+				.should("have.been.calledOnce");
+		});
+
 		it("renders items in insertion order regardless of icon name", () => {
 			cy.mount(
 				<ShellBar>

--- a/packages/fiori/cypress/specs/ShellBar.cy.tsx
+++ b/packages/fiori/cypress/specs/ShellBar.cy.tsx
@@ -631,7 +631,7 @@ describe("Slots", () => {
 			cy.get("@shellbar").invoke("prop", "showSearchField").should("equal", true);
 		});
 
-		it("Test search toggle in overflow expands search when clicked", () => {
+		it.skip("Test search toggle in overflow expands search when clicked", () => {
 			cy.mount(
 				<ShellBar
 					id="shellbar"

--- a/packages/fiori/src/ShellBarItem.ts
+++ b/packages/fiori/src/ShellBarItem.ts
@@ -126,7 +126,7 @@ class ShellBarItem extends UI5Element {
 		return [domRef];
 	}
 
-	fireClickEvent(e: UI5CustomEvent<Button, "click">) {
+	fireClickEvent(e: UI5CustomEvent<Button, "click"> | UI5CustomEvent<ListItemStandard, "click">) {
 		return this.fireDecoratorEvent("click", {
 			targetRef: (e.target as HTMLElement),
 		});

--- a/packages/fiori/src/ShellBarItemTemplate.tsx
+++ b/packages/fiori/src/ShellBarItemTemplate.tsx
@@ -12,6 +12,7 @@ export default function ShellBarItemTemplate(this: ShellBarItem) {
 				data-count={this.count}
 				data-ui5-stable={this.stableDomRef}
 				accessibilityAttributes={this.accessibilityAttributes}
+				onClick={this.fireClickEvent}
 			>
 				{this.text}
 			</ListItemStandard>

--- a/packages/fiori/test/pages/ShellBarSearch.html
+++ b/packages/fiori/test/pages/ShellBarSearch.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<meta charset="utf-8">
+	<title>Shell Bar</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+	<script src="%VITE_BUNDLE_PATH%" type="module"></script>
+</head>
+<ui5-shellbar slot="header" id="shellbar" notifications-count="10" show-notifications show-product-switch>
+	<ui5-shellbar-branding slot="branding">
+		VEGA CRM
+		<img slot="logo" src="https://ui5.github.io/webcomponents/nightly/images/sap-logo-svg.svg" />
+	</ui5-shellbar-branding>
+	<ui5-button id="menu-button" icon="menu2" slot="startButton" tooltip="Toggle side navigation"></ui5-button>
+	<ui5-tag design="Set2" color-scheme="7" slot="content" data-hide-order="2">Trial</ui5-tag>
+	<ui5-text slot="content" data-hide-order="1">30 days remaining</ui5-text>
+
+	<ui5-shellbar-spacer slot="content"></ui5-shellbar-spacer>
+
+	<ui5-toggle-button icon="sap-icon://da" slot="assistant"></ui5-toggle-button>
+
+	<ui5-shellbar-search slot="searchField" id="search-scope" scope-value="all" show-clear-icon
+		placeholder="Search Apps, Products">
+		<ui5-search-scope text="All" value="all" slot="scopes"></ui5-search-scope>
+		<ui5-search-scope text="Apps" value="apps" slot="scopes"></ui5-search-scope>
+		<ui5-search-scope text="Products" value="products" slot="scopes"></ui5-search-scope>
+	</ui5-shellbar-search>
+
+	<ui5-shellbar-item icon="sys-help" text="Help"></ui5-shellbar-item>
+	<ui5-avatar slot="profile">
+		<img src="https://ui5.github.io/webcomponents/nightly/images/avatars/man_avatar_3.png" />
+	</ui5-avatar>
+</ui5-shellbar>
+<body>
+</body>
+
+</html>


### PR DESCRIPTION
The click event was not fired when a ShellBarItem was activated from the overflow menu, because the ListItemStandard in the overflow template was missing an onClick handler. Added the handler and updated the fireClickEvent signature to accept both Button and ListItemStandard click events.