### PR TITLE
fix: ensure global styles are updated by the newest runtime

### DIFF
--- a/packages/base/src/FontFace.ts
+++ b/packages/base/src/FontFace.ts
@@ -1,4 +1,4 @@
-import { hasStyle, createStyle } from "./ManagedStyles.js";
+import { createOrUpdateStyle } from "./ManagedStyles.js";
 import { getFeature } from "./FeaturesRegistry.js";
 import fontFaceCSS from "./generated/css/FontFace.css.js";
 import type OpenUI5Support from "./features/OpenUI5Support.js";
@@ -20,9 +20,7 @@ const insertMainFontFace = () => {
 		return;
 	}
 
-	if (!hasStyle("data-ui5-font-face")) {
-		createStyle(fontFaceCSS, "data-ui5-font-face");
-	}
+	createOrUpdateStyle(fontFaceCSS, "data-ui5-font-face");
 };
 
 export default insertFontFace;

--- a/packages/base/src/ManagedStyles.ts
+++ b/packages/base/src/ManagedStyles.ts
@@ -27,6 +27,10 @@ const createStyle = (content: string, name: string, value = "", theme?: string) 
 };
 
 const updateStyle = (content: string, name: string, value = "", theme?: string) => {
+	if (isSSR) {
+		return;
+	}
+
 	const currentRuntimeIndex = getCurrentRuntimeIndex();
 
 	const stylesheet = document.adoptedStyleSheets.find(sh => (sh as Record<string, any>)._ui5StyleId === getStyleId(name, value));

--- a/packages/base/src/ScrollbarStyles.ts
+++ b/packages/base/src/ScrollbarStyles.ts
@@ -1,10 +1,8 @@
-import { hasStyle, createStyle } from "./ManagedStyles.js";
+import { createOrUpdateStyle } from "./ManagedStyles.js";
 import scrollbarStyles from "./generated/css/ScrollbarStyles.css.js";
 
 const insertScrollbarStyles = () => {
-	if (!hasStyle("data-ui5-scrollbar-styles")) {
-		createStyle(scrollbarStyles, "data-ui5-scrollbar-styles");
-	}
+	createOrUpdateStyle(scrollbarStyles, "data-ui5-scrollbar-styles");
 };
 
 export default insertScrollbarStyles;

--- a/packages/base/src/features/insertOpenUI5PopupStyles.ts
+++ b/packages/base/src/features/insertOpenUI5PopupStyles.ts
@@ -1,10 +1,8 @@
-import { hasStyle, createStyle } from "../ManagedStyles.js";
+import { createOrUpdateStyle } from "../ManagedStyles.js";
 import openUI5PopupStyles from "../generated/css/OpenUI5PopupStyles.css.js";
 
 const insertOpenUI5PopupStyles = () => {
-	if (!hasStyle("data-ui5-popup-styles")) {
-		createStyle(openUI5PopupStyles, "data-ui5-popup-styles");
-	}
+	createOrUpdateStyle(openUI5PopupStyles, "data-ui5-popup-styles");
 };
 
 export default insertOpenUI5PopupStyles;

--- a/packages/main/src/Popup.ts
+++ b/packages/main/src/Popup.ts
@@ -20,7 +20,7 @@ import {
 	getAllAccessibleDescriptionRefTexts,
 	deregisterUI5Element,
 } from "@ui5/webcomponents-base/dist/util/AccessibilityTextsHelper.js";
-import { hasStyle, createStyle } from "@ui5/webcomponents-base/dist/ManagedStyles.js";
+import { createOrUpdateStyle } from "@ui5/webcomponents-base/dist/ManagedStyles.js";
 import { isEnter, isTabPrevious } from "@ui5/webcomponents-base/dist/Keys.js";
 import { getFocusedElement, isFocusedElementWithinNode } from "@ui5/webcomponents-base/dist/util/PopupUtils.js";
 import ResizeHandler from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
@@ -37,9 +37,7 @@ import popupBlockLayerStyles from "./generated/themes/PopupBlockLayer.css.js";
 import globalStyles from "./generated/themes/PopupGlobal.css.js";
 
 const createBlockingStyle = (): void => {
-	if (!hasStyle("data-ui5-popup-scroll-blocker")) {
-		createStyle(globalStyles, "data-ui5-popup-scroll-blocker");
-	}
+	createOrUpdateStyle(globalStyles, "data-ui5-popup-scroll-blocker");
 };
 
 createBlockingStyle();


### PR DESCRIPTION
Replace hasStyle+createStyle guards with createOrUpdateStyle in FontFace, ScrollbarStyles, OpenUI5PopupStyles, and Popup so that a newer runtime loaded on the same page can overwrite previously inserted styles instead of skipping them.

Remove cache: 'yarn' from the Setup Node step in pr-dev-close-notice.yaml because this workflow never runs yarn install, leaving the Yarn cache directory unpopulated. The actions/setup-node post-job cleanup then fails trying to archive a path that doesn't exist, producing a "Path Validation Error". All other workflows that use cache: 'yarn' run an actual install step, so this change is isolated to this workflow  only.

Cherry-pick of: https://github.com/UI5/webcomponents/pull/13720