### PR TITLE
fix(ui5-list): expose item selection state via aria-selected attribute

### DIFF
--- a/packages/main/src/ListItem.ts
+++ b/packages/main/src/ListItem.ts
@@ -520,6 +520,7 @@ abstract class ListItem extends ListItemBase {
 			ariaLevel: undefined,
 			ariaLabel: ListItem.i18nBundle.getText(ARIA_LABEL_LIST_ITEM_CHECKBOX),
 			ariaLabelRadioButton: ListItem.i18nBundle.getText(ARIA_LABEL_LIST_ITEM_RADIO_BUTTON),
+			ariaSelected: this._ariaSelected,
 			ariaSelectedText: this.ariaSelectedText,
 			ariaHaspopup: this.accessibilityAttributes.hasPopup,
 			setsize: this.accessibilityAttributes.ariaSetsize,


### PR DESCRIPTION
The _accInfo getter in ListItem was omitting ariaSelected from its returned object, so the <li> element never received the aria-selected attribute despite the value being correctly computed by _ariaSelected.

Screen readers like VoiceOver rely on aria-selected for announcing selection state and were only seeing the aria-describedby fallback text, which is not consistently read across screen reader/browser combinations.

Fixes #13773

