### PR TITLE
fix(ui5-table-header-cell): set min-height to prevent header row jump

### DIFF
--- a/packages/main/cypress/specs/Table.cy.tsx
+++ b/packages/main/cypress/specs/Table.cy.tsx
@@ -119,6 +119,7 @@ describe("Table - Rendering", () => {
 		const expectedWidth = 100;
 		cy.get("ui5-table-header-cell").each(($cell) => {
 			expect($cell.outerWidth()).to.be.equal(expectedWidth);
+			expect(getComputedStyle($cell[0]).minHeight).to.not.equal("auto");
 		});
 	});
 

--- a/packages/main/src/themes/TableHeaderCell.css
+++ b/packages/main/src/themes/TableHeaderCell.css
@@ -5,6 +5,7 @@
 	flex-wrap: nowrap;
 	max-width: 100%;
 	gap: 0.125rem;
+	min-height: var(--_ui5_list_item_base_height);
 }
 
 :host(:empty) {


### PR DESCRIPTION
When a sortable header cell contains an Icon component, clicking it caused the header row to jump upward due to inconsistent cell height. Applying a minimum height based on the list item base height keeps the header row stable across interactions.

Fixes: #13454