### PR TITLE
fix(ui5-search): keep popup open on item click when search event is prevented

### DIFF
--- a/packages/fiori/cypress/specs/Search.mobile.cy.tsx
+++ b/packages/fiori/cypress/specs/Search.mobile.cy.tsx
@@ -284,4 +284,45 @@ describe("Search Field on mobile device", () => {
 		cy.get("[ui5-search]")
 			.should("have.prop", "value", "Item 1");
 	});
+
+	it("should keep the popup open on item selection when preventDefault is called", () => {
+		cy.mount(
+			<>
+				<Search showClearIcon={true}>
+					<SearchItem text="Item 1" />
+					<SearchItem text="Item 2" />
+					<SearchItem text="Item 3" />
+				</Search>
+			</>
+		);
+
+		cy.get("[ui5-search]")
+			.then(search => {
+				search.get(0).addEventListener("ui5-search", (e: Event) => {
+					e.preventDefault();
+				});
+			});
+
+		cy.get("[ui5-search]")
+			.realClick();
+
+		cy.get("[ui5-search]")
+			.shadow()
+			.find<ResponsivePopover>("[ui5-responsive-popover]")
+			.ui5ResponsivePopoverOpened();
+
+		// Click an item in the popup
+		cy.get("[ui5-search-item]")
+			.eq(0)
+			.realClick();
+
+		// preventDefault was called, so the picker should remain open on mobile
+		cy.get("[ui5-search]")
+			.should("have.prop", "open", true);
+
+		cy.get("[ui5-search]")
+			.shadow()
+			.find<ResponsivePopover>("[ui5-responsive-popover]")
+			.should("have.prop", "open", true);
+	});
 });

--- a/packages/fiori/src/Search.ts
+++ b/packages/fiori/src/Search.ts
@@ -554,10 +554,6 @@ class Search extends SearchField {
 		const prevented = !this.fireDecoratorEvent("search", { item });
 
 		if (prevented) {
-			if (isPhone()) {
-				this.open = false;
-			}
-
 			return;
 		}
 

--- a/packages/fiori/src/SearchPopoverTemplate.tsx
+++ b/packages/fiori/src/SearchPopoverTemplate.tsx
@@ -40,7 +40,7 @@ export default function SearchPopoverTemplate(this: Search, headerTemplate?: Jsx
 			{isPhone() ? (headerTemplate ? headerTemplate.call(this) : (
 				<>
 					<header slot="header" class="ui5-search-popup-searching-header">
-						<Input class="ui5-search-popover-search-field" onInput={this._handleMobileInput} showClearIcon={this.showClearIcon} noTypeahead={this.noTypeahead} hint={InputKeyHint.Search} onKeyDown={this._onMobileInputKeydown}>
+						<Input value={this.value} class="ui5-search-popover-search-field" onInput={this._handleMobileInput} showClearIcon={this.showClearIcon} noTypeahead={this.noTypeahead} hint={InputKeyHint.Search} onKeyDown={this._onMobileInputKeydown}>
 							{this._flattenItems.map(item => {
 								return (<SuggestionItem text={item.text}></SuggestionItem>);
 							})}

--- a/packages/fiori/test/pages/Search.html
+++ b/packages/fiori/test/pages/Search.html
@@ -225,6 +225,55 @@
 		<ui5-text style="padding-top: 0.25rem; font-style: italic;">The examples shows scoped search with scoped suggestions. Change scope to filter suggestions.</ui5-text>
 	</div>
 
+	<div class="container">
+		<ui5-label>Search with Grouped Suggestions and "Search in" group - Pick a scope from the suggestions</ui5-label>
+		<ui5-search id="search-in-scope" show-clear-icon scope-value="all" placeholder="Search ...">
+			<ui5-search-scope text="All" value="all" slot="scopes"></ui5-search-scope>
+			<ui5-search-scope text="Sales Orders" value="salesOrders" slot="scopes"></ui5-search-scope>
+			<ui5-search-scope text="Purchase Orders" value="purchaseOrders" slot="scopes"></ui5-search-scope>
+			<ui5-search-scope text="Customers" value="customers" slot="scopes"></ui5-search-scope>
+			<ui5-search-scope text="Products" value="products" slot="scopes"></ui5-search-scope>
+
+			<ui5-search-item-group header-text="Recent">
+				<ui5-search-item text="SO-1001 — Acme Corp" icon="sales-order"></ui5-search-item>
+				<ui5-search-item text="PO-4502 — Globex" icon="cart"></ui5-search-item>
+				<ui5-search-item text="Customer: Initech" icon="customer"></ui5-search-item>
+			</ui5-search-item-group>
+
+			<ui5-search-item-group id="search-in-group" header-text="Search in">
+				<ui5-search-item text="Sales Orders" icon="sales-order" data-scope="salesOrders"></ui5-search-item>
+				<ui5-search-item text="Purchase Orders" icon="cart" data-scope="purchaseOrders"></ui5-search-item>
+				<ui5-search-item text="Customers" icon="customer" data-scope="customers"></ui5-search-item>
+				<ui5-search-item text="Products" icon="product" data-scope="products"></ui5-search-item>
+			</ui5-search-item-group>
+		</ui5-search>
+		<ui5-text style="padding-top: 0.25rem; font-style: italic;">
+			Picking an item from the "Search in" group changes the active scope instead of completing the search.
+		</ui5-text>
+	</div>
+
+	<script>
+		(function () {
+			const searchInScope = document.getElementById('search-in-scope');
+
+			searchInScope.addEventListener('ui5-search', (event) => {
+				const item = event.detail.item;
+				const targetScope = item && item.dataset && item.dataset.scope;
+
+				if (!targetScope) {
+					return;
+				}
+
+				// Item belongs to the "Search in" group — switch scope rather than submitting a search.
+				// preventDefault keeps the popup open so the user can continue picking suggestions in the new scope.
+				event.preventDefault();
+				searchInScope.scopeValue = targetScope;
+				searchInScope.value = "";
+				searchInScope.focus();
+			});
+		}());
+	</script>
+
 
 	<div class="container">
 		<ui5-label>Search with Suggestions - Filters and noTypeAhead</ui5-label>

--- a/packages/fiori/test/pages/UXCIntegration.html
+++ b/packages/fiori/test/pages/UXCIntegration.html
@@ -1,0 +1,647 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+	<meta charset="UTF-8">
+	<title>UXC Integration</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+
+	<script data-ui5-config type="application/json">
+		{
+			"rtl": false
+		}
+	</script>
+
+	<style>
+		@media (width > 600px) {
+			.sideNavigation:not([collapsed]) {
+				width: 18rem;
+			}
+		}
+
+		.mainContent {
+			padding: var(--sapContent_Gap);
+		}
+
+		.quickCreateDialog::part(footer) {
+			padding-inline: 0;
+		}
+
+		/* Notifications */
+		.notificationsPopover {
+			width: 27rem;
+			max-height: 40rem;
+		}
+
+		.notificationsPopover::part(header) {
+			padding: 0;
+			box-shadow: none;
+		}
+
+		.notificationsPopover::part(content) {
+			padding: 0;
+		}
+
+		.notificationsPopoverHeader {
+			display: flex;
+			flex: 1;
+			flex-direction: column;
+		}
+
+		.notificationsPopoverList {
+			height: 100%;
+		}
+
+		.notificationsPopoverBar,
+		.notificationsPopoverBar::part(bar) {
+			box-shadow: none;
+		}
+		/* End notifications */
+
+		/* User Settings Dialog */
+		.ua-panel {
+			border-top: 2px solid lightgrey;
+			margin: 1rem 0;
+		}
+
+		.language-region-container {
+			display: flex;
+			min-height: 2.5rem;
+			align-item: flex-start;
+			flex-direction: column;
+			gap: 0.563rem;
+		}
+
+		.language-region-label {
+			display: flex;
+			flex: 1 0 0;
+			width: 100%;
+		}
+
+		.language-region-control {
+			display: flex;
+			gap: 0.188rem;
+			width: 100%;
+		}
+
+		.ui5-user-settings-appearance-view-additional-content-header {
+			display: flex;
+			justify-content: space-between;
+			align-items: center;
+			margin-bottom: 0.5rem;
+			width: 100%;
+		}
+
+		.ui5-user-settings-appearance-view-additional-content-description {
+			display: block;
+			color: var(--sapContent_LabelColor);
+			font-size: var(--sapFontSmallSize);
+		}
+	</style>
+
+	<script src="%VITE_BUNDLE_PATH%" type="module"></script>
+</head>
+
+<body style="background-color: var(--sapBackgroundColor); height: 50rem;">
+	<ui5-navigation-layout id="navigation-layout">
+		<ui5-shellbar slot="header" id="shellbar"
+			notifications-count="10" show-notifications show-product-switch>
+			<ui5-shellbar-branding slot="branding">
+				VEGA CRM
+				<img slot="logo" src="./img/sap-logo-svg.svg" />
+			</ui5-shellbar-branding>
+			<ui5-button id="menu-button" icon="menu2" slot="startButton" tooltip="Toggle side navigation"></ui5-button>
+			<ui5-tag design="Set2" color-scheme="7" slot="content" data-hide-order="2">Trial</ui5-tag>
+			<ui5-text slot="content" data-hide-order="1">30 days remaining</ui5-text>
+
+			<ui5-shellbar-spacer slot="content"></ui5-shellbar-spacer>
+
+			<ui5-toggle-button icon="sap-icon://da" slot="assistant"></ui5-toggle-button>
+
+			<ui5-shellbar-search slot="searchField" id="search-scope" scope-value="all" show-clear-icon placeholder="Search Apps, Products">
+				<ui5-search-scope text="All" value="all" slot="scopes"></ui5-search-scope>
+				<ui5-search-scope text="Apps" value="apps" slot="scopes"></ui5-search-scope>
+				<ui5-search-scope text="Products" value="products" slot="scopes"></ui5-search-scope>
+
+				<ui5-search-item-group id="search-in-group" header-text="Search in">
+					<ui5-search-item text="Apps" icon="business-objects-experience" data-scope="apps"></ui5-search-item>
+					<ui5-search-item text="Products" icon="product" data-scope="products"></ui5-search-item>
+				</ui5-search-item-group>
+			</ui5-shellbar-search>
+
+			<ui5-shellbar-item icon="sys-help" text="Help"></ui5-shellbar-item>
+			<ui5-avatar slot="profile">
+				<img src="./img/man_avatar_1.png" />
+			</ui5-avatar>
+		</ui5-shellbar>
+
+		<ui5-user-menu id="userMenu" show-manage-account show-other-accounts show-edit-accounts show-edit-button>
+			<ui5-user-menu-account slot="accounts"
+								   avatar-src="./img/man_avatar_1.png"
+								   title-text="Alain Chevalier 1"
+								   subtitle-text="alian.chevalier@sap.com"
+								   description="Delivery Manager, SAP SE"
+								   selected>
+			</ui5-user-menu-account>
+			<ui5-user-menu-account slot="accounts"
+								   avatar-initials="SD"
+								   title-text="John Walker"
+								   subtitle-text="john.walker@sap.com"
+								   description="Project Manager">
+			</ui5-user-menu-account>
+			<ui5-user-menu-account slot="accounts"
+								   avatar-initials="DS"
+								   title-text="David Wilson"
+								   subtitle-text="david.wilson@sap.com"
+								   description="Project Manager">
+			</ui5-user-menu-account>
+			<ui5-user-menu-item icon="action-settings" text="Setting" data-id="setting"></ui5-user-menu-item>
+			<ui5-user-menu-item icon="official-service" text="Legal Information">
+				<ui5-user-menu-item text="Terms of Use" data-id="terms-of-use"></ui5-user-menu-item>
+				<ui5-user-menu-item text="Private Policy" data-id="privacy-policy"></ui5-user-menu-item>
+			</ui5-user-menu-item>
+			<ui5-user-menu-item icon="message-information" text="About" data-id="about"></ui5-user-menu-item>
+			<ui5-user-menu-item icon="globe" text="Language" data-id="single-select" show-selection>
+				<ui5-user-menu-item-group check-mode="Single">
+					<ui5-user-menu-item text="English" data-id="single-select-item1" checked></ui5-user-menu-item>
+					<ui5-user-menu-item text="Deutsch" data-id="single-select-item2"></ui5-user-menu-item>
+				</ui5-user-menu-item-group>
+			</ui5-user-menu-item>
+		</ui5-user-menu>
+
+		<ui5-side-navigation id="side-navigation" class="sideNavigation" slot="sideContent" accessible-name="Main">
+			<ui5-side-navigation-item text="Home" icon="home" selected></ui5-side-navigation-item>
+			<ui5-side-navigation-item text="Favorites" expanded icon="favorite-list" unselectable>
+				<ui5-side-navigation-sub-item text="My Accounts"></ui5-side-navigation-sub-item>
+				<ui5-side-navigation-sub-item text="My Orders"></ui5-side-navigation-sub-item>
+			</ui5-side-navigation-item>
+			<ui5-side-navigation-item text="Customer Management" icon="account" expanded unselectable>
+				<ui5-side-navigation-sub-item text="Contacts"></ui5-side-navigation-sub-item>
+				<ui5-side-navigation-sub-item text="Companies"></ui5-side-navigation-sub-item>
+				<ui5-side-navigation-sub-item text="Partners"></ui5-side-navigation-sub-item>
+			</ui5-side-navigation-item>
+			<ui5-side-navigation-item text="Sales" icon="crm-sales" expanded unselectable>
+				<ui5-side-navigation-sub-item text="Leads"></ui5-side-navigation-sub-item>
+				<ui5-side-navigation-sub-item text="Opportunuties"></ui5-side-navigation-sub-item>
+				<ui5-side-navigation-sub-item text="Quotes"></ui5-side-navigation-sub-item>
+				<ui5-side-navigation-sub-item text="Orders"></ui5-side-navigation-sub-item>
+				<ui5-side-navigation-sub-item text="Invoices"></ui5-side-navigation-sub-item>
+			</ui5-side-navigation-item>
+			<ui5-side-navigation-item text="Products" icon="s4hana" expanded unselectable>
+				<ui5-side-navigation-sub-item text="Product Catalog"></ui5-side-navigation-sub-item>
+				<ui5-side-navigation-sub-item text="Pricing"></ui5-side-navigation-sub-item>
+				<ui5-side-navigation-sub-item text="Inventory Management"></ui5-side-navigation-sub-item>
+			</ui5-side-navigation-item>
+			<ui5-side-navigation-item text="Marketing" icon="business-by-design" expanded unselectable>
+				<ui5-side-navigation-sub-item text="Campaigns"></ui5-side-navigation-sub-item>
+				<ui5-side-navigation-sub-item text="E-Mail Marketing"></ui5-side-navigation-sub-item>
+				<ui5-side-navigation-sub-item text="Marketing Automation"></ui5-side-navigation-sub-item>
+			</ui5-side-navigation-item>
+			<ui5-side-navigation-item text="Reports" icon="manager-insight" expanded unselectable>
+				<ui5-side-navigation-sub-item text="Sales Reports"></ui5-side-navigation-sub-item>
+				<ui5-side-navigation-sub-item text="Customer Reports"></ui5-side-navigation-sub-item>
+			</ui5-side-navigation-item>
+			<ui5-side-navigation-item slot="fixedItems" id="quick-create" text="Quick Create" icon="add" design="Action" unselectable></ui5-side-navigation-item>
+			<ui5-side-navigation-item slot="fixedItems" text="Product Settings" icon="settings"></ui5-side-navigation-item>
+		</ui5-side-navigation>
+
+		<div class="mainContent">
+			<ui5-title id="content-title">Home</ui5-title>
+			<br />
+			<ui5-text>Content...</ui5-text>
+		</div>
+	</ui5-navigation-layout>
+
+	<ui5-dialog id="quick-create-dialog" class="quickCreateDialog" header-text="Create New Item" draggable resizable>
+		<ui5-text>Create new item...</ui5-text>
+		<ui5-bar slot="footer" design="Footer">
+			<ui5-button slot="endContent" design="Emphasized">Create</ui5-button>
+			<ui5-button slot="endContent" id="quick-create-dialog-close">Close</ui5-button>
+		</ui5-bar>
+	</ui5-dialog>
+
+	<ui5-responsive-popover
+		id="popover-with-notifications"
+		placement="Bottom"
+		class="notificationsPopover"
+		horizontal-align="End">
+		<div class="notificationsPopoverHeader" slot="header">
+			<ui5-bar class="notificationsPopoverBar" design="Header">
+				<ui5-title level="H5" slot="startContent">Notifications</ui5-title>
+				<ui5-button id="clear-all" design="Transparent" slot="endContent">Clear All</ui5-button>
+				<ui5-button id="btn-sort" design="Transparent" icon="sort" tooltip="Sort" slot="endContent"></ui5-button>
+				<ui5-button design="Transparent" icon="action-settings" tooltip="Go to settings" slot="endContent"></ui5-button>
+			</ui5-bar>
+		</div>
+
+		<ui5-notification-list class="notificationsPopoverList">
+			<ui5-li-notification-group id="notificationsListGroupGrowing"
+									   title-text="Today"
+									   loading-delay="0"
+									   growing="Button">
+				<ui5-li-notification title-text="Start Your Day with Your Sales Target!" show-close>
+					<ui5-avatar icon="crm-sales" color-scheme="Accent10" shape="Square" size="XS" slot="avatar"></ui5-avatar>
+					<span slot="footnotes">Sales</span>
+					<span slot="footnotes">11:13</span>
+					<ui5-menu slot="menu">
+						<ui5-menu-item text="Unsubscribe"></ui5-menu-item>
+					</ui5-menu>
+					Good morning! Don’t forget your daily sales target is $2,000.
+				</ui5-li-notification>
+				<ui5-li-notification title-text="Upcoming Client Meeting Reminder" importance="Important" show-close>
+					<ui5-avatar icon="crm-sales" color-scheme="Accent10" shape="Square" size="XS" slot="avatar"></ui5-avatar>
+					<span slot="footnotes">Sales</span>
+					<span slot="footnotes">11:05</span>
+					<ui5-menu slot="menu">
+						<ui5-menu-item text="Open in calendar"></ui5-menu-item>
+						<ui5-menu-item text="Unsubscribe"></ui5-menu-item>
+					</ui5-menu>
+					You have a client meeting scheduled at 3 PM today with Acme Corp.
+				</ui5-li-notification>
+				<ui5-li-notification title-text="Follow-Up Needed for Prospect" show-close>
+					<ui5-avatar icon="crm-sales" color-scheme="Accent10" shape="Square" size="XS" slot="avatar"></ui5-avatar>
+					<span slot="footnotes">Sales</span>
+					<span slot="footnotes">11:00</span>
+					<ui5-menu slot="menu">
+						<ui5-menu-item text="Follow-up meeting"></ui5-menu-item>
+						<ui5-menu-item text="Unsubscribe"></ui5-menu-item>
+					</ui5-menu>
+					Reminder to follow up with John Doe from XYZ Ltd.
+				</ui5-li-notification>
+			</ui5-li-notification-group>
+
+			<ui5-li-notification-group title-text="Yesterday" collapsed>
+				<ui5-li-notification title-text="New Sales Lead Assigned" show-close>
+					<ui5-avatar icon="crm-sales" color-scheme="Accent10" shape="Square" size="XS" slot="avatar"></ui5-avatar>
+					<span slot="footnotes">Sales</span>
+					<span slot="footnotes">1 Day</span>
+					<ui5-menu slot="menu">
+						<ui5-menu-item text="Unsubscribe"></ui5-menu-item>
+					</ui5-menu>
+					A new lead, Jane Smith from Innovative Tech, has been assigned to you.
+				</ui5-li-notification>
+			</ui5-li-notification-group>
+		</ui5-notification-list>
+	</ui5-responsive-popover>
+
+	<ui5-menu header-text="Sort By" id="sort-menu">
+		<ui5-menu-item text="Date"></ui5-menu-item>
+		<ui5-menu-item text="Importance"></ui5-menu-item>
+	</ui5-menu>
+
+	<ui5-dialog id="clear-all-dialog" header-text="Clear All Notifications">
+		<ui5-text>Are you sure you want to clear all the notifications?</ui5-text>
+		<ui5-bar slot="footer" design="Footer">
+			<ui5-button id="clear-all-action" class="dialogCloser" design="Emphasized" slot="endContent" style="min-width: 4rem;">OK</ui5-button>
+			<ui5-button class="dialogCloser" slot="endContent" style="min-width: 4rem;">Cancel</ui5-button>
+		</ui5-bar>
+	</ui5-dialog>
+
+	<ui5-user-settings-dialog id="settings" header-text="Settings" show-search-field>
+		<ui5-user-settings-item icon="user-settings" text="User Account" tooltip="User Account" header-text="User Account" selected>
+			<ui5-user-settings-account-view show-manage-account="true">
+				<ui5-user-menu-account slot="account"
+									   avatar-src="./img/man_avatar_1.png"
+									   title-text="Alain Chevalier"
+									   subtitle-text="alian.chevalier@sap.com"
+									   description="Delivery Manager, SAP SE"
+									   selected>
+				</ui5-user-menu-account>
+				<ui5-label for="reset-all-button">Personalization</ui5-label><br/>
+				<ui5-button id="reset-all-button">Reset All Personalization</ui5-button>
+				<ui5-panel fixed class="ua-panel">
+					<ui5-text>
+						Reset your personalization settings for the launchpad (such as theme, language, user activities, and home page content).
+					</ui5-text>
+				</ui5-panel>
+			</ui5-user-settings-account-view>
+		</ui5-user-settings-item>
+
+		<ui5-user-settings-item icon="palette" text="Appearance" tooltip="Appearance" header-text="Appearance">
+			<ui5-user-settings-appearance-view text="Themes">
+				<div slot="additionalContent">
+					<div class="ui5-user-settings-appearance-view-additional-content-header">
+						<ui5-text id="touch-input-label">Optimize for Touch Input</ui5-text>
+						<ui5-switch accessible-name-ref="touch-input-label"></ui5-switch>
+					</div>
+					<ui5-text class="ui5-user-settings-appearance-view-additional-content-description">
+						Increases the size and spacing of controls to allow you to interact with them more easily using your fingertip.
+					</ui5-text>
+				</div>
+				<ui5-user-settings-appearance-view-group header-text="Horizon">
+					<ui5-user-settings-appearance-view-item item-key="sap_horizon" text="Morning Horizon" selected></ui5-user-settings-appearance-view-item>
+					<ui5-user-settings-appearance-view-item item-key="sap_horizon_dark" text="Evening Horizon"></ui5-user-settings-appearance-view-item>
+					<ui5-user-settings-appearance-view-item item-key="sap_horizon_hcb" text="Horizon High Contrast Black"></ui5-user-settings-appearance-view-item>
+					<ui5-user-settings-appearance-view-item item-key="sap_horizon_hcw" text="Horizon High Contrast White"></ui5-user-settings-appearance-view-item>
+				</ui5-user-settings-appearance-view-group>
+				<ui5-user-settings-appearance-view-group header-text="Quartz">
+					<ui5-user-settings-appearance-view-item item-key="sap_fiori_3" text="Quartz Light"></ui5-user-settings-appearance-view-item>
+					<ui5-user-settings-appearance-view-item item-key="sap_fiori_3_dark" text="Quartz Dark"></ui5-user-settings-appearance-view-item>
+					<ui5-user-settings-appearance-view-item item-key="sap_fiori_3_hcb" text="Quartz High Contrast Black"></ui5-user-settings-appearance-view-item>
+					<ui5-user-settings-appearance-view-item item-key="sap_fiori_3_hcw" text="Quartz High Contrast White"></ui5-user-settings-appearance-view-item>
+				</ui5-user-settings-appearance-view-group>
+			</ui5-user-settings-appearance-view>
+		</ui5-user-settings-item>
+
+		<ui5-user-settings-item icon="bell" text="Notifications" tooltip="Notifications" header-text="Notifications">
+			<ui5-user-settings-view>
+				<ui5-checkbox checked text="Show High-Priority Notification Alerts"></ui5-checkbox>
+			</ui5-user-settings-view>
+		</ui5-user-settings-item>
+
+		<ui5-user-settings-item icon="reset" slot="fixedItems" text="Reset Settings" tooltip="Reset Settings" header-text="Reset Settings">
+			<ui5-user-settings-view text="Reset Personalization">
+				<ui5-button id="resetPersonalization">Reset Personalization content</ui5-button>
+				<ui5-toast id="toastReset">Changes Reset.</ui5-toast>
+			</ui5-user-settings-view>
+			<ui5-user-settings-view text="Reset All Settings">
+				<ui5-button id="resetAll">Reset All Settings content</ui5-button>
+				<ui5-toast id="toastResetAll">All changes Reset.</ui5-toast>
+			</ui5-user-settings-view>
+		</ui5-user-settings-item>
+	</ui5-user-settings-dialog>
+
+	<ui5-dialog id="additionalDialog" state="Information" header-text="Change Display Language">
+		<ui5-text>Changing the display language to [New Language] will update the language across the user interface.</ui5-text>
+		<ui5-toolbar slot="footer">
+			<ui5-toolbar-button class="dialogCloser" design="Emphasized" text="Change Language"></ui5-toolbar-button>
+			<ui5-toolbar-button class="dialogCloser" design="Transparent" text="Cancel"></ui5-toolbar-button>
+		</ui5-toolbar>
+	</ui5-dialog>
+
+	<script type="module">
+		import { setTheme } from "@ui5/webcomponents-base/dist/config/Theme.js";
+
+		const shellbar = document.getElementById("shellbar");
+
+		[...document.querySelectorAll("ui5-toggle-button")].forEach(el => {
+			el.addEventListener("click", event => {
+				const toggleButton = event.target;
+				toggleButton.icon = toggleButton.pressed ? "sap-icon://da-2" : "sap-icon://da";
+			});
+		});
+
+		/* Side navigation */
+		const menuButton = document.getElementById("menu-button");
+		const navigationLayout = document.getElementById("navigation-layout");
+		menuButton.addEventListener("click", () => {
+			navigationLayout.mode = navigationLayout.isSideCollapsed() ? "Expanded" : "Collapsed";
+		});
+
+		const sideNavigation = document.getElementById("side-navigation");
+		sideNavigation.addEventListener("selection-change", event => {
+			const contentTitle = document.getElementById("content-title");
+			contentTitle.textContent = event.detail.item?.text;
+		});
+		/* End side navigation */
+
+		/* Quick create dialog */
+		const quickCreate = document.getElementById("quick-create");
+		const quickCreateDialog = document.getElementById("quick-create-dialog");
+		quickCreate.accessibilityAttributes = {
+			hasPopup: "dialog"
+		};
+		quickCreate.addEventListener("click", () => {
+			quickCreateDialog.open = true;
+		});
+		document.getElementById("quick-create-dialog-close").addEventListener("click", () => {
+			quickCreateDialog.open = false;
+		});
+		/* End quick create dialog */
+
+		/* Notifications */
+		const notificationsPopover = document.querySelector(".notificationsPopover");
+		const notificationList = document.querySelector(".notificationsPopoverList");
+		const btnClearAll = document.querySelector("#clear-all");
+		const clearAllDialog = document.querySelector("#clear-all-dialog");
+		const dialogClosers = [...clearAllDialog.querySelectorAll(".dialogCloser")];
+		const btnClearAllAction = document.querySelector("#clear-all-action");
+		const notificationsListGroupGrowing = document.querySelector("#notificationsListGroupGrowing");
+		const btnOpenMenuSort = document.getElementById("btn-sort");
+		const menu = document.getElementById("sort-menu");
+
+		const itemsToLoad = 10;
+		let itemsLoaded = 6;
+
+		shellbar.addEventListener("notifications-click", e => {
+			e.preventDefault();
+			notificationsPopover.opener = e.detail.targetRef;
+			notificationsPopover.open = true;
+		});
+
+		notificationList.addEventListener("item-close", e => {
+			let visibleItems = 0;
+
+			e.detail.item.hidden = true;
+
+			Array.from(e.detail.item.parentElement.childNodes).forEach((element) => {
+				if (element.nodeName === "UI5-LI-NOTIFICATION" && !element.hidden) {
+					visibleItems++;
+				}
+			});
+
+			if (visibleItems === 0) {
+				e.detail.item.parentElement.hidden = true;
+			}
+		});
+
+		const insertItems = (list) => {
+			for (let i = itemsLoaded + 1; i <= itemsLoaded + itemsToLoad; i++) {
+				list.insertAdjacentHTML("beforeend",
+					`<ui5-li-notification title-text="Notification Title ${i}" show-close>
+						<ui5-avatar icon="expense-report" color-scheme="Accent1" shape="Square" size="XS" slot="avatar"></ui5-avatar>
+						<span slot="footnotes">Product Name</span>
+						<span slot="footnotes">Now</span>
+						<ui5-menu slot="menu">
+							<ui5-menu-item text="Unsubscribe"></ui5-menu-item>
+						</ui5-menu>
+						Description ${i}
+					</ui5-li-notification>`);
+			}
+
+			itemsLoaded += itemsToLoad;
+		};
+
+		notificationsListGroupGrowing.addEventListener("load-more", () => {
+			const focusIndex = notificationsListGroupGrowing.items.length;
+
+			notificationsListGroupGrowing.loading = true;
+			setTimeout(() => {
+				insertItems(notificationsListGroupGrowing);
+				notificationsListGroupGrowing.loading = false;
+
+				setTimeout(() => {
+					notificationsListGroupGrowing.items[focusIndex]?.focus();
+				}, 500);
+			}, 2000);
+		});
+
+		btnClearAll.accessibilityAttributes = {
+			hasPopup: "dialog",
+			controls: clearAllDialog.id,
+		};
+
+		btnClearAll.addEventListener("click", () => {
+			clearAllDialog.open = true;
+		});
+
+		dialogClosers.forEach(btn => {
+			btn.addEventListener("click", () => {
+				clearAllDialog.open = false;
+			});
+		});
+
+		btnClearAllAction.addEventListener("click", () => {
+			notificationList.innerHTML = `<ui5-illustrated-message name="NoNotifications"></ui5-illustrated-message>`;
+		});
+
+		btnOpenMenuSort.addEventListener("click", () => {
+			menu.opener = btnOpenMenuSort;
+			menu.open = true;
+		});
+		/* End Notifications */
+
+		/* User Menu */
+		const userMenu = document.getElementById("userMenu");
+
+		shellbar.addEventListener("ui5-profile-click", (event) => {
+			userMenu.opener = event.detail.targetRef;
+			userMenu.open = true;
+		});
+
+		userMenu.addEventListener("item-click", function (event) {
+			const item = event.detail.item.getAttribute("data-id");
+
+			switch (item) {
+				case "setting":
+					settingsDialog.open = true;
+					break;
+				default:
+					console.log("User menu item:", item);
+			}
+		});
+
+		userMenu.addEventListener("sign-out-click", function (event) {
+			const result = prompt("Sign Out", "Are you sure you want to sign out?");
+			if (result) {
+				userMenu.open = false;
+			}
+			event.preventDefault();
+		});
+		/* End User Menu */
+
+		/* User Settings Dialog */
+		const settingsDialog = document.getElementById("settings");
+		const settingsDialogItems = [...document.getElementsByTagName("ui5-user-settings-item")];
+		const appearanceView = document.querySelector("ui5-user-settings-appearance-view");
+		const additionalDialog = document.getElementById("additionalDialog");
+		const additionalDialogClosers = [...additionalDialog.querySelectorAll(".dialogCloser")];
+		const resetAllButton = document.getElementById("reset-all-button");
+		const resetAll = document.getElementById("resetAll");
+		const resetPersonalization = document.getElementById("resetPersonalization");
+		const toastReset = document.getElementById("toastReset");
+		const toastResetAll = document.getElementById("toastResetAll");
+
+		additionalDialogClosers.forEach(btn => {
+			btn.addEventListener("click", () => {
+				additionalDialog.open = false;
+			});
+		});
+
+		appearanceView.addEventListener("selection-change", (e) => {
+			const selectedItem = e.detail.item;
+
+			if (selectedItem?.itemKey) {
+				setTheme(selectedItem.itemKey);
+			}
+		});
+
+		resetAllButton.addEventListener("click", function () {
+			additionalDialog.open = true;
+		});
+
+		resetPersonalization.addEventListener("click", function () {
+			toastReset.open = true;
+		});
+
+		resetAll.addEventListener("click", function () {
+			toastResetAll.open = true;
+		});
+
+		settingsDialog.addEventListener("selection-change", function (event) {
+			if (event.detail.item?.text === "Language and Region") {
+				event.detail.item.loading = true;
+				event.detail.item.loadingReason = "Language & Region loading data...";
+				setTimeout(function () {
+					event.detail.item.loading = false;
+				}, 500);
+			}
+		});
+
+		settingsDialogItems.forEach((settingsDialogItem) => {
+			settingsDialogItem.addEventListener("selection-change", function (event) {
+				console.log(`Settings selection: ${event.detail.view?.text}`);
+			});
+		});
+		/* End User Settings Dialog */
+
+		/* Search */
+		const scopeData = [
+			{ name: "Laptop", scope: "products" },
+			{ name: "Leave Requests", scope: "apps" },
+			{ name: "Log work", scope: "apps" },
+			{ name: "Manage Products", scope: "apps" },
+			{ name: "Mobile Phones", scope: "products" },
+			{ name: "Tablet", scope: "products" },
+		];
+
+		const searchScope = document.getElementById("search-scope");
+		const searchInGroup = document.getElementById("search-in-group");
+
+		function createScopeItems(scope) {
+			const filterData = !scope ? scopeData : scopeData.filter(item => item.scope === scope);
+
+			filterData.forEach(item => {
+				const searchItem = document.createElement("ui5-search-item");
+				searchItem.text = item.name;
+				searchItem.scopeName = item.scope;
+				// Insert before the "Search in" group so it stays at the bottom of the popup.
+				searchScope.insertBefore(searchItem, searchInGroup);
+			});
+		}
+
+		createScopeItems();
+
+		searchScope.addEventListener("ui5-scope-change", (event) => {
+			const scope = event.detail.scope.value === "all" ? "" : event.detail.scope.value;
+
+			// Remove only the scope-driven suggestion items; keep the "Search in" group intact.
+			[...searchScope.children].forEach(child => {
+				if (child.tagName === "UI5-SEARCH-ITEM") {
+					child.remove();
+				}
+			});
+
+			createScopeItems(scope);
+		});
+
+		// Items in the "Search in" group act as scope switchers rather than search submissions.
+		searchScope.addEventListener("ui5-search", (event) => {
+			const item = event.detail.item;
+			const targetScope = item && item.dataset && item.dataset.scope;
+
+			if (!targetScope) {
+				return;
+			}
+
+			// preventDefault keeps the popup open so the user can continue picking suggestions in the new scope.
+			event.preventDefault();
+			searchScope.scopeValue = targetScope;
+			searchScope.value = "";
+			searchScope.focus();
+		});
+		/* End Search */
+	</script>
+</body>
+
+</html>


### PR DESCRIPTION
## Why

Calling \`event.preventDefault()\` on the \`ui5-search\` event from an item click is the established way to signal *"I handled this selection myself, don't dismiss the picker"*. On desktop that worked. On phone, \`_onItemClick\` still forced \`this.open = false\` in the prevented branch, so the dialog closed regardless.

A real-world consequence: you can't implement *"pick a scope from a 'Search in' suggestion group"* on mobile because the popup vanishes the moment the user taps the scope-switching item.

## What changes

- **\`Search.ts\`** — Remove the phone-only \`this.open = false\` inside the prevented arm of \`_onItemClick\`. Mobile now matches desktop: \`preventDefault\` keeps the popup open.
- **\`SearchPopoverTemplate.tsx\`** — Pass \`value={this.value}\` into the mobile dialog \`Input\` so the host search's current value is reflected when the dialog opens.
- **\`test/pages/Search.html\`** — Add a "Search in" example: a \`ui5-search-item-group header-text="Search in"\` where each item carries \`data-scope\`. A page-level \`ui5-search\` handler calls \`preventDefault()\`, switches \`scopeValue\`, clears \`value\`, and keeps the popup open.
- **\`test/pages/UXCIntegration.html\`** — New test page mirroring the website's UXC Integration sample, with the same scope-switching pattern wired into the shellbar search.
- **\`Search.mobile.cy.tsx\`** — New test \`should keep the popup open on item selection when preventDefault is called\` that opens the mobile dialog, taps a suggestion with a \`preventDefault\` listener attached, and asserts both \`search.open === true\` and the inner \`ui5-responsive-popover\` is still open. Verified to fail against the pre-fix code with: *"expected \`<ui5-search>\` to have property 'open' with the value true, but the value was false"*.

## How to verify

- Open \`packages/fiori/test/pages/Search.html\` → "Search with Grouped Suggestions and 'Search in' group" → pick a scope from the bottom group; popup stays open and the scope chip switches.
- Open \`packages/fiori/test/pages/UXCIntegration.html\` → shellbar search → "Search in" group → same behavior.
- \`yarn test:cypress:single cypress/specs/Search.mobile.cy.tsx\` — 9/9 passing.
- \`yarn test:cypress:single cypress/specs/Search.cy.tsx\` — 63/63 passing.