### PR TITLE
fix(ui5-li-custom, ui5-tree-item-custom): add accessibleName property for stable accessible names

### DIFF
--- a/packages/main/src/ListItemCustom.ts
+++ b/packages/main/src/ListItemCustom.ts
@@ -65,10 +65,10 @@ class ListItemCustom extends ListItem {
 	 * **Note**: If not provided a default text alternative will be set, if present.
 	 * @default undefined
 	 * @public
-	 * @since 1.0.0-rc.15
+	 * @since 2.24.0
 	 */
 	@property()
-	declare accessibleName?: string;
+	accessibleName?: string;
 
 	_onkeydown(e: KeyboardEvent) {
 		const isFocused = this.matches(":focus");

--- a/packages/main/src/ListItemCustom.ts
+++ b/packages/main/src/ListItemCustom.ts
@@ -65,7 +65,7 @@ class ListItemCustom extends ListItem {
 	 * **Note**: If not provided a default text alternative will be set, if present.
 	 * @default undefined
 	 * @public
-	 * @since 2.24.0
+	 * @since 1.0.0-rc.15
 	 */
 	@property()
 	accessibleName?: string;

--- a/packages/main/src/TreeItemBase.ts
+++ b/packages/main/src/TreeItemBase.ts
@@ -168,7 +168,7 @@ class TreeItemBase extends ListItem {
 	 * Defines the accessible name of the component.
 	 * @default undefined
 	 * @public
-	 * @since 2.24.0
+	 * @since 1.8.0
 	 */
 	@property()
 	accessibleName?: string;

--- a/packages/main/src/TreeItemBase.ts
+++ b/packages/main/src/TreeItemBase.ts
@@ -168,10 +168,10 @@ class TreeItemBase extends ListItem {
 	 * Defines the accessible name of the component.
 	 * @default undefined
 	 * @public
-	 * @since 1.8.0
+	 * @since 2.24.0
 	 */
 	@property()
-	declare accessibleName?: string;
+	accessibleName?: string;
 
 	/**
 	 * @private


### PR DESCRIPTION
**Problem:**
- Before this change, the accessible name of `ui5-li-custom` items was only populated
while the item was focused, causing `aria-labelledby` to be empty for non-focused items.

**Solution:**
- Adds an `accessibleName` property to `ui5-li-custom` and `TreeItemBase` (used by
`ui5-tree-item-custom`). When set, it bypasses the focus-based invisible text mechanism and
provides a stable, always-present accessible name regardless of focus state.

Fixes: https://github.com/UI5/webcomponents/issues/13478