### PR TITLE
test: add visual regression tests for main and fiori components

### DIFF
--- a/.claude/skills/visual-test/SKILL.md
+++ b/.claude/skills/visual-test/SKILL.md
@@ -1,0 +1,401 @@
+---
+name: visual-test
+description: >
+  Write basic Cypress visual tests for UI5 web components, placing them in
+  cypress/specs/visuals/. Use this skill whenever the user asks to create,
+  add, or write a visual test (or screenshot test) for any UI5 web component.
+  Also trigger when the user says things like "add a visual spec for X",
+  "create a visual test for X", or "write a cypress visual for X".
+---
+
+# Writing Visual Tests for UI5 Web Components
+
+Visual tests live in `packages/main/cypress/specs/visuals/` and capture
+screenshots of a component at key states. They are intentionally minimal —
+their job is to record what the component looks like, not to assert on DOM
+internals.
+
+## One component per file
+
+Each file tests exactly ONE component. Do not import unrelated components.
+If the component uses child items (e.g. `MultiComboBoxItem` inside
+`MultiComboBox`), those child imports are fine — they are part of the same
+component family.
+
+**Wrong:** importing `RangeSlider` in a `MultiComboBox` test just to
+demonstrate a layout.
+
+**Right:** only `MultiComboBox` + `MultiComboBoxItem`.
+
+## Required parent containers
+
+Some components cannot render meaningfully (or at all) without a specific
+parent. Always wrap them in the minimal required parent — and import that
+parent too. The parent is part of the component's contract, not an
+"unrelated component".
+
+| Component(s) | Required parent |
+|---|---|
+| `ListItemStandard`, `ListItemCustom`, `ListItemGroup` | `List` |
+| `TableRow`, `TableHeaderRow`, `TableGroupRow`, `TableCell`, `TableHeaderCell` | `Table` |
+| `Tab`, `TabSeparator` | `TabContainer` |
+| `TreeItem`, `TreeItemCustom` | `Tree` |
+| `MenuItem`, `MenuItemGroup`, `MenuSeparator` | `Menu` |
+| `Option` | `Select` |
+| `BreadcrumbsItem` | `Breadcrumbs` |
+| `Token` | `Tokenizer` |
+| `ToolbarButton`, `ToolbarSelect`, `ToolbarSeparator`, `ToolbarSpacer` | `Toolbar` |
+| `CarouselPage` (or any direct child) | `Carousel` |
+| `NotificationListItem`, `NotificationListGroupItem` | `NotificationList` |
+
+When writing a visual test for a child component (e.g. `ListItemStandard`),
+name the **file** after the child (`ListItemStandard.cy.tsx`), but wrap it
+in the minimal parent — just enough items to show the component, nothing
+more.
+
+## File location and naming
+
+```
+packages/main/cypress/specs/visuals/ComponentName.cy.tsx   # for @ui5/webcomponents
+packages/fiori/cypress/specs/visuals/ComponentName.cy.tsx  # for @ui5/webcomponents-fiori
+```
+
+Use the same PascalCase name as the source component file.
+
+## Import paths
+
+For **main** package components, import three levels up from `visuals/`:
+
+```tsx
+import MultiComboBox from "../../../src/MultiComboBox.js";
+import MultiComboBoxItem from "../../../src/MultiComboBoxItem.js";
+```
+
+For **fiori** package components, import two levels up from `visuals/`:
+
+```tsx
+import IllustratedMessage from "../../src/IllustratedMessage.js";
+import Timeline from "../../src/Timeline.js";
+```
+
+When a fiori component needs a main-package component (e.g. a Button in a slot), import from the dist package:
+
+```tsx
+import Button from "@ui5/webcomponents/dist/Button.js";
+```
+
+For `IllustratedMessage`, there are no individual illustration source files — import the single bundle from src:
+
+```tsx
+import "../../../src/illustrations/AllIllustrations.js";
+```
+
+Import only what you actually use in the test.
+
+## Before writing: read the existing functional test
+
+Before writing a visual test for `ComponentName`, always read the existing
+functional test file at:
+
+```
+packages/main/cypress/specs/ComponentName.cy.tsx     # main package
+packages/fiori/cypress/specs/ComponentName.cy.tsx    # fiori package
+```
+
+Skim it for:
+- **What prop combinations** it exercises (these are the states worth
+  capturing visually).
+- **What interactions** it triggers — open, focus, type, navigate — that
+  produce a distinct visual state.
+- **What custom commands** it uses — these are already available for reuse
+  in the visual test.
+- **What child components and slots** it uses, which tells you the correct
+  parent container and slot names.
+
+You do not need to cover every functional test case — only the ones that
+produce a meaningfully different visual appearance. But anything the
+functional test exercises that you had not considered is a signal worth
+checking.
+
+## Test structure: one case per distinct visual state
+
+Write one `it` per meaningful visual state. Do not bundle multiple states
+into a single test — each screenshot should capture exactly one thing.
+
+A single `it` can contain multiple `cy.screenshot()` calls if you are
+stepping through a sequential interaction and each intermediate step is
+worth recording (e.g. arrow-key navigation through a list). But if two
+states are reached by completely independent setups, use two separate `it`
+blocks.
+
+### Standard cases to consider for every component
+
+1. **Initial/basic state** — component mounted with minimal props, no
+   interaction. Always include this.
+2. **Compact mode** — remount the same component with `data-ui5-compact-size`
+   on a wrapper `<div>`, then screenshot. Most components render
+   differently in compact.
+3. **Interactive/open state** — dropdown open, popover visible, focused,
+   etc.
+
+### Additional cases based on what the component supports
+
+Look at what the component can show and add cases accordingly:
+
+- **Item focus in dropdown** — open the picker, press ArrowDown to focus
+  the first item, screenshot. Press again to focus a group header if present.
+- **Filtering** — type a character to filter suggestions, screenshot the
+  narrowed list.
+- **Selected items / tokens** — pre-select items, screenshot the tokenized
+  state.
+- **Value state** — when a component accepts `valueState`, write one `it` per
+  value state value. The full set is `Negative`, `Critical`, `Positive`,
+  `Information`. `None` is the default and is already covered by the basic
+  state test — do not add a separate case for it. Always include a
+  `valueStateMessage` slot so the message strip renders. Applies to Input,
+  MultiComboBox, Select, DatePicker, DateTimePicker, etc.
+- **No items** — empty list state (e.g. `<MultiComboBox>` with no children,
+  dropdown open).
+- **Wrapping / long content** — pass a very long text or many tokens to
+  capture overflow/wrapping behaviour.
+
+### What does NOT need its own test
+
+- Trivial prop changes that produce no visible difference.
+- States already covered by another `it`.
+
+There is no fixed maximum — cover what the component genuinely shows.
+
+## Slot assignment
+
+Always assign slotted children as **child elements with a `slot` attribute**,
+never as JSX props on the parent component:
+
+```tsx
+// WRONG — passing slot content as a JSX prop
+<Page header={<Bar>...</Bar>} footer={<Bar>...</Bar>} />
+
+// CORRECT — slot attribute on the child element
+<Page>
+  <Bar slot="header">...</Bar>
+  <div>Main content</div>
+  <Bar slot="footer">...</Bar>
+</Page>
+```
+
+This matches how web component slots work in the DOM. Passing slot content
+as a prop bypasses the slot mechanism and will not render correctly.
+
+
+
+Use attribute selectors, not tag names:
+
+```tsx
+cy.get("[ui5-multi-combobox]")   // correct
+cy.get("ui5-multi-combobox")     // wrong
+```
+
+The attribute selector matches the `[ui5-*]` marker that web components add
+to themselves and is more resilient to tag name changes.
+
+## Triggering interactions
+
+Always prefer the existing custom commands over raw DOM queries — they
+already handle waiting and shadow DOM traversal correctly.
+
+### Available custom commands (use these for interactions)
+
+| Component | Command | What it does |
+|---|---|---|
+| `DatePicker` | `.ui5DatePickerValueHelpIconPress()` | Opens the calendar popover |
+| `TimePicker` | `.ui5TimePickerValueHelpIconPress()` | Opens the time picker popover |
+| `Menu` | `.ui5MenuOpen()` | Opens the menu popover |
+| `Menu` | `.ui5MenuOpened()` | Asserts menu is open (use after open) |
+| `ColorPalettePopover` | `.ui5ColorPalettePopoverOpen()` | Opens the color palette popover |
+| `DynamicDateRange` | `.ui5DynamicDateRangeOpen()` | Opens the DDR popover |
+| `TabContainer` | `.ui5TabContainerOpenEndOverflow()` | Opens the overflow tab list |
+| `Dialog` | `.ui5DialogOpened()` | Asserts dialog is open |
+| `Popover` | `.ui5PopoverOpened()` | Asserts popover is open |
+| `ResponsivePopover` | `.ui5ResponsivePopoverOpened()` | Asserts responsive popover is open |
+
+For components without a custom command, use `realClick()`:
+
+```tsx
+// Open a select dropdown
+cy.get("[ui5-select]").realClick();
+
+// Open a multicombobox dropdown via its icon
+cy.get("[ui5-multi-combobox]").shadow().find("[icon]").realClick();
+```
+
+After triggering the interaction, call `cy.screenshot()` immediately — no
+assertions needed.
+
+## Complete example
+
+The example below covers the full range of meaningful visual states for
+MultiComboBox — the same states tested in the openui5 visual regression
+suite: basic, open, filtering, item focus, tokens, value state, no items.
+
+```tsx
+import MultiComboBox from "../../../src/MultiComboBox.js";
+import MultiComboBoxItem from "../../../src/MultiComboBoxItem.js";
+
+describe("MultiComboBox visual", () => {
+	it("basic state", () => {
+		cy.mount(
+			<MultiComboBox>
+				<MultiComboBoxItem text="Algeria" />
+				<MultiComboBoxItem text="Bulgaria" />
+				<MultiComboBoxItem text="Canada" />
+			</MultiComboBox>
+		);
+		cy.screenshot();
+	});
+
+	it("dropdown open", () => {
+		cy.mount(
+			<MultiComboBox>
+				<MultiComboBoxItem text="Algeria" />
+				<MultiComboBoxItem text="Bulgaria" />
+				<MultiComboBoxItem text="Canada" />
+			</MultiComboBox>
+		);
+		cy.get("[ui5-multi-combobox]").shadow().find("[ui5-icon]").realClick();
+		cy.get("[ui5-multi-combobox]").shadow().find("ui5-responsive-popover").ui5ResponsivePopoverOpened();
+		cy.screenshot();
+	});
+
+	it("filtering — type to narrow list", () => {
+		cy.mount(
+			<MultiComboBox>
+				<MultiComboBoxItem text="Algeria" />
+				<MultiComboBoxItem text="Bulgaria" />
+				<MultiComboBoxItem text="Canada" />
+			</MultiComboBox>
+		);
+		cy.get("[ui5-multi-combobox]").realClick();
+		cy.realType("B");
+		cy.screenshot();
+	});
+
+	it("dropdown open — first item focused via arrow key", () => {
+		cy.mount(
+			<MultiComboBox>
+				<MultiComboBoxItem text="Algeria" />
+				<MultiComboBoxItem text="Bulgaria" />
+				<MultiComboBoxItem text="Canada" />
+			</MultiComboBox>
+		);
+		cy.get("[ui5-multi-combobox]").shadow().find("[ui5-icon]").realClick();
+		cy.get("[ui5-multi-combobox]").shadow().find("ui5-responsive-popover").ui5ResponsivePopoverOpened();
+		cy.realPress("ArrowDown");
+		cy.screenshot();
+	});
+
+	it("with selected tokens", () => {
+		cy.mount(
+			<MultiComboBox>
+				<MultiComboBoxItem selected text="Algeria" />
+				<MultiComboBoxItem selected text="Bulgaria" />
+				<MultiComboBoxItem text="Canada" />
+			</MultiComboBox>
+		);
+		cy.screenshot();
+	});
+
+	it("value state — Negative", () => {
+		cy.mount(
+			<MultiComboBox valueState="Negative">
+				<span slot="valueStateMessage">Error message</span>
+				<MultiComboBoxItem text="Algeria" />
+				<MultiComboBoxItem text="Bulgaria" />
+			</MultiComboBox>
+		);
+		cy.screenshot();
+	});
+
+	it("value state — Critical", () => {
+		cy.mount(
+			<MultiComboBox valueState="Critical">
+				<span slot="valueStateMessage">Warning message</span>
+				<MultiComboBoxItem text="Algeria" />
+				<MultiComboBoxItem text="Bulgaria" />
+			</MultiComboBox>
+		);
+		cy.screenshot();
+	});
+
+	it("value state — Positive", () => {
+		cy.mount(
+			<MultiComboBox valueState="Positive">
+				<span slot="valueStateMessage">Success message</span>
+				<MultiComboBoxItem text="Algeria" />
+				<MultiComboBoxItem text="Bulgaria" />
+			</MultiComboBox>
+		);
+		cy.screenshot();
+	});
+
+	it("value state — Information", () => {
+		cy.mount(
+			<MultiComboBox valueState="Information">
+				<span slot="valueStateMessage">Info message</span>
+				<MultiComboBoxItem text="Algeria" />
+				<MultiComboBoxItem text="Bulgaria" />
+			</MultiComboBox>
+		);
+		cy.screenshot();
+	});
+
+	it("no items — empty dropdown open", () => {
+		cy.mount(<MultiComboBox />);
+		cy.get("[ui5-multi-combobox]").shadow().find("[ui5-icon]").realClick();
+		cy.screenshot();
+	});
+});
+```
+
+## What NOT to do
+
+- No `.should()` assertions — this is a visual test, not a functional one.
+- No interactions unrelated to the component's own UI (don't open a Dialog
+  just to show the component inside it).
+- No extra wrapper components to "set up" the test — if the component needs
+  a value, pass it as a prop directly.
+- No `cy.wait()` or arbitrary timeouts — if you need to wait for an open
+  animation, use `.ui5ResponsivePopoverOpened()` (chained off the popover
+  element found in shadow DOM) to verify the popup is open before screenshotting.
+
+## Avoid dynamic / non-deterministic content
+
+Screenshots must be identical on every run. Anything that changes between
+runs will cause false diffs and make the test useless as a visual baseline.
+
+**Avoid:**
+- `BusyIndicator` — the spinner animation frame varies per run.
+- `DatePicker`, `TimePicker`, `DateRangePicker`, `DateTimePicker` without a
+  fixed value — they display today's date, which changes daily. Always pass
+  a hardcoded `value` prop: `<DatePicker value="2024-01-15" />`.
+- `DynamicDateRange` without a fixed option selected.
+- Any component that fetches or derives content at runtime (clocks,
+  relative timestamps, random IDs shown in the UI).
+
+**If you must include a date/time component**, pin the value:
+```tsx
+<DatePicker value="Jan 15, 2024" />
+<TimePicker value="10:00:00" />
+```
+
+## Running the test
+
+```bash
+cd packages/main
+npx cypress run --component --browser chrome --spec cypress/specs/visuals/ComponentName.cy.tsx
+```
+
+Or open interactive mode:
+```bash
+cd packages/main
+yarn test:cypress:open
+```

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ coverage
 # Cypress internal logs
 cypress-logs
 
+cypress/screenshots
+cypress/videos
+
 # scoping feature generated entry points for vite consumption
 packages/compat/test/pages/scoped
 packages/main/test/pages/scoped

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "ci:test:fiori": "yarn workspace @ui5/webcomponents-fiori test:ssr && yarn workspace @ui5/webcomponents-fiori test:cypress",
     "ci:test:compat": "yarn workspace @ui5/webcomponents-compat test:ssr && yarn workspace @ui5/webcomponents-compat test:cypress",
     "ci:test:ai": "yarn workspace @ui5/webcomponents-ai test:ssr && yarn workspace @ui5/webcomponents-ai test",
+    "ci:test:visual": "yarn workspaces foreach --all --include '@ui5/webcomponents' --include '@ui5/webcomponents-fiori' run test:cypress:visual",
     "lint": "yarn workspaces foreach --all --parallel run lint",
     "lint:scope": "yarn workspaces foreach --all --parallel run lint:scope",
     "link-all": "yarn workspaces foreach --all --parallel run link",

--- a/packages/cypress-internal/src/commands.ts
+++ b/packages/cypress-internal/src/commands.ts
@@ -32,6 +32,19 @@ const realEventCmdCallback = (originalFn: any, element: any, ...args: any) => {
 		.then(() => originalFn(element, ...args));
 };
 
+Cypress.Commands.overwrite("focus", (originalFn, element, ...args) => {
+	cy.waitRenderFinished();
+
+	cy.get(element as any)
+		.then($el => {
+			const el = $el[0];
+			if (el.tagName.includes("-") && typeof el.focus === "function") {
+				return cy.wrap(el.focus(...args), { log: false });
+			}
+			return originalFn(element, ...args);
+		});
+});
+
 const realEventCommands = [
 	"realClick",
 	"realHover",

--- a/packages/cypress-internal/src/cypress.config.ts
+++ b/packages/cypress-internal/src/cypress.config.ts
@@ -4,9 +4,15 @@ import viteConfig from "../../../vite.config.js";
 import coverageTask from "@cypress/code-coverage/task.js";
 import svgTask from "./svg_validation/task.js";
 
+// @ts-ignore
+const isVisual = process.env.CYPRESS_VISUAL === "true";
 
 export default defineConfig({
 	component: {
+		specPattern: isVisual
+			? "cypress/specs/visuals/**/*.cy.{js,jsx,ts,tsx}"
+			: "cypress/specs/**/*.cy.{js,jsx,ts,tsx}",
+		excludeSpecPattern: isVisual ? [] : ["cypress/specs/visuals/**"],
 		setupNodeEvents(on, config) {
 			coverageTask(on, config);
 			svgTask(on, config);

--- a/packages/fiori/cypress/specs/visuals/IllustratedMessage.cy.tsx
+++ b/packages/fiori/cypress/specs/visuals/IllustratedMessage.cy.tsx
@@ -1,0 +1,64 @@
+import IllustratedMessage from "../../../src/IllustratedMessage.js";
+import "../../../src/illustrations/AllIllustrations.js";
+
+describe("IllustratedMessage visual", () => {
+	it("basic state — BeforeSearch", () => {
+		cy.mount(<IllustratedMessage name="BeforeSearch" />);
+		cy.screenshot();
+	});
+
+	it("illustration — NoData", () => {
+		cy.mount(<IllustratedMessage name="NoData" />);
+		cy.screenshot();
+	});
+
+	it("illustration — UnableToUpload", () => {
+		cy.mount(<IllustratedMessage name="UnableToUpload" />);
+		cy.screenshot();
+	});
+
+	it("illustration — SuccessScreen", () => {
+		cy.mount(<IllustratedMessage name="SuccessScreen" />);
+		cy.screenshot();
+	});
+
+	it("design — ExtraSmall", () => {
+		cy.mount(<IllustratedMessage name="BeforeSearch" design="ExtraSmall" />);
+		cy.screenshot();
+	});
+
+	it("design — Small", () => {
+		cy.mount(<IllustratedMessage name="BeforeSearch" design="Small" />);
+		cy.screenshot();
+	});
+
+	it("design — Medium", () => {
+		cy.mount(<IllustratedMessage name="BeforeSearch" design="Medium" />);
+		cy.screenshot();
+	});
+
+	it("design — Large", () => {
+		cy.mount(<IllustratedMessage name="BeforeSearch" design="Large" />);
+		cy.screenshot();
+	});
+
+	it("custom title and subtitle", () => {
+		cy.mount(
+			<IllustratedMessage
+				name="NoData"
+				titleText="No results found"
+				subtitleText="Try adjusting your search or filter criteria."
+			/>
+		);
+		cy.screenshot();
+	});
+
+	it("compact mode", () => {
+		cy.mount(
+			<div data-ui5-compact-size>
+				<IllustratedMessage name="NoData" design="Small" />
+			</div>
+		);
+		cy.screenshot();
+	});
+});

--- a/packages/fiori/cypress/specs/visuals/NotificationListItem.cy.tsx
+++ b/packages/fiori/cypress/specs/visuals/NotificationListItem.cy.tsx
@@ -1,0 +1,137 @@
+import NotificationList from "../../../src/NotificationList.js";
+import NotificationListItem from "../../../src/NotificationListItem.js";
+
+describe("NotificationListItem visual", () => {
+	it("basic state — unread", () => {
+		cy.mount(
+			<NotificationList>
+				<NotificationListItem titleText="New order received" showClose>
+					Order #12345 has been placed and is awaiting processing.
+				</NotificationListItem>
+			</NotificationList>
+		);
+		cy.screenshot();
+	});
+
+	it("read state", () => {
+		cy.mount(
+			<NotificationList>
+				<NotificationListItem titleText="New order received" read showClose>
+					Order #12345 has been placed and is awaiting processing.
+				</NotificationListItem>
+			</NotificationList>
+		);
+		cy.screenshot();
+	});
+
+	it("importance — Important", () => {
+		cy.mount(
+			<NotificationList>
+				<NotificationListItem titleText="Critical system alert" importance="Important" showClose>
+					System maintenance scheduled for tonight at 10 PM.
+				</NotificationListItem>
+			</NotificationList>
+		);
+		cy.screenshot();
+	});
+
+	it("state — Negative", () => {
+		cy.mount(
+			<NotificationList>
+				<NotificationListItem titleText="Upload failed" state="Negative" showClose>
+					The file could not be uploaded. Please try again.
+				</NotificationListItem>
+			</NotificationList>
+		);
+		cy.screenshot();
+	});
+
+	it("state — Critical", () => {
+		cy.mount(
+			<NotificationList>
+				<NotificationListItem titleText="Storage almost full" state="Critical" showClose>
+					You have used 90% of your storage quota.
+				</NotificationListItem>
+			</NotificationList>
+		);
+		cy.screenshot();
+	});
+
+	it("state — Positive", () => {
+		cy.mount(
+			<NotificationList>
+				<NotificationListItem titleText="Deployment successful" state="Positive" showClose>
+					Your application has been deployed successfully.
+				</NotificationListItem>
+			</NotificationList>
+		);
+		cy.screenshot();
+	});
+
+	it("state — Information", () => {
+		cy.mount(
+			<NotificationList>
+				<NotificationListItem titleText="Scheduled maintenance" state="Information" showClose>
+					System will be unavailable from 2:00 AM to 4:00 AM.
+				</NotificationListItem>
+			</NotificationList>
+		);
+		cy.screenshot();
+	});
+
+	it("wrapping — long text", () => {
+		cy.mount(
+			<NotificationList>
+				<NotificationListItem
+					titleText="Very long notification title that should wrap onto the next line when wrapping is enabled"
+					wrappingType="Normal"
+					showClose
+				>
+					This is a longer description that goes into more detail about the notification and what action needs to be taken by the user to resolve the issue.
+				</NotificationListItem>
+			</NotificationList>
+		);
+		cy.screenshot();
+	});
+
+	it("without close button", () => {
+		cy.mount(
+			<NotificationList>
+				<NotificationListItem titleText="Non-dismissable notification">
+					This notification cannot be closed by the user.
+				</NotificationListItem>
+			</NotificationList>
+		);
+		cy.screenshot();
+	});
+
+	it("multiple items", () => {
+		cy.mount(
+			<NotificationList>
+				<NotificationListItem titleText="New order received" importance="Important" showClose>
+					Order #12345 has been placed.
+				</NotificationListItem>
+				<NotificationListItem titleText="Upload failed" state="Negative" read showClose>
+					The file could not be uploaded.
+				</NotificationListItem>
+				<NotificationListItem titleText="Deployment successful" state="Positive" showClose>
+					Your application is live.
+				</NotificationListItem>
+			</NotificationList>
+		);
+		cy.screenshot();
+	});
+
+	it("compact mode", () => {
+		cy.mount(
+			<div data-ui5-compact-size>
+				<NotificationList>
+					<NotificationListItem titleText="Compact notification" importance="Important" showClose>
+						Compact mode notification item.
+					</NotificationListItem>
+				</NotificationList>
+			</div>
+		);
+		cy.screenshot();
+	});
+});

--- a/packages/fiori/cypress/specs/visuals/Page.cy.tsx
+++ b/packages/fiori/cypress/specs/visuals/Page.cy.tsx
@@ -1,0 +1,76 @@
+import Page from "../../../src/Page.js";
+import Bar from "@ui5/webcomponents/dist/Bar.js";
+import Button from "@ui5/webcomponents/dist/Button.js";
+
+describe("Page visual", () => {
+	it("basic state", () => {
+		cy.mount(
+			<Page style={{ height: "300px" }}>
+				<div style={{ padding: "16px" }}>Page content goes here.</div>
+			</Page>
+		);
+		cy.screenshot();
+	});
+
+	it("with header and footer", () => {
+		cy.mount(
+			<Page style={{ height: "300px" }}>
+				<Bar slot="header"><div slot="startContent"><strong>Page Title</strong></div></Bar>
+				<div style={{ padding: "16px" }}>Page with header and footer.</div>
+				<Bar slot="footer"><Button slot="endContent" design="Emphasized">Save</Button><Button slot="endContent">Cancel</Button></Bar>
+			</Page>
+		);
+		cy.screenshot();
+	});
+
+	it("backgroundDesign — Solid", () => {
+		cy.mount(
+			<Page backgroundDesign="Solid" style={{ height: "300px" }}>
+				<div style={{ padding: "16px" }}>Solid background.</div>
+			</Page>
+		);
+		cy.screenshot();
+	});
+
+	it("backgroundDesign — List", () => {
+		cy.mount(
+			<Page backgroundDesign="List" style={{ height: "300px" }}>
+				<div style={{ padding: "16px" }}>List background.</div>
+			</Page>
+		);
+		cy.screenshot();
+	});
+
+	it("backgroundDesign — Transparent", () => {
+		cy.mount(
+			<Page backgroundDesign="Transparent" style={{ height: "300px" }}>
+				<div style={{ padding: "16px" }}>Transparent background.</div>
+			</Page>
+		);
+		cy.screenshot();
+	});
+
+	it("fixed footer", () => {
+		cy.mount(
+			<Page style={{ height: "300px" }} fixedFooter>
+				<Bar slot="header"><div slot="startContent"><strong>Fixed Footer Page</strong></div></Bar>
+				<div style={{ padding: "16px" }}>Content with a fixed footer that stays at the bottom.</div>
+				<Bar slot="footer"><Button slot="endContent" design="Emphasized">Confirm</Button></Bar>
+			</Page>
+		);
+		cy.screenshot();
+	});
+
+	it("compact mode", () => {
+		cy.mount(
+			<div data-ui5-compact-size>
+				<Page style={{ height: "200px" }}>
+					<Bar slot="header"><div slot="startContent"><strong>Compact Page</strong></div></Bar>
+					<div style={{ padding: "8px" }}>Compact mode content.</div>
+					<Bar slot="footer"><Button slot="endContent">OK</Button></Bar>
+				</Page>
+			</div>
+		);
+		cy.screenshot();
+	});
+});

--- a/packages/fiori/cypress/specs/visuals/SideNavigation.cy.tsx
+++ b/packages/fiori/cypress/specs/visuals/SideNavigation.cy.tsx
@@ -1,0 +1,93 @@
+import SideNavigation from "../../../src/SideNavigation.js";
+import SideNavigationItem from "../../../src/SideNavigationItem.js";
+import SideNavigationSubItem from "../../../src/SideNavigationSubItem.js";
+import SideNavigationGroup from "../../../src/SideNavigationGroup.js";
+import "@ui5/webcomponents-icons/dist/home.js";
+import "@ui5/webcomponents-icons/dist/calendar.js";
+import "@ui5/webcomponents-icons/dist/settings.js";
+import "@ui5/webcomponents-icons/dist/employee.js";
+import "@ui5/webcomponents-icons/dist/bell.js";
+
+describe("SideNavigation visual", () => {
+	it("basic state — expanded", () => {
+		cy.mount(
+			<SideNavigation style={{ height: "400px" }}>
+				<SideNavigationItem text="Home" icon="home" selected />
+				<SideNavigationItem text="Calendar" icon="calendar" />
+				<SideNavigationItem text="Employees" icon="employee" />
+				<SideNavigationItem text="Notifications" icon="bell" />
+				<SideNavigationItem text="Settings" icon="settings" slot="fixedItems" />
+			</SideNavigation>
+		);
+		cy.screenshot();
+	});
+
+	it("collapsed state", () => {
+		cy.mount(
+			<SideNavigation collapsed style={{ height: "400px" }}>
+				<SideNavigationItem text="Home" icon="home" selected />
+				<SideNavigationItem text="Calendar" icon="calendar" />
+				<SideNavigationItem text="Employees" icon="employee" />
+				<SideNavigationItem text="Notifications" icon="bell" />
+				<SideNavigationItem text="Settings" icon="settings" slot="fixedItems" />
+			</SideNavigation>
+		);
+		cy.screenshot();
+	});
+
+	it("with sub-items expanded", () => {
+		cy.mount(
+			<SideNavigation style={{ height: "400px" }}>
+				<SideNavigationItem text="Home" icon="home" />
+				<SideNavigationItem text="Employees" icon="employee" expanded>
+					<SideNavigationSubItem text="Overview" />
+					<SideNavigationSubItem text="HR Management" />
+					<SideNavigationSubItem text="Payroll" selected />
+				</SideNavigationItem>
+				<SideNavigationItem text="Settings" icon="settings" />
+			</SideNavigation>
+		);
+		cy.screenshot();
+	});
+
+	it("with groups", () => {
+		cy.mount(
+			<SideNavigation style={{ height: "450px" }}>
+				<SideNavigationGroup text="Main">
+					<SideNavigationItem text="Home" icon="home" selected />
+					<SideNavigationItem text="Calendar" icon="calendar" />
+				</SideNavigationGroup>
+				<SideNavigationGroup text="Administration">
+					<SideNavigationItem text="Employees" icon="employee" />
+					<SideNavigationItem text="Settings" icon="settings" />
+				</SideNavigationGroup>
+			</SideNavigation>
+		);
+		cy.screenshot();
+	});
+
+	it("with fixed items", () => {
+		cy.mount(
+			<SideNavigation style={{ height: "400px" }}>
+				<SideNavigationItem text="Home" icon="home" selected />
+				<SideNavigationItem text="Calendar" icon="calendar" />
+				<SideNavigationItem text="Notifications" icon="bell" slot="fixedItems" />
+				<SideNavigationItem text="Settings" icon="settings" slot="fixedItems" />
+			</SideNavigation>
+		);
+		cy.screenshot();
+	});
+
+	it("compact mode", () => {
+		cy.mount(
+			<div data-ui5-compact-size>
+				<SideNavigation style={{ height: "300px" }}>
+					<SideNavigationItem text="Home" icon="home" selected />
+					<SideNavigationItem text="Calendar" icon="calendar" />
+					<SideNavigationItem text="Settings" icon="settings" />
+				</SideNavigation>
+			</div>
+		);
+		cy.screenshot();
+	});
+});

--- a/packages/fiori/cypress/specs/visuals/Timeline.cy.tsx
+++ b/packages/fiori/cypress/specs/visuals/Timeline.cy.tsx
@@ -1,0 +1,114 @@
+import Timeline from "../../../src/Timeline.js";
+import TimelineItem from "../../../src/TimelineItem.js";
+import "@ui5/webcomponents-icons/dist/calendar.js";
+import "@ui5/webcomponents-icons/dist/phone.js";
+import "@ui5/webcomponents-icons/dist/map.js";
+
+describe("Timeline visual", () => {
+	it("basic state — vertical layout", () => {
+		cy.mount(
+			<Timeline>
+				<TimelineItem titleText="Meeting" subtitleText="Jan 15, 2024" name="John Doe" icon="calendar">
+					Discussed project milestones and deliverables.
+				</TimelineItem>
+				<TimelineItem titleText="Phone call" subtitleText="Jan 16, 2024" name="Jane Smith" icon="phone">
+					Follow-up call about the design review.
+				</TimelineItem>
+				<TimelineItem titleText="Site visit" subtitleText="Jan 17, 2024" name="Bob Lee" icon="map">
+					On-site inspection of the new office.
+				</TimelineItem>
+			</Timeline>
+		);
+		cy.screenshot();
+	});
+
+	it("horizontal layout", () => {
+		cy.mount(
+			<Timeline layout="Horizontal">
+				<TimelineItem titleText="Meeting" subtitleText="Jan 15" icon="calendar" />
+				<TimelineItem titleText="Phone call" subtitleText="Jan 16" icon="phone" />
+				<TimelineItem titleText="Site visit" subtitleText="Jan 17" icon="map" />
+			</Timeline>
+		);
+		cy.screenshot();
+	});
+
+	it("item states", () => {
+		cy.mount(
+			<Timeline>
+				<TimelineItem titleText="Completed" subtitleText="Jan 15, 2024" state="Positive" icon="calendar" />
+				<TimelineItem titleText="Warning" subtitleText="Jan 16, 2024" state="Critical" icon="phone" />
+				<TimelineItem titleText="Error" subtitleText="Jan 17, 2024" state="Negative" icon="map" />
+				<TimelineItem titleText="Info" subtitleText="Jan 18, 2024" state="Information" icon="calendar" />
+			</Timeline>
+		);
+		cy.screenshot();
+	});
+
+	it("item state — Positive", () => {
+		cy.mount(
+			<Timeline>
+				<TimelineItem titleText="Task completed" subtitleText="Jan 15, 2024" state="Positive" icon="calendar">
+					All requirements met successfully.
+				</TimelineItem>
+			</Timeline>
+		);
+		cy.screenshot();
+	});
+
+	it("item state — Negative", () => {
+		cy.mount(
+			<Timeline>
+				<TimelineItem titleText="Task failed" subtitleText="Jan 15, 2024" state="Negative" icon="calendar">
+					Critical error encountered during processing.
+				</TimelineItem>
+			</Timeline>
+		);
+		cy.screenshot();
+	});
+
+	it("item state — Critical", () => {
+		cy.mount(
+			<Timeline>
+				<TimelineItem titleText="Needs attention" subtitleText="Jan 15, 2024" state="Critical" icon="calendar">
+					Review required before proceeding.
+				</TimelineItem>
+			</Timeline>
+		);
+		cy.screenshot();
+	});
+
+	it("item state — Information", () => {
+		cy.mount(
+			<Timeline>
+				<TimelineItem titleText="FYI" subtitleText="Jan 15, 2024" state="Information" icon="calendar">
+					Informational update for team awareness.
+				</TimelineItem>
+			</Timeline>
+		);
+		cy.screenshot();
+	});
+
+	it("items without icons", () => {
+		cy.mount(
+			<Timeline>
+				<TimelineItem titleText="Kickoff" subtitleText="Jan 15, 2024" name="Alice" />
+				<TimelineItem titleText="Review" subtitleText="Jan 20, 2024" name="Bob" />
+				<TimelineItem titleText="Launch" subtitleText="Jan 25, 2024" name="Carol" />
+			</Timeline>
+		);
+		cy.screenshot();
+	});
+
+	it("compact mode", () => {
+		cy.mount(
+			<div data-ui5-compact-size>
+				<Timeline>
+					<TimelineItem titleText="Meeting" subtitleText="Jan 15, 2024" icon="calendar" />
+					<TimelineItem titleText="Call" subtitleText="Jan 16, 2024" icon="phone" />
+				</Timeline>
+			</div>
+		);
+		cy.screenshot();
+	});
+});

--- a/packages/fiori/package-scripts.cjs
+++ b/packages/fiori/package-scripts.cjs
@@ -21,6 +21,7 @@ const options = {
 	standalone: false,
 	internal: {
 		cypress_code_coverage: false,
+		cypress_visual: process.env.CYPRESS_VISUAL === "true",
 	},
 	illustrationsData: [
 		{

--- a/packages/fiori/package.json
+++ b/packages/fiori/package.json
@@ -45,6 +45,8 @@
     "test:cypress": "wc-dev test-cy-ci",
     "test:cypress:single": "npx cypress run --component --browser chrome --spec",
     "test:cypress:open": "wc-dev test-cy-open",
+    "test:cypress:visual": "CYPRESS_VISUAL=true yarn test:cypress",
+    "test:cypress:open:visual": "CYPRESS_VISUAL=true yarn test:cypress:open",
     "create-ui5-element": "wc-create-ui5-element",
     "prepublishOnly": "tsc -b"
   },

--- a/packages/main/cypress/specs/SplitButton.cy.tsx
+++ b/packages/main/cypress/specs/SplitButton.cy.tsx
@@ -129,7 +129,11 @@ describe("Split Button general interaction", () => {
 		cy.get("[ui5-split-button]")
 			.shadow()
 			.find(".ui5-split-arrow-button")
-			.focus()
+			.focus();
+
+		cy.get("[ui5-split-button]")
+			.shadow()
+			.find(".ui5-split-arrow-button")
 			.should("be.focused")
 			.then(($btn) => {
 				const el = $btn[0] as Element;

--- a/packages/main/cypress/specs/visuals/Avatar.cy.tsx
+++ b/packages/main/cypress/specs/visuals/Avatar.cy.tsx
@@ -1,0 +1,90 @@
+import Avatar from "../../../src/Avatar.js";
+import "@ui5/webcomponents-icons/dist/employee.js";
+
+describe("Avatar visual", () => {
+	it("initials — all sizes", () => {
+		cy.mount(
+			<div style={{ display: "flex", gap: "8px", alignItems: "center" }}>
+				<Avatar size="XS" initials="AB" />
+				<Avatar size="S" initials="AB" />
+				<Avatar size="M" initials="AB" />
+				<Avatar size="L" initials="AB" />
+				<Avatar size="XL" initials="AB" />
+			</div>
+		);
+		cy.screenshot();
+	});
+
+	it("size — XS", () => {
+		cy.mount(<Avatar size="XS" initials="XS" />);
+		cy.screenshot();
+	});
+
+	it("size — S", () => {
+		cy.mount(<Avatar size="S" initials="SM" />);
+		cy.screenshot();
+	});
+
+	it("size — M", () => {
+		cy.mount(<Avatar size="M" initials="MD" />);
+		cy.screenshot();
+	});
+
+	it("size — L", () => {
+		cy.mount(<Avatar size="L" initials="LG" />);
+		cy.screenshot();
+	});
+
+	it("size — XL", () => {
+		cy.mount(<Avatar size="XL" initials="XL" />);
+		cy.screenshot();
+	});
+
+	it("shape — Circle vs Square", () => {
+		cy.mount(
+			<div style={{ display: "flex", gap: "8px" }}>
+				<Avatar shape="Circle" size="M" initials="CI" />
+				<Avatar shape="Square" size="M" initials="SQ" />
+			</div>
+		);
+		cy.screenshot();
+	});
+
+	it("icon content", () => {
+		cy.mount(<Avatar size="M" icon="employee" />);
+		cy.screenshot();
+	});
+
+	it("color schemes", () => {
+		cy.mount(
+			<div style={{ display: "flex", gap: "8px", flexWrap: "wrap" }}>
+				<Avatar size="S" initials="A1" colorScheme="Accent1" />
+				<Avatar size="S" initials="A2" colorScheme="Accent2" />
+				<Avatar size="S" initials="A3" colorScheme="Accent3" />
+				<Avatar size="S" initials="A4" colorScheme="Accent4" />
+				<Avatar size="S" initials="A5" colorScheme="Accent5" />
+				<Avatar size="S" initials="A6" colorScheme="Accent6" />
+				<Avatar size="S" initials="A7" colorScheme="Accent7" />
+				<Avatar size="S" initials="A8" colorScheme="Accent8" />
+				<Avatar size="S" initials="A9" colorScheme="Accent9" />
+				<Avatar size="S" initials="10" colorScheme="Accent10" />
+			</div>
+		);
+		cy.screenshot();
+	});
+
+	it("disabled state", () => {
+		cy.mount(
+			<div style={{ display: "flex", gap: "8px" }}>
+				<Avatar size="M" initials="AB" disabled />
+				<Avatar size="M" icon="employee" disabled />
+			</div>
+		);
+		cy.screenshot();
+	});
+
+	it("placeholder color scheme", () => {
+		cy.mount(<Avatar size="M" colorScheme="Placeholder" />);
+		cy.screenshot();
+	});
+});

--- a/packages/main/cypress/specs/visuals/Button.cy.tsx
+++ b/packages/main/cypress/specs/visuals/Button.cy.tsx
@@ -1,0 +1,113 @@
+import Button from "../../../src/Button.js";
+import ButtonBadge from "../../../src/ButtonBadge.js";
+import download from "@ui5/webcomponents-icons/dist/download.js";
+import edit from "@ui5/webcomponents-icons/dist/edit.js";
+
+describe("Button visual", () => {
+	it("basic state", () => {
+		cy.mount(<Button>Default Button</Button>);
+		cy.screenshot();
+	});
+
+	it("all design variants", () => {
+		cy.mount(
+			<div style={{ display: "flex", gap: "8px", flexWrap: "wrap" }}>
+				<Button design="Default">Default</Button>
+				<Button design="Emphasized">Emphasized</Button>
+				<Button design="Positive">Positive</Button>
+				<Button design="Negative">Negative</Button>
+				<Button design="Transparent">Transparent</Button>
+				<Button design="Attention">Attention</Button>
+			</div>
+		);
+		cy.screenshot();
+	});
+
+	it("with icon", () => {
+		cy.mount(
+			<div style={{ display: "flex", gap: "8px" }}>
+				<Button icon={download}>Download</Button>
+				<Button icon={edit} design="Emphasized">Edit</Button>
+			</div>
+		);
+		cy.screenshot();
+	});
+
+	it("icon only", () => {
+		cy.mount(
+			<div style={{ display: "flex", gap: "8px" }}>
+				<Button icon={download} />
+				<Button icon={edit} design="Emphasized" />
+				<Button icon={download} design="Negative" />
+			</div>
+		);
+		cy.screenshot();
+	});
+
+	it("icon end", () => {
+		cy.mount(
+			<div style={{ display: "flex", gap: "8px" }}>
+				<Button icon={download} iconEnd>Download</Button>
+				<Button icon={edit} iconEnd design="Emphasized">Edit</Button>
+			</div>
+		);
+		cy.screenshot();
+	});
+
+	it("disabled state", () => {
+		cy.mount(
+			<div style={{ display: "flex", gap: "8px", flexWrap: "wrap" }}>
+				<Button disabled>Default</Button>
+				<Button disabled design="Emphasized">Emphasized</Button>
+				<Button disabled design="Positive">Positive</Button>
+				<Button disabled design="Negative">Negative</Button>
+				<Button disabled icon={download}>With Icon</Button>
+			</div>
+		);
+		cy.screenshot();
+	});
+
+	it("compact mode", () => {
+		cy.mount(
+			<div data-ui5-compact-size style={{ display: "flex", gap: "8px" }}>
+				<Button>Default</Button>
+				<Button design="Emphasized">Emphasized</Button>
+				<Button icon={download}>With Icon</Button>
+				<Button icon={download} />
+			</div>
+		);
+		cy.screenshot();
+	});
+
+	it("with badge — attention dot", () => {
+		cy.mount(
+			<Button design="Emphasized">
+				Messages
+				<ButtonBadge slot="badge" design="AttentionDot" />
+			</Button>
+		);
+		cy.screenshot();
+	});
+
+	it("with badge — counter", () => {
+		cy.mount(
+			<div style={{ display: "flex", gap: "8px" }}>
+				<Button>
+					Notifications
+					<ButtonBadge slot="badge" text="5" />
+				</Button>
+				<Button design="Emphasized">
+					Alerts
+					<ButtonBadge slot="badge" text="42" />
+				</Button>
+			</div>
+		);
+		cy.screenshot();
+	});
+
+	it("focused state", () => {
+		cy.mount(<Button>Focus Me</Button>);
+		cy.get("[ui5-button]").focus();
+		cy.screenshot();
+	});
+});

--- a/packages/main/cypress/specs/visuals/CheckBox.cy.tsx
+++ b/packages/main/cypress/specs/visuals/CheckBox.cy.tsx
@@ -1,0 +1,82 @@
+import CheckBox from "../../../src/CheckBox.js";
+
+describe("CheckBox visual", () => {
+	it("basic state — unchecked", () => {
+		cy.mount(<CheckBox text="Default checkbox" />);
+		cy.screenshot();
+	});
+
+	it("checked state", () => {
+		cy.mount(<CheckBox text="Checked checkbox" checked />);
+		cy.screenshot();
+	});
+
+	it("indeterminate state", () => {
+		cy.mount(<CheckBox text="Indeterminate checkbox" indeterminate />);
+		cy.screenshot();
+	});
+
+	it("disabled — unchecked", () => {
+		cy.mount(<CheckBox text="Disabled unchecked" disabled />);
+		cy.screenshot();
+	});
+
+	it("disabled — checked", () => {
+		cy.mount(<CheckBox text="Disabled checked" checked disabled />);
+		cy.screenshot();
+	});
+
+	it("readonly — checked", () => {
+		cy.mount(<CheckBox text="Readonly checked" checked readonly />);
+		cy.screenshot();
+	});
+
+	it("value state — Negative", () => {
+		cy.mount(<CheckBox text="Error checkbox" valueState="Negative" />);
+		cy.screenshot();
+	});
+
+	it("value state — Critical", () => {
+		cy.mount(<CheckBox text="Warning checkbox" valueState="Critical" />);
+		cy.screenshot();
+	});
+
+	it("value state — Positive", () => {
+		cy.mount(<CheckBox text="Success checkbox" checked valueState="Positive" />);
+		cy.screenshot();
+	});
+
+	it("value state — Information", () => {
+		cy.mount(<CheckBox text="Info checkbox" valueState="Information" />);
+		cy.screenshot();
+	});
+
+	it("wrapping — long text", () => {
+		cy.mount(
+			<div style={{ width: "200px" }}>
+				<CheckBox text="This is a very long checkbox label that should wrap onto multiple lines in normal wrapping mode" />
+			</div>
+		);
+		cy.screenshot();
+	});
+
+	it("no wrapping — text truncated", () => {
+		cy.mount(
+			<div style={{ width: "200px" }}>
+				<CheckBox wrappingType="None" text="This is a very long checkbox label that should be truncated" />
+			</div>
+		);
+		cy.screenshot();
+	});
+
+	it("compact mode", () => {
+		cy.mount(
+			<div data-ui5-compact-size style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+				<CheckBox text="Compact unchecked" />
+				<CheckBox text="Compact checked" checked />
+				<CheckBox text="Compact indeterminate" indeterminate />
+			</div>
+		);
+		cy.screenshot();
+	});
+});

--- a/packages/main/cypress/specs/visuals/ComboBox.cy.tsx
+++ b/packages/main/cypress/specs/visuals/ComboBox.cy.tsx
@@ -1,0 +1,154 @@
+import ComboBox from "../../../src/ComboBox.js";
+import ComboBoxItem from "../../../src/ComboBoxItem.js";
+import ComboBoxItemGroup from "../../../src/ComboBoxItemGroup.js";
+
+describe("ComboBox visual", () => {
+	it("basic state", () => {
+		cy.mount(
+			<ComboBox>
+				<ComboBoxItem text="Algeria" />
+				<ComboBoxItem text="Bulgaria" />
+				<ComboBoxItem text="Canada" />
+				<ComboBoxItem text="Denmark" />
+				<ComboBoxItem text="Estonia" />
+			</ComboBox>
+		);
+		cy.screenshot();
+	});
+
+	it("with value", () => {
+		cy.mount(
+			<ComboBox value="Bulgaria">
+				<ComboBoxItem text="Algeria" />
+				<ComboBoxItem text="Bulgaria" />
+				<ComboBoxItem text="Canada" />
+			</ComboBox>
+		);
+		cy.screenshot();
+	});
+
+	it("dropdown open", () => {
+		cy.mount(
+			<ComboBox>
+				<ComboBoxItem text="Algeria" />
+				<ComboBoxItem text="Bulgaria" />
+				<ComboBoxItem text="Canada" />
+				<ComboBoxItem text="Denmark" />
+				<ComboBoxItem text="Estonia" />
+			</ComboBox>
+		);
+		cy.get("[ui5-combobox]").shadow().find("[ui5-icon]").realClick();
+		cy.get("[ui5-combobox]").shadow().find("ui5-responsive-popover").ui5ResponsivePopoverOpened();
+		cy.screenshot();
+	});
+
+	it("filtering — type to narrow list", () => {
+		cy.mount(
+			<ComboBox>
+				<ComboBoxItem text="Algeria" />
+				<ComboBoxItem text="Bulgaria" />
+				<ComboBoxItem text="Canada" />
+				<ComboBoxItem text="Denmark" />
+				<ComboBoxItem text="Estonia" />
+			</ComboBox>
+		);
+		cy.get("[ui5-combobox]").realClick();
+		cy.realType("B");
+		cy.screenshot();
+	});
+
+	it("with grouped items — dropdown open", () => {
+		cy.mount(
+			<ComboBox>
+				<ComboBoxItemGroup headerText="Africa">
+					<ComboBoxItem text="Algeria" />
+					<ComboBoxItem text="Egypt" />
+				</ComboBoxItemGroup>
+				<ComboBoxItemGroup headerText="Europe">
+					<ComboBoxItem text="Bulgaria" />
+					<ComboBoxItem text="Denmark" />
+				</ComboBoxItemGroup>
+			</ComboBox>
+		);
+		cy.get("[ui5-combobox]").shadow().find("[ui5-icon]").realClick();
+		cy.get("[ui5-combobox]").shadow().find("ui5-responsive-popover").ui5ResponsivePopoverOpened();
+		cy.screenshot();
+	});
+
+	it("disabled state", () => {
+		cy.mount(
+			<ComboBox value="Bulgaria" disabled>
+				<ComboBoxItem text="Algeria" />
+				<ComboBoxItem text="Bulgaria" />
+			</ComboBox>
+		);
+		cy.screenshot();
+	});
+
+	it("readonly state", () => {
+		cy.mount(
+			<ComboBox value="Bulgaria" readonly>
+				<ComboBoxItem text="Algeria" />
+				<ComboBoxItem text="Bulgaria" />
+			</ComboBox>
+		);
+		cy.screenshot();
+	});
+
+	it("value state — Negative", () => {
+		cy.mount(
+			<ComboBox value="invalid" valueState="Negative">
+				<span slot="valueStateMessage">Invalid value</span>
+				<ComboBoxItem text="Algeria" />
+				<ComboBoxItem text="Bulgaria" />
+			</ComboBox>
+		);
+		cy.screenshot();
+	});
+
+	it("value state — Critical", () => {
+		cy.mount(
+			<ComboBox value="Bulgaria" valueState="Critical">
+				<span slot="valueStateMessage">Please review</span>
+				<ComboBoxItem text="Algeria" />
+				<ComboBoxItem text="Bulgaria" />
+			</ComboBox>
+		);
+		cy.screenshot();
+	});
+
+	it("value state — Positive", () => {
+		cy.mount(
+			<ComboBox value="Bulgaria" valueState="Positive">
+				<span slot="valueStateMessage">Valid selection</span>
+				<ComboBoxItem text="Algeria" />
+				<ComboBoxItem text="Bulgaria" />
+			</ComboBox>
+		);
+		cy.screenshot();
+	});
+
+	it("value state — Information", () => {
+		cy.mount(
+			<ComboBox value="Bulgaria" valueState="Information">
+				<span slot="valueStateMessage">Select a country</span>
+				<ComboBoxItem text="Algeria" />
+				<ComboBoxItem text="Bulgaria" />
+			</ComboBox>
+		);
+		cy.screenshot();
+	});
+
+	it("compact mode", () => {
+		cy.mount(
+			<div data-ui5-compact-size>
+				<ComboBox value="Bulgaria">
+					<ComboBoxItem text="Algeria" />
+					<ComboBoxItem text="Bulgaria" />
+					<ComboBoxItem text="Canada" />
+				</ComboBox>
+			</div>
+		);
+		cy.screenshot();
+	});
+});

--- a/packages/main/cypress/specs/visuals/DatePicker.cy.tsx
+++ b/packages/main/cypress/specs/visuals/DatePicker.cy.tsx
@@ -1,0 +1,82 @@
+import DatePicker from "../../../src/DatePicker.js";
+import { setAnimationMode } from "@ui5/webcomponents-base/dist/config/AnimationMode.js";
+import AnimationMode from "@ui5/webcomponents-base/dist/types/AnimationMode.js";
+
+const FIXED_VALUE = "Jan 15, 2024";
+
+describe("DatePicker visual", () => {
+	beforeEach(() => {
+		setAnimationMode(AnimationMode.None);
+	});
+
+	it("basic state", () => {
+		cy.mount(<DatePicker value={FIXED_VALUE} />);
+		cy.screenshot();
+	});
+
+	it("placeholder only — no value", () => {
+		cy.mount(<DatePicker placeholder="Select date" />);
+		cy.screenshot();
+	});
+
+	it("disabled state", () => {
+		cy.mount(<DatePicker value={FIXED_VALUE} disabled />);
+		cy.screenshot();
+	});
+
+	it("readonly state", () => {
+		cy.mount(<DatePicker value={FIXED_VALUE} readonly />);
+		cy.screenshot();
+	});
+
+	it("value state — Negative", () => {
+		cy.mount(
+			<DatePicker value={FIXED_VALUE} valueState="Negative">
+				<span slot="valueStateMessage">Invalid date</span>
+			</DatePicker>
+		);
+		cy.screenshot();
+	});
+
+	it("value state — Critical", () => {
+		cy.mount(
+			<DatePicker value={FIXED_VALUE} valueState="Critical">
+				<span slot="valueStateMessage">Date outside range</span>
+			</DatePicker>
+		);
+		cy.screenshot();
+	});
+
+	it("value state — Positive", () => {
+		cy.mount(
+			<DatePicker value={FIXED_VALUE} valueState="Positive">
+				<span slot="valueStateMessage">Valid date</span>
+			</DatePicker>
+		);
+		cy.screenshot();
+	});
+
+	it("value state — Information", () => {
+		cy.mount(
+			<DatePicker value={FIXED_VALUE} valueState="Information">
+				<span slot="valueStateMessage">Date will be used as reference</span>
+			</DatePicker>
+		);
+		cy.screenshot();
+	});
+
+	it("calendar popover open", () => {
+		cy.mount(<DatePicker value={FIXED_VALUE} />);
+		cy.get("[ui5-date-picker]").ui5DatePickerValueHelpIconPress();
+		cy.screenshot();
+	});
+
+	it("compact mode", () => {
+		cy.mount(
+			<div data-ui5-compact-size>
+				<DatePicker value={FIXED_VALUE} />
+			</div>
+		);
+		cy.screenshot();
+	});
+});

--- a/packages/main/cypress/specs/visuals/DateTimePicker.cy.tsx
+++ b/packages/main/cypress/specs/visuals/DateTimePicker.cy.tsx
@@ -1,0 +1,83 @@
+import DateTimePicker from "../../../src/DateTimePicker.js";
+import { setAnimationMode } from "@ui5/webcomponents-base/dist/config/AnimationMode.js";
+import AnimationMode from "@ui5/webcomponents-base/dist/types/AnimationMode.js";
+
+const FIXED_VALUE = "Apr 15, 2024, 10:30:00 AM";
+const FIXED_FORMAT = "MMM d, yyyy, hh:mm:ss a";
+
+describe("DateTimePicker visual", () => {
+	beforeEach(() => {
+		setAnimationMode(AnimationMode.None);
+	});
+
+	it("basic state", () => {
+		cy.mount(<DateTimePicker value={FIXED_VALUE} formatPattern={FIXED_FORMAT} />);
+		cy.screenshot();
+	});
+
+	it("placeholder only — no value", () => {
+		cy.mount(<DateTimePicker placeholder="Select date and time" />);
+		cy.screenshot();
+	});
+
+	it("disabled state", () => {
+		cy.mount(<DateTimePicker value={FIXED_VALUE} formatPattern={FIXED_FORMAT} disabled />);
+		cy.screenshot();
+	});
+
+	it("readonly state", () => {
+		cy.mount(<DateTimePicker value={FIXED_VALUE} formatPattern={FIXED_FORMAT} readonly />);
+		cy.screenshot();
+	});
+
+	it("value state — Negative", () => {
+		cy.mount(
+			<DateTimePicker value={FIXED_VALUE} formatPattern={FIXED_FORMAT} valueState="Negative">
+				<span slot="valueStateMessage">Invalid date and time</span>
+			</DateTimePicker>
+		);
+		cy.screenshot();
+	});
+
+	it("value state — Critical", () => {
+		cy.mount(
+			<DateTimePicker value={FIXED_VALUE} formatPattern={FIXED_FORMAT} valueState="Critical">
+				<span slot="valueStateMessage">Date outside allowed range</span>
+			</DateTimePicker>
+		);
+		cy.screenshot();
+	});
+
+	it("value state — Positive", () => {
+		cy.mount(
+			<DateTimePicker value={FIXED_VALUE} formatPattern={FIXED_FORMAT} valueState="Positive">
+				<span slot="valueStateMessage">Date is valid</span>
+			</DateTimePicker>
+		);
+		cy.screenshot();
+	});
+
+	it("value state — Information", () => {
+		cy.mount(
+			<DateTimePicker value={FIXED_VALUE} formatPattern={FIXED_FORMAT} valueState="Information">
+				<span slot="valueStateMessage">Date will be used as reference</span>
+			</DateTimePicker>
+		);
+		cy.screenshot();
+	});
+
+	it("popover open", () => {
+		cy.mount(<DateTimePicker value={FIXED_VALUE} formatPattern={FIXED_FORMAT} />);
+		cy.get("[ui5-datetime-picker]").ui5DateTimePickerOpen();
+		cy.screenshot();
+	});
+
+	it("compact mode", () => {
+		cy.mount(
+			<div data-ui5-compact-size>
+				<DateTimePicker value={FIXED_VALUE} formatPattern={FIXED_FORMAT} />
+			</div>
+		);
+		cy.screenshot();
+	});
+});

--- a/packages/main/cypress/specs/visuals/Input.cy.tsx
+++ b/packages/main/cypress/specs/visuals/Input.cy.tsx
@@ -1,0 +1,84 @@
+import Input from "../../../src/Input.js";
+
+describe("Input visual", () => {
+	it("basic state", () => {
+		cy.mount(<Input placeholder="Enter text" />);
+		cy.screenshot();
+	});
+
+	it("with value", () => {
+		cy.mount(<Input value="Hello World" />);
+		cy.screenshot();
+	});
+
+	it("type — Password", () => {
+		cy.mount(<Input type="Password" value="secret123" />);
+		cy.screenshot();
+	});
+
+	it("type — Number", () => {
+		cy.mount(<Input type="Number" value="42" />);
+		cy.screenshot();
+	});
+
+	it("type — Search", () => {
+		cy.mount(<Input type="Search" placeholder="Search..." />);
+		cy.screenshot();
+	});
+
+	it("disabled state", () => {
+		cy.mount(<Input value="Disabled input" disabled />);
+		cy.screenshot();
+	});
+
+	it("readonly state", () => {
+		cy.mount(<Input value="Read-only input" readonly />);
+		cy.screenshot();
+	});
+
+	it("value state — Negative", () => {
+		cy.mount(
+			<Input value="invalid@" valueState="Negative">
+				<span slot="valueStateMessage">Invalid input</span>
+			</Input>
+		);
+		cy.screenshot();
+	});
+
+	it("value state — Critical", () => {
+		cy.mount(
+			<Input value="warning text" valueState="Critical">
+				<span slot="valueStateMessage">Please review</span>
+			</Input>
+		);
+		cy.screenshot();
+	});
+
+	it("value state — Positive", () => {
+		cy.mount(
+			<Input value="valid input" valueState="Positive">
+				<span slot="valueStateMessage">Looks good</span>
+			</Input>
+		);
+		cy.screenshot();
+	});
+
+	it("value state — Information", () => {
+		cy.mount(
+			<Input value="info text" valueState="Information">
+				<span slot="valueStateMessage">Additional info</span>
+			</Input>
+		);
+		cy.screenshot();
+	});
+
+	it("compact mode", () => {
+		cy.mount(
+			<div data-ui5-compact-size style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+				<Input placeholder="Compact input" />
+				<Input value="Compact with value" />
+			</div>
+		);
+		cy.screenshot();
+	});
+});

--- a/packages/main/cypress/specs/visuals/ListItemCustom.cy.tsx
+++ b/packages/main/cypress/specs/visuals/ListItemCustom.cy.tsx
@@ -1,0 +1,122 @@
+import List from "../../../src/List.js";
+import ListItemCustom from "../../../src/ListItemCustom.js";
+
+describe("ListItemCustom visual", () => {
+	it("basic state", () => {
+		cy.mount(
+			<List>
+				<ListItemCustom>
+					<div style={{ padding: "8px" }}>Custom item content</div>
+				</ListItemCustom>
+				<ListItemCustom>
+					<div style={{ padding: "8px" }}>Another custom item</div>
+				</ListItemCustom>
+				<ListItemCustom>
+					<div style={{ padding: "8px" }}>Third custom item</div>
+				</ListItemCustom>
+			</List>
+		);
+		cy.screenshot();
+	});
+
+	it("selected state", () => {
+		cy.mount(
+			<List selectionMode="Single">
+				<ListItemCustom selected>
+					<div style={{ padding: "8px" }}>Selected custom item</div>
+				</ListItemCustom>
+				<ListItemCustom>
+					<div style={{ padding: "8px" }}>Unselected custom item</div>
+				</ListItemCustom>
+			</List>
+		);
+		cy.screenshot();
+	});
+
+	it("multiple selection mode", () => {
+		cy.mount(
+			<List selectionMode="Multiple">
+				<ListItemCustom selected>
+					<div style={{ padding: "8px" }}>First selected item</div>
+				</ListItemCustom>
+				<ListItemCustom selected>
+					<div style={{ padding: "8px" }}>Second selected item</div>
+				</ListItemCustom>
+				<ListItemCustom>
+					<div style={{ padding: "8px" }}>Unselected item</div>
+				</ListItemCustom>
+			</List>
+		);
+		cy.screenshot();
+	});
+
+	it("delete mode", () => {
+		cy.mount(
+			<List selectionMode="Delete">
+				<ListItemCustom>
+					<div style={{ padding: "8px" }}>Deletable custom item</div>
+				</ListItemCustom>
+				<ListItemCustom>
+					<div style={{ padding: "8px" }}>Another deletable item</div>
+				</ListItemCustom>
+			</List>
+		);
+		cy.screenshot();
+	});
+
+	it("navigated state", () => {
+		cy.mount(
+			<List>
+				<ListItemCustom navigated>
+					<div style={{ padding: "8px" }}>Navigated custom item</div>
+				</ListItemCustom>
+				<ListItemCustom>
+					<div style={{ padding: "8px" }}>Regular custom item</div>
+				</ListItemCustom>
+			</List>
+		);
+		cy.screenshot();
+	});
+
+	it("with rich content", () => {
+		cy.mount(
+			<List>
+				<ListItemCustom>
+					<div style={{ display: "flex", alignItems: "center", gap: "12px", padding: "8px" }}>
+						<div style={{ width: "40px", height: "40px", borderRadius: "50%", background: "#0070f2", flexShrink: "0" }} />
+						<div>
+							<div style={{ fontWeight: "bold" }}>John Doe</div>
+							<div style={{ color: "#666", fontSize: "12px" }}>john.doe@example.com</div>
+						</div>
+					</div>
+				</ListItemCustom>
+				<ListItemCustom>
+					<div style={{ display: "flex", alignItems: "center", gap: "12px", padding: "8px" }}>
+						<div style={{ width: "40px", height: "40px", borderRadius: "50%", background: "#e9730c", flexShrink: "0" }} />
+						<div>
+							<div style={{ fontWeight: "bold" }}>Jane Smith</div>
+							<div style={{ color: "#666", fontSize: "12px" }}>jane.smith@example.com</div>
+						</div>
+					</div>
+				</ListItemCustom>
+			</List>
+		);
+		cy.screenshot();
+	});
+
+	it("compact mode", () => {
+		cy.mount(
+			<div data-ui5-compact-size>
+				<List selectionMode="Multiple">
+					<ListItemCustom selected>
+						<div style={{ padding: "4px 8px" }}>Compact selected item</div>
+					</ListItemCustom>
+					<ListItemCustom>
+						<div style={{ padding: "4px 8px" }}>Compact regular item</div>
+					</ListItemCustom>
+				</List>
+			</div>
+		);
+		cy.screenshot();
+	});
+});

--- a/packages/main/cypress/specs/visuals/MessageStrip.cy.tsx
+++ b/packages/main/cypress/specs/visuals/MessageStrip.cy.tsx
@@ -1,0 +1,61 @@
+import MessageStrip from "../../../src/MessageStrip.js";
+
+describe("MessageStrip visual", () => {
+	it("design — Information", () => {
+		cy.mount(<MessageStrip design="Information">This is an informational message.</MessageStrip>);
+		cy.screenshot();
+	});
+
+	it("design — Positive", () => {
+		cy.mount(<MessageStrip design="Positive">Operation completed successfully.</MessageStrip>);
+		cy.screenshot();
+	});
+
+	it("design — Negative", () => {
+		cy.mount(<MessageStrip design="Negative">An error has occurred.</MessageStrip>);
+		cy.screenshot();
+	});
+
+	it("design — Critical", () => {
+		cy.mount(<MessageStrip design="Critical">Please review your input.</MessageStrip>);
+		cy.screenshot();
+	});
+
+	it("design — ColorSet1", () => {
+		cy.mount(<MessageStrip design="ColorSet1">ColorSet1 message strip.</MessageStrip>);
+		cy.screenshot();
+	});
+
+	it("design — ColorSet2", () => {
+		cy.mount(<MessageStrip design="ColorSet2">ColorSet2 message strip.</MessageStrip>);
+		cy.screenshot();
+	});
+
+	it("hide close button", () => {
+		cy.mount(<MessageStrip design="Information" hideCloseButton>This message cannot be dismissed.</MessageStrip>);
+		cy.screenshot();
+	});
+
+	it("all designs stacked", () => {
+		cy.mount(
+			<div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+				<MessageStrip design="Information">Information</MessageStrip>
+				<MessageStrip design="Positive">Positive</MessageStrip>
+				<MessageStrip design="Negative">Negative</MessageStrip>
+				<MessageStrip design="Critical">Critical</MessageStrip>
+				<MessageStrip design="ColorSet1">ColorSet1</MessageStrip>
+				<MessageStrip design="ColorSet2">ColorSet2</MessageStrip>
+			</div>
+		);
+		cy.screenshot();
+	});
+
+	it("compact mode", () => {
+		cy.mount(
+			<div data-ui5-compact-size>
+				<MessageStrip design="Negative">Compact error message.</MessageStrip>
+			</div>
+		);
+		cy.screenshot();
+	});
+});

--- a/packages/main/cypress/specs/visuals/MultiComboBox.cy.tsx
+++ b/packages/main/cypress/specs/visuals/MultiComboBox.cy.tsx
@@ -1,0 +1,176 @@
+import MultiComboBox from "../../../src/MultiComboBox.js";
+import MultiComboBoxItem from "../../../src/MultiComboBoxItem.js";
+import MultiComboBoxItemGroup from "../../../src/MultiComboBoxItemGroup.js";
+
+describe("MultiComboBox visual", () => {
+	it("basic state", () => {
+		cy.mount(
+			<MultiComboBox>
+				<MultiComboBoxItem text="Algeria" />
+				<MultiComboBoxItem text="Bulgaria" />
+				<MultiComboBoxItem text="Canada" />
+				<MultiComboBoxItem text="Denmark" />
+				<MultiComboBoxItem text="Estonia" />
+			</MultiComboBox>
+		);
+		cy.screenshot();
+	});
+
+	it("with selected tokens", () => {
+		cy.mount(
+			<MultiComboBox>
+				<MultiComboBoxItem selected text="Algeria" />
+				<MultiComboBoxItem selected text="Bulgaria" />
+				<MultiComboBoxItem text="Canada" />
+				<MultiComboBoxItem text="Denmark" />
+				<MultiComboBoxItem text="Estonia" />
+			</MultiComboBox>
+		);
+		cy.screenshot();
+	});
+
+	it("dropdown open", () => {
+		cy.mount(
+			<MultiComboBox>
+				<MultiComboBoxItem text="Algeria" />
+				<MultiComboBoxItem text="Bulgaria" />
+				<MultiComboBoxItem text="Canada" />
+				<MultiComboBoxItem text="Denmark" />
+				<MultiComboBoxItem text="Estonia" />
+			</MultiComboBox>
+		);
+		cy.get("[ui5-multi-combobox]").shadow().find("[ui5-icon]").realClick();
+		cy.get("[ui5-multi-combobox]").shadow().find("ui5-responsive-popover").ui5ResponsivePopoverOpened();
+		cy.screenshot();
+	});
+
+	it("dropdown open — first item focused via arrow key", () => {
+		cy.mount(
+			<MultiComboBox>
+				<MultiComboBoxItem text="Algeria" />
+				<MultiComboBoxItem text="Bulgaria" />
+				<MultiComboBoxItem text="Canada" />
+			</MultiComboBox>
+		);
+		cy.get("[ui5-multi-combobox]").shadow().find("[ui5-icon]").realClick();
+		cy.get("[ui5-multi-combobox]").shadow().find("ui5-responsive-popover").ui5ResponsivePopoverOpened();
+		cy.realPress("ArrowDown");
+		cy.screenshot();
+	});
+
+	it("filtering — type to narrow list", () => {
+		cy.mount(
+			<MultiComboBox>
+				<MultiComboBoxItem text="Algeria" />
+				<MultiComboBoxItem text="Bulgaria" />
+				<MultiComboBoxItem text="Canada" />
+				<MultiComboBoxItem text="Denmark" />
+				<MultiComboBoxItem text="Estonia" />
+			</MultiComboBox>
+		);
+		cy.get("[ui5-multi-combobox]").realClick();
+		cy.realType("B");
+		cy.screenshot();
+	});
+
+	it("with grouped items — dropdown open", () => {
+		cy.mount(
+			<MultiComboBox>
+				<MultiComboBoxItemGroup headerText="Africa">
+					<MultiComboBoxItem text="Algeria" />
+					<MultiComboBoxItem text="Egypt" />
+				</MultiComboBoxItemGroup>
+				<MultiComboBoxItemGroup headerText="Europe">
+					<MultiComboBoxItem text="Bulgaria" />
+					<MultiComboBoxItem text="Denmark" />
+				</MultiComboBoxItemGroup>
+			</MultiComboBox>
+		);
+		cy.get("[ui5-multi-combobox]").shadow().find("[ui5-icon]").realClick();
+		cy.get("[ui5-multi-combobox]").shadow().find("ui5-responsive-popover").ui5ResponsivePopoverOpened();
+		cy.screenshot();
+	});
+
+	it("value state — Negative", () => {
+		cy.mount(
+			<MultiComboBox valueState="Negative">
+				<span slot="valueStateMessage">Invalid selection</span>
+				<MultiComboBoxItem text="Algeria" />
+				<MultiComboBoxItem text="Bulgaria" />
+			</MultiComboBox>
+		);
+		cy.screenshot();
+	});
+
+	it("value state — Critical", () => {
+		cy.mount(
+			<MultiComboBox valueState="Critical">
+				<span slot="valueStateMessage">Please review your selection</span>
+				<MultiComboBoxItem text="Algeria" />
+				<MultiComboBoxItem text="Bulgaria" />
+			</MultiComboBox>
+		);
+		cy.screenshot();
+	});
+
+	it("value state — Positive", () => {
+		cy.mount(
+			<MultiComboBox valueState="Positive">
+				<span slot="valueStateMessage">Selection is valid</span>
+				<MultiComboBoxItem text="Algeria" />
+				<MultiComboBoxItem text="Bulgaria" />
+			</MultiComboBox>
+		);
+		cy.screenshot();
+	});
+
+	it("value state — Information", () => {
+		cy.mount(
+			<MultiComboBox valueState="Information">
+				<span slot="valueStateMessage">Select up to 3 items</span>
+				<MultiComboBoxItem text="Algeria" />
+				<MultiComboBoxItem text="Bulgaria" />
+			</MultiComboBox>
+		);
+		cy.screenshot();
+	});
+
+	it("disabled state", () => {
+		cy.mount(
+			<MultiComboBox disabled>
+				<MultiComboBoxItem selected text="Algeria" />
+				<MultiComboBoxItem text="Bulgaria" />
+			</MultiComboBox>
+		);
+		cy.screenshot();
+	});
+
+	it("readonly state", () => {
+		cy.mount(
+			<MultiComboBox readonly>
+				<MultiComboBoxItem selected text="Algeria" />
+				<MultiComboBoxItem text="Bulgaria" />
+			</MultiComboBox>
+		);
+		cy.screenshot();
+	});
+
+	it("no items — empty dropdown open", () => {
+		cy.mount(<MultiComboBox />);
+		cy.get("[ui5-multi-combobox]").shadow().find("[ui5-icon]").realClick();
+		cy.screenshot();
+	});
+
+	it("compact mode", () => {
+		cy.mount(
+			<div data-ui5-compact-size>
+				<MultiComboBox>
+					<MultiComboBoxItem selected text="Algeria" />
+					<MultiComboBoxItem selected text="Bulgaria" />
+					<MultiComboBoxItem text="Canada" />
+				</MultiComboBox>
+			</div>
+		);
+		cy.screenshot();
+	});
+});

--- a/packages/main/cypress/specs/visuals/RadioButton.cy.tsx
+++ b/packages/main/cypress/specs/visuals/RadioButton.cy.tsx
@@ -1,0 +1,65 @@
+import RadioButton from "../../../src/RadioButton.js";
+
+describe("RadioButton visual", () => {
+	it("basic state — unchecked", () => {
+		cy.mount(<RadioButton text="Option A" name="group1" />);
+		cy.screenshot();
+	});
+
+	it("group — one checked", () => {
+		cy.mount(
+			<div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+				<RadioButton text="Option A" name="group1" checked />
+				<RadioButton text="Option B" name="group1" />
+				<RadioButton text="Option C" name="group1" />
+			</div>
+		);
+		cy.screenshot();
+	});
+
+	it("disabled — unchecked", () => {
+		cy.mount(<RadioButton text="Disabled option" name="group2" disabled />);
+		cy.screenshot();
+	});
+
+	it("disabled — checked", () => {
+		cy.mount(<RadioButton text="Disabled checked" name="group3" checked disabled />);
+		cy.screenshot();
+	});
+
+	it("readonly — checked", () => {
+		cy.mount(<RadioButton text="Readonly checked" name="group4" checked readonly />);
+		cy.screenshot();
+	});
+
+	it("value state — Negative", () => {
+		cy.mount(<RadioButton text="Error option" name="group5" valueState="Negative" />);
+		cy.screenshot();
+	});
+
+	it("value state — Critical", () => {
+		cy.mount(<RadioButton text="Warning option" name="group6" valueState="Critical" />);
+		cy.screenshot();
+	});
+
+	it("value state — Positive", () => {
+		cy.mount(<RadioButton text="Success option" name="group7" checked valueState="Positive" />);
+		cy.screenshot();
+	});
+
+	it("value state — Information", () => {
+		cy.mount(<RadioButton text="Info option" name="group8" valueState="Information" />);
+		cy.screenshot();
+	});
+
+	it("compact mode", () => {
+		cy.mount(
+			<div data-ui5-compact-size style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+				<RadioButton text="Compact A" name="groupC" checked />
+				<RadioButton text="Compact B" name="groupC" />
+				<RadioButton text="Compact C" name="groupC" />
+			</div>
+		);
+		cy.screenshot();
+	});
+});

--- a/packages/main/cypress/specs/visuals/Select.cy.tsx
+++ b/packages/main/cypress/specs/visuals/Select.cy.tsx
@@ -1,0 +1,118 @@
+import Select from "../../../src/Select.js";
+import Option from "../../../src/Option.js";
+
+describe("Select visual", () => {
+	it("basic state", () => {
+		cy.mount(
+			<Select>
+				<Option>Apple</Option>
+				<Option>Banana</Option>
+				<Option>Cherry</Option>
+			</Select>
+		);
+		cy.screenshot();
+	});
+
+	it("with selected option", () => {
+		cy.mount(
+			<Select>
+				<Option>Apple</Option>
+				<Option selected>Banana</Option>
+				<Option>Cherry</Option>
+			</Select>
+		);
+		cy.screenshot();
+	});
+
+	it("dropdown open", () => {
+		cy.mount(
+			<Select>
+				<Option>Apple</Option>
+				<Option>Banana</Option>
+				<Option>Cherry</Option>
+				<Option>Date</Option>
+				<Option>Elderberry</Option>
+			</Select>
+		);
+		cy.get("[ui5-select]").realClick();
+		cy.get("[ui5-select]").shadow().find("ui5-responsive-popover").ui5ResponsivePopoverOpened();
+		cy.screenshot();
+	});
+
+	it("disabled state", () => {
+		cy.mount(
+			<Select disabled>
+				<Option>Apple</Option>
+				<Option selected>Banana</Option>
+			</Select>
+		);
+		cy.screenshot();
+	});
+
+	it("readonly state", () => {
+		cy.mount(
+			<Select readonly>
+				<Option>Apple</Option>
+				<Option selected>Banana</Option>
+			</Select>
+		);
+		cy.screenshot();
+	});
+
+	it("value state — Negative", () => {
+		cy.mount(
+			<Select valueState="Negative">
+				<span slot="valueStateMessage">Invalid selection</span>
+				<Option>Apple</Option>
+				<Option>Banana</Option>
+			</Select>
+		);
+		cy.screenshot();
+	});
+
+	it("value state — Critical", () => {
+		cy.mount(
+			<Select valueState="Critical">
+				<span slot="valueStateMessage">Please review</span>
+				<Option>Apple</Option>
+				<Option>Banana</Option>
+			</Select>
+		);
+		cy.screenshot();
+	});
+
+	it("value state — Positive", () => {
+		cy.mount(
+			<Select valueState="Positive">
+				<span slot="valueStateMessage">Valid selection</span>
+				<Option>Apple</Option>
+				<Option>Banana</Option>
+			</Select>
+		);
+		cy.screenshot();
+	});
+
+	it("value state — Information", () => {
+		cy.mount(
+			<Select valueState="Information">
+				<span slot="valueStateMessage">Select one option</span>
+				<Option>Apple</Option>
+				<Option>Banana</Option>
+			</Select>
+		);
+		cy.screenshot();
+	});
+
+	it("compact mode", () => {
+		cy.mount(
+			<div data-ui5-compact-size>
+				<Select>
+					<Option>Apple</Option>
+					<Option selected>Banana</Option>
+					<Option>Cherry</Option>
+				</Select>
+			</div>
+		);
+		cy.screenshot();
+	});
+});

--- a/packages/main/cypress/specs/visuals/Switch.cy.tsx
+++ b/packages/main/cypress/specs/visuals/Switch.cy.tsx
@@ -1,0 +1,68 @@
+import Switch from "../../../src/Switch.js";
+
+describe("Switch visual", () => {
+	it("Textual design — unchecked", () => {
+		cy.mount(<Switch design="Textual" accessibleName="Notifications" />);
+		cy.screenshot();
+	});
+
+	it("Textual design — checked", () => {
+		cy.mount(<Switch design="Textual" checked accessibleName="Notifications" />);
+		cy.screenshot();
+	});
+
+	it("Textual design — custom labels", () => {
+		cy.mount(<Switch design="Textual" textOn="ON" textOff="OFF" />);
+		cy.screenshot();
+	});
+
+	it("Textual design — custom labels checked", () => {
+		cy.mount(<Switch design="Textual" textOn="ON" textOff="OFF" checked />);
+		cy.screenshot();
+	});
+
+	it("Graphical design — unchecked", () => {
+		cy.mount(<Switch design="Graphical" accessibleName="Dark mode" />);
+		cy.screenshot();
+	});
+
+	it("Graphical design — checked", () => {
+		cy.mount(<Switch design="Graphical" checked accessibleName="Dark mode" />);
+		cy.screenshot();
+	});
+
+	it("disabled — unchecked", () => {
+		cy.mount(<Switch design="Textual" disabled accessibleName="Disabled switch" />);
+		cy.screenshot();
+	});
+
+	it("disabled — checked", () => {
+		cy.mount(<Switch design="Textual" checked disabled accessibleName="Disabled switch" />);
+		cy.screenshot();
+	});
+
+	it("readonly — checked", () => {
+		cy.mount(<Switch design="Textual" checked readonly accessibleName="Readonly switch" />);
+		cy.screenshot();
+	});
+
+	it("both designs side by side", () => {
+		cy.mount(
+			<div style={{ display: "flex", gap: "16px", alignItems: "center" }}>
+				<Switch design="Textual" textOn="Yes" textOff="No" checked />
+				<Switch design="Graphical" checked accessibleName="Graphical" />
+			</div>
+		);
+		cy.screenshot();
+	});
+
+	it("compact mode", () => {
+		cy.mount(
+			<div data-ui5-compact-size style={{ display: "flex", gap: "16px" }}>
+				<Switch design="Textual" accessibleName="Compact off" />
+				<Switch design="Textual" checked accessibleName="Compact on" />
+			</div>
+		);
+		cy.screenshot();
+	});
+});

--- a/packages/main/cypress/specs/visuals/Tag.cy.tsx
+++ b/packages/main/cypress/specs/visuals/Tag.cy.tsx
@@ -1,0 +1,81 @@
+import Tag from "../../../src/Tag.js";
+import Icon from "../../../src/Icon.js";
+import "@ui5/webcomponents-icons/dist/employee.js";
+
+describe("Tag visual", () => {
+	it("all designs", () => {
+		cy.mount(
+			<div style={{ display: "flex", gap: "8px", flexWrap: "wrap" }}>
+				<Tag design="Neutral">Neutral</Tag>
+				<Tag design="Information">Information</Tag>
+				<Tag design="Positive">Positive</Tag>
+				<Tag design="Negative">Negative</Tag>
+				<Tag design="Critical">Critical</Tag>
+				<Tag design="Set1">Set1</Tag>
+				<Tag design="Set2">Set2</Tag>
+			</div>
+		);
+		cy.screenshot();
+	});
+
+	it("design — Neutral", () => {
+		cy.mount(<Tag design="Neutral">Neutral</Tag>);
+		cy.screenshot();
+	});
+
+	it("design — Information", () => {
+		cy.mount(<Tag design="Information">Information</Tag>);
+		cy.screenshot();
+	});
+
+	it("design — Positive", () => {
+		cy.mount(<Tag design="Positive">Positive</Tag>);
+		cy.screenshot();
+	});
+
+	it("design — Negative", () => {
+		cy.mount(<Tag design="Negative">Negative</Tag>);
+		cy.screenshot();
+	});
+
+	it("design — Critical", () => {
+		cy.mount(<Tag design="Critical">Critical</Tag>);
+		cy.screenshot();
+	});
+
+	it("design — Set1", () => {
+		cy.mount(<Tag design="Set1">Set1</Tag>);
+		cy.screenshot();
+	});
+
+	it("design — Set2", () => {
+		cy.mount(<Tag design="Set2">Set2</Tag>);
+		cy.screenshot();
+	});
+
+	it("with icon", () => {
+		cy.mount(
+			<div style={{ display: "flex", gap: "8px" }}>
+				<Tag design="Positive"><Icon name="employee" slot="icon" />With icon</Tag>
+				<Tag design="Negative"><Icon name="employee" slot="icon" />With icon</Tag>
+			</div>
+		);
+		cy.screenshot();
+	});
+
+	it("interactive state", () => {
+		cy.mount(<Tag design="Information" interactive>Interactive tag</Tag>);
+		cy.screenshot();
+	});
+
+	it("compact mode", () => {
+		cy.mount(
+			<div data-ui5-compact-size style={{ display: "flex", gap: "8px", flexWrap: "wrap" }}>
+				<Tag design="Neutral">Neutral</Tag>
+				<Tag design="Positive">Positive</Tag>
+				<Tag design="Negative">Negative</Tag>
+			</div>
+		);
+		cy.screenshot();
+	});
+});

--- a/packages/main/package-scripts.cjs
+++ b/packages/main/package-scripts.cjs
@@ -9,6 +9,7 @@ const options = {
 	cssVariablesTarget: "host",
 	internal: {
 		cypress_code_coverage: false,
+		cypress_visual: process.env.CYPRESS_VISUAL === "true",
 	},
 };
 

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -33,6 +33,8 @@
     "test:cypress:suite-3": "wc-dev test-cy-ci-suite-3",
     "test:cypress:suite-4": "wc-dev test-cy-ci-suite-4",
     "test:cypress:open": "wc-dev test-cy-open",
+    "test:cypress:visual": "CYPRESS_VISUAL=true yarn test:cypress",
+    "test:cypress:open:visual": "CYPRESS_VISUAL=true yarn test:cypress:open",
     "test:cypress:single": "npx cypress run --component --browser chrome --spec",
     "test:vitest": "yarn vitest run",
     "test:ssr": "node -e \"import('./test/ssr/component-imports.js')\"",

--- a/packages/tools/components-package/nps.js
+++ b/packages/tools/components-package/nps.js
@@ -83,6 +83,7 @@ const getScripts = (options) => {
 			UI5_TS: `${tsOption}`,
 			CSS_VARIABLES_TARGET: options.cssVariablesTarget ?? "root",
 			CYPRESS_COVERAGE: !!(options.internal?.cypress_code_coverage),
+			CYPRESS_VISUAL: !!(options.internal?.cypress_visual),
 		},
 		clean: {
 			"default": "ui5nps clean.generated clean.dist scope.testPages.clean",


### PR DESCRIPTION
Add Cypress-based visual (screenshot) tests for 21 components across @ui5/webcomponents and @ui5/webcomponents-fiori, covering key variants, states, and themes. Includes the supporting infrastructure: custom Cypress commands for visual snapshots, config updates, and a visual-test skill guide for authoring new specs.

Packages changed: main, fiori, cypress-internal, tools