### PR TITLE
fix(ui5-flexible-column-layout): correct desktop column widths for ThreeColumnsStartHiddenMidExpanded

### DIFF
--- a/packages/fiori/cypress/specs/FCL.cy.tsx
+++ b/packages/fiori/cypress/specs/FCL.cy.tsx
@@ -343,6 +343,64 @@ describe("First column closing arrow behavior", () => {
 	});
 });
 
+describe("ThreeColumnsStartHidden column widths", () => {
+	it("ThreeColumnsStartHiddenMidExpanded should have mid as the wide column on desktop", () => {
+		cy.mount(
+			<FlexibleColumnLayout style={{ height: "300px" }} layout="ThreeColumnsStartHiddenMidExpanded">
+				<div slot="startColumn">some content</div>
+				<div slot="midColumn">some content</div>
+				<div slot="endColumn">some content</div>
+			</FlexibleColumnLayout>
+		);
+
+		cy.get("[ui5-flexible-column-layout]")
+			.shadow()
+			.find(".ui5-fcl-column--start")
+			.should("have.attr", "style")
+			.and("include", "width: 0px");
+
+		cy.get("[ui5-flexible-column-layout]")
+			.shadow()
+			.find(".ui5-fcl-column--middle")
+			.should("have.attr", "style")
+			.and("include", "width: 67%");
+
+		cy.get("[ui5-flexible-column-layout]")
+			.shadow()
+			.find(".ui5-fcl-column--end")
+			.should("have.attr", "style")
+			.and("include", "width: 33%");
+	});
+
+	it("ThreeColumnsStartHiddenEndExpanded should have end as the wide column on desktop", () => {
+		cy.mount(
+			<FlexibleColumnLayout style={{ height: "300px" }} layout="ThreeColumnsStartHiddenEndExpanded">
+				<div slot="startColumn">some content</div>
+				<div slot="midColumn">some content</div>
+				<div slot="endColumn">some content</div>
+			</FlexibleColumnLayout>
+		);
+
+		cy.get("[ui5-flexible-column-layout]")
+			.shadow()
+			.find(".ui5-fcl-column--start")
+			.should("have.attr", "style")
+			.and("include", "width: 0px");
+
+		cy.get("[ui5-flexible-column-layout]")
+			.shadow()
+			.find(".ui5-fcl-column--middle")
+			.should("have.attr", "style")
+			.and("include", "width: 33%");
+
+		cy.get("[ui5-flexible-column-layout]")
+			.shadow()
+			.find(".ui5-fcl-column--end")
+			.should("have.attr", "style")
+			.and("include", "width: 67%");
+	});
+});
+
 describe("Layout Change API", () => {
 	it("tests change layout with API", () => {
 		cy.mount(

--- a/packages/fiori/src/fcl-utils/FCLLayout.ts
+++ b/packages/fiori/src/fcl-utils/FCLLayout.ts
@@ -78,7 +78,7 @@ const getDefaultLayoutsByMedia = (): DefaultLayoutConfiguration => {
 				],
 			},
 			"ThreeColumnsStartHiddenMidExpanded": {
-				layout: ["0px", "33%", "67%"],
+				layout: ["0px", "67%", "33%"],
 				separators: [
 					{
 						visible: true,


### PR DESCRIPTION
The desktop layout had swapped percentages for ThreeColumnsStartHiddenMidExpanded, making it render identically to ThreeColumnsStartHiddenEndExpanded. Changed the mid/end split from ["0px", "33%", "67%"] to ["0px", "67%", "33%"] to match the intended behavior (tablet was already correct).

Fixes #13693

