### PR TITLE
fix(ui5-shellbar-branding): space key now triggers click event

### DIFF
--- a/packages/fiori/cypress/specs/ShellBarBranding.cy.tsx
+++ b/packages/fiori/cypress/specs/ShellBarBranding.cy.tsx
@@ -109,4 +109,21 @@ describe("ShellBarBranding", () => {
 				.should("have.attr", "tabIndex", "0");
 		});
 	});
+
+	it("fires click event on Enter and Space", () => {
+			basicTemplate();
+
+			cy.get("[slot='branding']").then(branding => {
+				branding.get(0).addEventListener("ui5-click", cy.stub().as("brandingClick"));
+			});
+
+			cy.get("@shellbarBranding")
+				.find("a")
+				.focus()
+				.realPress("Enter")
+				.realPress("Space");
+
+			cy.get("@brandingClick")
+				.should("have.been.calledTwice");
+		});
 });

--- a/packages/fiori/src/ShellBarBranding.ts
+++ b/packages/fiori/src/ShellBarBranding.ts
@@ -136,26 +136,34 @@ class ShellBarBranding extends UI5Element {
 		this.fireDecoratorEvent("click");
 	}
 
-	_onclick(e: MouseEvent) {
+	private _activate(e: Event) {
 		e.stopPropagation();
 		this._fireClick();
 	}
 
-	_onkeyup(e: KeyboardEvent) {
-		if (isSpace(e)) {
-			this._fireClick();
-		}
+	private _getAnchor() {
+		return this.shadowRoot?.querySelector("a") as HTMLAnchorElement | null;
+	}
+
+	_onclick(e: MouseEvent) {
+		this._activate(e);
 	}
 
 	_onkeydown(e: KeyboardEvent) {
-		if (isSpace(e)) {
+		if (isEnter(e) && !this.href) {
 			e.preventDefault();
+			this._getAnchor()?.click();
+		} else if (isSpace(e)) {
+			e.preventDefault();
+		}
+	}
+
+	_onkeyup(e: KeyboardEvent) {
+		if (!isSpace(e)) {
 			return;
 		}
 
-		if (isEnter(e)) {
-			this._fireClick();
-		}
+		this._getAnchor()?.click();
 	}
 }
 


### PR DESCRIPTION
"Space" key now triggers "click" event on Shellbar Branding.

Cherry-pick of: https://github.com/UI5/webcomponents/pull/13686