### PR TITLE
fix(ui5-shellbar): prevent search collapse during resize

### DIFF
--- a/packages/fiori/cypress/specs/ShellBar.cy.tsx
+++ b/packages/fiori/cypress/specs/ShellBar.cy.tsx
@@ -1449,6 +1449,72 @@ describe("Search Controllers", () => {
 
 		cy.get("#shellbar").should("have.prop", "showSearchField", true);
 	});
+
+	it("Test search auto-restores when resizing back to large viewport", () => {
+		cy.viewport(500, 1080);
+		cy.mount(
+			<ShellBar id="shellbar" showSearchField={true} showNotifications={true} showProductSwitch={true}>
+				<img slot="logo" src="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg" />
+				<ShellBarSearch id="search" slot="searchField"></ShellBarSearch>
+				<ShellBarItem icon={activities} text="Action"></ShellBarItem>
+				<Button slot="content">Button</Button>
+			</ShellBar>
+		);
+
+		// search collapses on initial small-viewport load
+		cy.get("#shellbar").should("have.prop", "showSearchField", false);
+
+		// resize to large — search should restore
+		cy.viewport(1200, 800);
+		cy.wait(RESIZE_THROTTLE_RATE);
+
+		cy.get("#shellbar").should("have.prop", "showSearchField", true);
+	});
+
+	it("Test search stays open across small→large→small resize cycle", () => {
+		cy.mount(
+			<ShellBar id="shellbar" showSearchField={true} showNotifications={true} showProductSwitch={true}>
+				<img slot="logo" src="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg" />
+				<ShellBarSearch id="search" slot="searchField"></ShellBarSearch>
+				<ShellBarItem icon={activities} text="Action"></ShellBarItem>
+				<Button slot="content">Button</Button>
+			</ShellBar>
+		);
+
+		// initial large-viewport render — search stays open
+		cy.get("#shellbar").should("have.prop", "showSearchField", true);
+
+		cy.viewport(400, 800);
+		cy.wait(RESIZE_THROTTLE_RATE);
+		cy.get("#shellbar").should("have.prop", "showSearchField", true);
+
+		cy.viewport(1200, 800);
+		cy.wait(RESIZE_THROTTLE_RATE);
+		cy.get("#shellbar").should("have.prop", "showSearchField", true);
+
+		cy.viewport(400, 800);
+		cy.wait(RESIZE_THROTTLE_RATE);
+		cy.get("#shellbar").should("have.prop", "showSearchField", true);
+	});
+
+	it("Test search collapsed on small-viewport mount stays collapsed across small resize", () => {
+		cy.viewport(500, 1080);
+		cy.mount(
+			<ShellBar id="shellbar" showSearchField={true} showNotifications={true} showProductSwitch={true}>
+				<img slot="logo" src="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg" />
+				<ShellBarSearch id="search" slot="searchField"></ShellBarSearch>
+				<ShellBarItem icon={activities} text="Action"></ShellBarItem>
+				<Button slot="content">Button</Button>
+			</ShellBar>
+		);
+
+		cy.get("#shellbar").should("have.prop", "showSearchField", false);
+
+		cy.viewport(400, 800);
+		cy.wait(RESIZE_THROTTLE_RATE);
+
+		cy.get("#shellbar").should("have.prop", "showSearchField", false);
+	});
 });
 
 describe("Overflow", () => {

--- a/packages/fiori/src/ShellBar.ts
+++ b/packages/fiori/src/ShellBar.ts
@@ -665,7 +665,8 @@ class ShellBar extends UI5Element {
 
 	onAfterRendering() {
 		this.updateBreakpoint();
-		this.updateOverflow();
+		const hiddenItemsIds = this.updateOverflow() ?? [];
+		this.searchAdaptor?.notifyInitialRender(hiddenItemsIds.length);
 	}
 
 	/* =================== Actions Management =================== */

--- a/packages/fiori/src/shellbar/IShellBarSearchController.ts
+++ b/packages/fiori/src/shellbar/IShellBarSearchController.ts
@@ -29,4 +29,12 @@ export interface IShellBarSearchController {
 	 * Returns true when shellbar is overflowing AND search is visible.
 	 */
 	shouldShowFullScreen(): boolean;
+
+	/**
+	 * Called from onAfterRendering to inform the controller of the initial render state.
+	 * If hiddenItems is 0 (component rendered without overflow), clears the initialRender flag
+	 * so that subsequent resize events don't incorrectly treat themselves as "initial render"
+	 * and collapse search that the user explicitly opened.
+	 */
+	notifyInitialRender(hiddenItems: number): void;
 }

--- a/packages/fiori/src/shellbar/ShellBarSearch.ts
+++ b/packages/fiori/src/shellbar/ShellBarSearch.ts
@@ -76,10 +76,12 @@ class ShellBarSearch implements IShellBarSearchController {
 		const searchHasFocus = document.activeElement === this.getSearchField();
 		const searchHasValue = !!this.getSearchField()?.value;
 
-		// On initial load, allow search to collapse even if it would trigger full-screen mode.
-		// This prevents search from showing in full-screen when page loads on small screens.
-		// After initial render, prevent collapse in full-screen mode during resize.
-		const inFullScreen = !this.initialRender && this.shouldShowFullScreen();
+		// Prevent collapse if search is visible and items are overflowing (full-screen mode).
+		// Use hiddenItems count rather than live DOM overflow check, since updateOverflow()
+		// has already resolved the overflow by hiding items before this is called.
+		// On the very first autoManageSearchState call (initialRender=true), allow collapse
+		// so search doesn't show in full-screen when the page first loads on a small screen.
+		const inFullScreen = !this.initialRender && hiddenItems > 0 && this.getSearchState();
 		const preventCollapse = searchHasFocus || searchHasValue || inFullScreen;
 
 		if (hiddenItems > 0 && !preventCollapse) {
@@ -117,6 +119,12 @@ class ShellBarSearch implements IShellBarSearchController {
 	 */
 	shouldShowFullScreen(): boolean {
 		return this.getOverflowed() && this.getSearchState();
+	}
+
+	notifyInitialRender(hiddenItems: number) {
+		if (hiddenItems === 0) {
+			this.initialRender = false;
+		}
 	}
 
 	private onSearchOpen(e: Event) {

--- a/packages/fiori/src/shellbar/ShellBarSearchLegacy.ts
+++ b/packages/fiori/src/shellbar/ShellBarSearchLegacy.ts
@@ -77,10 +77,12 @@ class ShellBarSearchLegacy implements IShellBarSearchController {
 		const searchHasFocus = searchField?.contains(document.activeElement) || false;
 		const searchHasValue = this.hasValue(searchField);
 
-		// On initial load, allow search to collapse even if it would trigger full-screen mode.
-		// This prevents search from showing in full-screen when page loads on small screens.
-		// After initial render, prevent collapse in full-screen mode during resize.
-		const inFullScreen = !this.initialRender && this.shouldShowFullScreen();
+		// Prevent collapse if search is visible and items are overflowing (full-screen mode).
+		// Use hiddenItems count rather than live DOM overflow check, since updateOverflow()
+		// has already resolved the overflow by hiding items before this is called.
+		// On the very first autoManageSearchState call (initialRender=true), allow collapse
+		// so search doesn't show in full-screen when the page first loads on a small screen.
+		const inFullScreen = !this.initialRender && hiddenItems > 0 && this.getSearchState();
 		const preventCollapse = searchHasFocus || searchHasValue || inFullScreen;
 
 		if (hiddenItems > 0 && !preventCollapse) {
@@ -105,6 +107,12 @@ class ShellBarSearchLegacy implements IShellBarSearchController {
 	 */
 	shouldShowFullScreen(): boolean {
 		return this.getOverflowed() && this.getSearchState();
+	}
+
+	notifyInitialRender(hiddenItems: number) {
+		if (hiddenItems === 0) {
+			this.initialRender = false;
+		}
 	}
 
 	/**


### PR DESCRIPTION
The search field was incorrectly collapsing on the first resize from a large to a small viewport when showSearchField was set to true at mount time. This happened because the initialRender flag in the search controllers was only cleared when autoManageSearchState first ran (on the first resize), so the very first resize was treated as an "initial load" and allowed to collapse the search unconditionally.

Fix: call notifyInitialRender() from onAfterRendering, passing the hidden item count from the just-completed overflow calculation. If the initial render had no overflow (hiddenItems === 0), the initialRender flag is cleared immediately, so the subsequent resize correctly applies full-screen collapse protection. If the initial render already had overflow (small viewport), the flag stays true so the first resize can still collapse search on page load — preserving the existing behavior.

Also fix the inFullScreen check in autoManageSearchState to use the hiddenItems parameter instead of the live getOverflowed() DOM check. getOverflowed() always returns false at call time because updateOverflow() has already resolved the overflow by hiding items before autoManageSearchState is invoked.

Add four new resize tests covering: auto-restore after small→large resize, full small→large→small cycle, and small-viewport mount staying collapsed across further small resizes.