### PR TITLE
fix(OpenUI5Support): fix error on Firefox

### DIFF
--- a/packages/base/src/features/patchPopup.ts
+++ b/packages/base/src/features/patchPopup.ts
@@ -11,7 +11,7 @@ const patchFocusEvent = (Popup: OpenUI5Popup) => {
 	Popup.prototype.onFocusEvent = function onFocusEvent(e: FocusEvent, ...rest) {
 		const isTypeFocus = e.type === "focus" || e.type === "activate";
 		const target = e.target as HTMLElement;
-		if (!isTypeFocus || !target.closest("[ui5-popover],[ui5-responsive-popover],[ui5-dialog]")) {
+		if (!isTypeFocus || !target?.closest?.("[ui5-popover],[ui5-responsive-popover],[ui5-dialog]")) {
 			origFocusEvent.call(this, e, ...rest);
 		}
 	};


### PR DESCRIPTION
fixes #13783

In Firefox, the exception target.closest is not a function occurs when a popup is open, the user shifts focus away from the window (e.g., to the address bar), and then refocuses the popup. Firefox first dispatches a focus event where the target is the Document instead of an element, and Document does not implement closest().