### PR TITLE
fix(ui5-select): align value state message header with design spec

### DIFF
--- a/packages/main/src/themes/SelectPopover.css
+++ b/packages/main/src/themes/SelectPopover.css
@@ -4,5 +4,19 @@
 }
 
 .ui5-select-popover .ui5-responsive-popover-header .row {
-    justify-content: flex-start;
+	justify-content: flex-start;
+}
+
+/* Align value state message header with Visual Design spec (issue #13308):
+   - Remove the per-state inset bottom border (box-shadow)
+   - Add sapContent_HeaderShadow to separate header from options list */
+.ui5-select-popover .ui5-valuestatemessage--error,
+.ui5-select-popover .ui5-valuestatemessage--warning,
+.ui5-select-popover .ui5-valuestatemessage--success,
+.ui5-select-popover .ui5-valuestatemessage--information {
+	box-shadow: none;
+}
+
+.ui5-select-popover .ui5-valuestatemessage-header {
+	box-shadow: var(--sapContent_HeaderShadow);
 }

--- a/packages/main/src/themes/SelectPopover.css
+++ b/packages/main/src/themes/SelectPopover.css
@@ -7,9 +7,6 @@
 	justify-content: flex-start;
 }
 
-/* Align value state message header with Visual Design spec (issue #13308):
-   - Remove the per-state inset bottom border (box-shadow)
-   - Add sapContent_HeaderShadow to separate header from options list */
 .ui5-select-popover .ui5-valuestatemessage--error,
 .ui5-select-popover .ui5-valuestatemessage--warning,
 .ui5-select-popover .ui5-valuestatemessage--success,


### PR DESCRIPTION
The value state message header in the Select dropdown had a colored inset box-shadow acting as a
bottom border (e.g. red for error, orange for warning). This did not match the Horizon
Visual Design specification.

**Changes in `SelectPopover.css`:**

- Remove the per-state inset box-shadow (bottom border) from all four value states (`error`,
  `warning`, `success`, `information`) scoped to `.ui5-select-popover`
- Add `sapContent_HeaderShadow` to the value state message header to visually separate it from the
  options list below.

JIRA: BGSOFUIPIRIN-7061
Related to: https://github.com/UI5/webcomponents/issues/13308