### PR TITLE
fix(ui5-flexible-column-layout): expose separator accessible name via aria-label

### DIFF
--- a/packages/fiori/src/FlexibleColumnLayoutTemplate.tsx
+++ b/packages/fiori/src/FlexibleColumnLayoutTemplate.tsx
@@ -30,6 +30,7 @@ export default function FlexibleColumnLayoutTemplate(this: FlexibleColumnLayout)
 			<div
 				role={this.accStartSeparatorRole}
 				title={this.accStartSeparatorText}
+				aria-label={this.accStartSeparatorText}
 				class="ui5-fcl-separator ui5-fcl-separator-start"
 				style={{ display: this.showStartSeparator ? "flex" : "none" }}
 				tabindex={this.startSeparatorTabIndex}
@@ -62,6 +63,7 @@ export default function FlexibleColumnLayoutTemplate(this: FlexibleColumnLayout)
 			<div
 				role={this.accEndSeparatorRole}
 				title={this.accEndSeparatorText}
+				aria-label={this.accEndSeparatorText}
 				class="ui5-fcl-separator ui5-fcl-separator-end"
 				style={{ display: this.showEndSeparator ? "flex" : "none" }}
 				tabindex={this.endSeparatorTabIndex}


### PR DESCRIPTION
The start/end separator role="separator" elements were only announcing their accessible name through the title attribute, which VoiceOver ignores by default and JAWS only reads at higher verbosity settings.

Added aria-label alongside the existing title on both separators so all major screen readers reliably announce "Resize between ... columns".

Fixes #13775
