### PR TITLE
fix(framework): await pending language change in connectedCallback instead of skipping first render

### DIFF
--- a/packages/base/cypress/specs/LanguageAwareLifecycle.cy.tsx
+++ b/packages/base/cypress/specs/LanguageAwareLifecycle.cy.tsx
@@ -1,0 +1,104 @@
+import { setLanguage } from "../../src/config/Language.js";
+import { registerI18nLoader } from "../../src/i18nBundle.js";
+import parseProperties from "../../src/PropertiesFileFormat.js";
+import LanguageAwareLifecycle from "../../test/test-elements/LanguageAwareLifecycle.js";
+
+// Regression test for the language-aware lifecycle bug introduced by PR #13602.
+//
+// Before the fix, if setLanguage() was called without awaiting and a language-aware
+// component was inserted into the DOM while languageChangePending was true,
+// connectedCallback bailed out with a bare `return`. The deferred reRenderAllUI5Elements
+// call re-rendered the shadow DOM but the onEnterDOM lifecycle hook was never fired,
+// so consumers that register a ResizeHandler / add DOM listeners / set attributes
+// inside onEnterDOM saw those side effects silently drop.
+describe("Language-aware component lifecycle when setLanguage is not awaited", () => {
+	beforeEach(() => {
+		// Register a slow custom-language loader so setLanguage("bg") stays pending
+		// long enough for the component to be inserted before CLDR resolves.
+		cy.wrap({ registerI18nLoader })
+			.then(api => {
+				api.registerI18nLoader("lifecycle-lang-test", "bg", () => {
+					return new Promise(resolve => {
+						setTimeout(() => resolve(parseProperties("KEY=Value")), 50);
+					});
+				});
+			});
+
+		// Reset language back to en between tests
+		cy.wrap({ setLanguage })
+			.then(async api => {
+				await api.setLanguage("en");
+			});
+	});
+
+	it("fires onEnterDOM exactly once after the deferred first render", () => {
+		// Kick off a language change but do NOT await the promise - this is the
+		// pattern the Udex Footer's host app was using.
+		let languageReady: Promise<void>;
+		cy.wrap({ setLanguage })
+			.then(api => {
+				languageReady = api.setLanguage("bg");
+			});
+
+		cy.mount(<LanguageAwareLifecycle />);
+
+		// Wait for the language change to settle
+		cy.then(() => languageReady);
+
+		// After the deferred re-render, onEnterDOM must have fired exactly once
+		// and the component must be marked as fully connected.
+		cy.get<LanguageAwareLifecycle>("[ui5-language-aware-lifecycle]")
+			.should($el => {
+				const el = $el[0];
+				expect(el.enterDOMCount, "onEnterDOM call count").to.equal(1);
+				expect(el._fullyConnected, "_fullyConnected flag").to.equal(true);
+				expect(el.afterRenderingCount, "onAfterRendering call count").to.be.at.least(1);
+			});
+	});
+
+	it("does not fire onEnterDOM twice on subsequent language re-renders", () => {
+		let languageReady: Promise<void>;
+		cy.wrap({ setLanguage })
+			.then(api => {
+				languageReady = api.setLanguage("bg");
+			});
+
+		cy.mount(<LanguageAwareLifecycle />);
+
+		cy.then(() => languageReady);
+
+		// Change language a second time - this triggers reRenderAllUI5Elements
+		// again but the element is already fully connected, so onEnterDOM must
+		// NOT be called again.
+		cy.wrap({ setLanguage })
+			.then(async api => {
+				await api.setLanguage("en");
+			});
+
+		cy.get<LanguageAwareLifecycle>("[ui5-language-aware-lifecycle]")
+			.should($el => {
+				expect($el[0].enterDOMCount, "onEnterDOM should still be 1 after re-render").to.equal(1);
+			});
+	});
+
+	it("does not fire onEnterDOM if element is removed before deferred render", () => {
+		cy.wrap({ setLanguage })
+			.then(async api => {
+				// Insert then synchronously remove the element while the language
+				// change is still pending. The element is unregistered by
+				// disconnectedCallback, so reRenderAllUI5Elements must not touch it
+				// and its lifecycle hooks must stay silent.
+				const el = document.createElement("ui5-language-aware-lifecycle") as LanguageAwareLifecycle;
+
+				const languageReady = api.setLanguage("bg"); // NOT awaited yet
+				document.body.appendChild(el);
+				document.body.removeChild(el);
+
+				await languageReady;
+
+				expect(el.enterDOMCount, "onEnterDOM should not fire on removed element").to.equal(0);
+				expect(el.exitDOMCount, "onExitDOM should not fire (was never fully connected)").to.equal(0);
+				expect(el._fullyConnected, "_fullyConnected flag stays false").to.equal(false);
+			});
+	});
+});

--- a/packages/base/src/UI5Element.ts
+++ b/packages/base/src/UI5Element.ts
@@ -357,17 +357,24 @@ abstract class UI5Element extends HTMLElement {
 			await ctor._definePromise;
 		}
 
-		// Skip rendering while a language change is in progress to avoid rendering with not fully loaded locale data.
-		// Once the locale data is loaded, the language-aware component will be re-rendered.
-		if (ctor.getMetadata().isLanguageAware() && getLanguageChangePending()) {
-			return;
+		// Wait for any pending language change to finish before rendering to avoid rendering
+		// with not fully loaded locale data. Once it resolves, proceed with the normal render
+		// path so onEnterDOM and the rest of the lifecycle fire exactly as they would otherwise.
+		// Note: the reRenderAllUI5Elements call that closes out the language change may already
+		// have rendered this element via the deferred queue (since it was registered above), so
+		// we skip renderImmediately if the first render has already happened.
+		const languageChangePending = getLanguageChangePending();
+		if (ctor.getMetadata().isLanguageAware() && languageChangePending) {
+			await languageChangePending;
 		}
 
 		if (!this._inDOM) { // Component removed from DOM while _processChildren was running
 			return;
 		}
 
-		renderImmediately(this);
+		if (!this._rendered) {
+			renderImmediately(this);
+		}
 		this._domRefReadyPromise._deferredResolve!();
 		this._fullyConnected = true;
 		this.onEnterDOM();

--- a/packages/base/src/config/Language.ts
+++ b/packages/base/src/config/Language.ts
@@ -17,27 +17,33 @@ attachConfigurationReset(() => {
 	fetchDefaultLanguage = undefined;
 });
 
-// Flag indicating that a language change is in progress and not yet complete.
-// While this flag is true, language-aware components will not re-render.
-// These components may rely on language-specific data (e.g., CLDR, language bundles),
-// which might be unavailable during the loading phase.
-// During this phase, all re-rendering is postponed.
-// Once all necessary language data has been loaded, the language change
-// will trigger a re-render of all language-aware components.
-let languageChangePending = false;
+// Promise that resolves when the current language change (i18n bundles + CLDR data)
+// completes, or `null` when no language change is in flight. Consumers that need to
+// wait for locale data to be ready before rendering — most notably language-aware
+// UI5Element instances mounted while setLanguage is in flight — can await it.
+let languageChangePending: Promise<void> | null = null;
+
+const startLanguageChange = (language: string): Promise<void> => {
+	const changePromise = fireLanguageChange(language).then(() => {
+		if (isBooted()) {
+			return reRenderAllUI5Elements({ languageAware: true });
+		}
+	}).finally(() => {
+		// Only clear if no newer change has already replaced us
+		if (languageChangePending === changePromise) {
+			languageChangePending = null;
+		}
+	});
+	languageChangePending = changePromise;
+	return changePromise;
+};
 
 attachConfigChange("language", (language: string) => {
 	curLanguage = language;
-	languageChangePending = true;
-	fireLanguageChange(language).then(() => {
-		languageChangePending = false;
-		if (isBooted()) {
-			reRenderAllUI5Elements({ languageAware: true });
-		}
-	});
+	startLanguageChange(language);
 });
 
-const getLanguageChangePending = () => languageChangePending;
+const getLanguageChangePending = (): Promise<void> | null => languageChangePending;
 
 /**
  * Returns the currently configured language, or the browser language as a fallback.
@@ -64,18 +70,11 @@ const setLanguage = async (language: string): Promise<void> => {
 		return;
 	}
 
-	languageChangePending = true;
 	curLanguage = language;
 
 	fireConfigChange("language", language);
 
-	await fireLanguageChange(language);
-
-	languageChangePending = false;
-
-	if (isBooted()) {
-		await reRenderAllUI5Elements({ languageAware: true });
-	}
+	await startLanguageChange(language);
 };
 
 /**

--- a/packages/base/test/test-elements/LanguageAwareLifecycle.tsx
+++ b/packages/base/test/test-elements/LanguageAwareLifecycle.tsx
@@ -1,0 +1,40 @@
+import UI5Element from "../../src/UI5Element.js";
+import customElement from "../../src/decorators/customElement.js";
+import jsxRenderer from "../../src/renderer/JsxRenderer.js";
+
+/**
+ * Language-aware test element that records how many times each lifecycle hook fires.
+ * Used by base/cypress/specs/LanguageAwareLifecycle.cy.tsx to verify that onEnterDOM
+ * still fires exactly once, even when connectedCallback runs while a language change
+ * is pending (see fix for the PR #13602 regression).
+ */
+@customElement({
+	tag: "ui5-language-aware-lifecycle",
+	renderer: jsxRenderer,
+	languageAware: true,
+})
+class LanguageAwareLifecycle extends UI5Element {
+	enterDOMCount = 0;
+	exitDOMCount = 0;
+	afterRenderingCount = 0;
+
+	onEnterDOM() {
+		this.enterDOMCount++;
+	}
+
+	onExitDOM() {
+		this.exitDOMCount++;
+	}
+
+	onAfterRendering() {
+		this.afterRenderingCount++;
+	}
+
+	static get template() {
+		return () => <div>lifecycle</div>;
+	}
+}
+
+LanguageAwareLifecycle.define();
+
+export default LanguageAwareLifecycle;


### PR DESCRIPTION
## Summary

Follow-up to #13602. That PR made `connectedCallback` bail out early for language-aware components mounted while a language change was in progress. The early-return path silently skipped `onEnterDOM()`, `_fullyConnected = true`, and the `_domRefReadyPromise` resolution — so consumers that register listeners or observers in `onEnterDOM` never saw those side effects wired up.

## Reporter symptom

Reported against `udex-footer` (built on top of UI5 Web Components):

```ts
onEnterDOM(): void {
    if (isDesktop()) {
        this.setAttribute("desktop", "");
    }
    ResizeHandler.register(this, this._handleResizeBound);
}
```

- App calls `setLanguage("zh_CN")` without awaiting → language change pending.
- `<udex-footer>` inserted while pending → `connectedCallback` hits the early return at `UI5Element.ts:362`.
- `ResizeHandler.register` never runs → mobile Accordion never appears because the resize observer never fires.

## Fix

Instead of bailing out (which desynchronized the lifecycle), await the pending language change and then continue on the normal render path. To make that ergonomic, `languageChangePending` in `Language.ts` is repurposed from a boolean flag into a promise handle — the in-flight settlement promise, or `null` when no change is pending.

**`Language.ts`**
- `languageChangePending: Promise<void> | null` replaces the boolean.
- A single `startLanguageChange` helper builds the promise (chaining `fireLanguageChange` + the deferred `reRenderAllUI5Elements`) and clears the field on `.finally` — only if a newer change hasn't already replaced it.
- Both `setLanguage()` and the cross-runtime `attachConfigChange` handler share the helper, so both paths keep the field consistent.
- `getLanguageChangePending()` now returns the in-flight promise or `null`.

**`UI5Element.ts` — `connectedCallback`**
```ts
const languageChangePending = getLanguageChangePending();
if (ctor.getMetadata().isLanguageAware() && languageChangePending) {
    await languageChangePending;
}
// ...normal render path continues, onEnterDOM fires exactly as usual
```
A small guard skips the redundant `renderImmediately(this)` if the deferred `reRenderAllUI5Elements` already rendered the element during the await.

**`UI5Element.ts` — `_invalidate`**
Unchanged. `getLanguageChangePending()` in a truthy context still means "a change is in flight, don't invalidate now".

## Why this shape

- **Preserves the lifecycle invariant.** `onEnterDOM` fires exactly once, after the first render, on the natural code path — no deferred bookkeeping.
- **Single source of truth.** One field on `Language.ts` — either a promise or `null` — captures pending-ness. No boolean/promise pair to keep in sync.
- **Composable.** Any future consumer that needs "wait for locale data to be ready" can `await getLanguageChangePending()` without adding another synchronization surface.

## Tests

- New test element `packages/base/test/test-elements/LanguageAwareLifecycle.tsx` — `languageAware: true`, counts each lifecycle hook invocation.
- New spec `packages/base/cypress/specs/LanguageAwareLifecycle.cy.tsx`:
  - `onEnterDOM` fires exactly once after a pending language change resolves
  - `onEnterDOM` does not fire a second time on a subsequent re-render
  - `onEnterDOM` does not fire if the element is removed before rendering

Verified locally:
- New tests: **3/3 pass with the fix, 2/3 fail without the fix** (confirms the regression is caught).
- Existing `main/cypress/specs/DatePicker_cldr_race.cy.tsx` (from #13602): still passes.
- Existing `base/cypress/specs/i18n_texts.cy.tsx`: still passes.
- `yarn lint` clean.

## Backport

Should be cherry-picked to the 2.23.x line since #13602 shipped there and Udex is affected.

## Related

- #13602 introduced the early return.
- Reported by the UDEX (Digital Design System) team — `sapudex/digital-design-system` Footer component.