### PR TITLE
docs: Add space for markdown syntax

### DIFF
--- a/docs/12-FAQ.md
+++ b/docs/12-FAQ.md
@@ -22,7 +22,7 @@ sidebar_label: FAQ
 
 **Q: Are UI5 Web Components APIs stable?**
 
-**A:**Yes.
+**A:** Yes.
 
 
 **Q: Can I create my own UI5 Web Components?**


### PR DESCRIPTION
Fixes: #13771

**Thank you for your contribution!** 👏

### Background
A section in the [FAQ](https://ui5.github.io/webcomponents/docs/FAQ/) shows asterisks instead of being bold, included in Issue #13771 is a screenshot of how it is rendering. This PR corrects the syntax.

### Change
Added a space in `docs/12-FAQ.md` to correct the syntax.

### PR checklist
- [x] Check the [Development Hints](https://ui5.github.io/webcomponents/docs/contributing/DoD/)

- [x] Follow the [Commit message Guidelines](https://github.com/UI5/webcomponents/blob/main/docs/5-contributing/02-conventions-and-guidelines.md#commit-message-style)

For example: `fix(ui5-*): correct/fix sth` or `feat(ui5-*): add/introduce sth`. If you don't want the change to be part of the release changelog - use `chore`, `refactor` or `docs`.

- [x] Add proper description about the background of the change and the change itself

- [x] Link to an existing issue (if available)

Use `Fixes: {#PR_NUMBER}` to close the issue automatically when the PR is merged
or `Related to: {#PR_NUMBER}` to just create a link between the PR and the issue.

- [x] Read the [Contributing Guidelines](https://github.com/UI5/webcomponents/blob/main/CONTRIBUTING.md)
