### PR TITLE
fix(ui5-table): ignore 1px scrollWidth/clientWidth diff to prevent stuck popin on Safari

### DIFF
--- a/packages/main/src/Table.ts
+++ b/packages/main/src/Table.ts
@@ -523,10 +523,12 @@ class Table extends UI5Element {
 
 	_onResize() {
 		const { clientWidth, scrollWidth } = this._tableElement;
+		// Safari can report scrollWidth 1px greater than clientWidth during zoom transitions
+		// due to subpixel rounding, so a strict > check triggers spurious popin cycles.
+		const overflow = scrollWidth - clientWidth;
 
-		if (scrollWidth > clientWidth) {
+		if (overflow > 1) {
 			// Overflow Handling: Move columns into the popin until overflow is resolved
-			const overflow = scrollWidth - clientWidth;
 			const headers = this._getPopinOrderedColumns(false);
 			const poppedInWidth = headers.reduce((totalPoppedInWidth, headerCell) => {
 				if (totalPoppedInWidth < overflow && !headerCell._popin) {


### PR DESCRIPTION
Safari can report scrollWidth 1px greater than clientWidth during zoom transitions due to subpixel rounding. The previous strict `scrollWidth > clientWidth` check treated this as real overflow and triggered spurious popin cycles that corrupted `_containerWidth`, leaving columns stuck in the popin area even after zooming back out.

Treat differences of 1px as no overflow. Real overflows (>= 2px) still trigger popin as before.

Fixes: #12812 