### PR TITLE
fix(framework): await pending language change in connectedCallback (2.23.3 backport)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.23.1](https://github.com/UI5/webcomponents/compare/v2.23.0...v2.23.1) (2026-06-11)
+
+
+### Bug Fixes
+
+* **framework:** re-apply theme on secondary boot to detect OpenUI5 custom themes ([#13680](https://github.com/UI5/webcomponents/issues/13680)) ([feab9ea](https://github.com/UI5/webcomponents/commit/feab9ea62d3c126627be6eade10118a36bae3a6b))
+* **OpenUI5Support:** move popover to top of top layer ([#13671](https://github.com/UI5/webcomponents/issues/13671)) ([e90ebe5](https://github.com/UI5/webcomponents/commit/e90ebe58a21e01a241896f71e2d3ebc95aba8451))
+
+
+
+
+
 # [2.23.0](https://github.com/UI5/webcomponents/compare/v2.23.0-rc.2...v2.23.0) (2026-06-05)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.23.2](https://github.com/UI5/webcomponents/compare/v2.23.1...v2.23.2) (2026-06-26)
+
+
+### Bug Fixes
+
+* ensure global styles are updated by the newest runtime ([#13745](https://github.com/UI5/webcomponents/issues/13745)) ([3cdaa23](https://github.com/UI5/webcomponents/commit/3cdaa233d2d4bab8553e44d3d455cf466dbbe3d1))
+* **ui5-search:** keep popup open on item click when search event is prevented ([#13757](https://github.com/UI5/webcomponents/issues/13757)) ([32f551b](https://github.com/UI5/webcomponents/commit/32f551b5375978c878f757fa9d54eef2a5b2ede6)), closes [#13750](https://github.com/UI5/webcomponents/issues/13750)
+* **ui5-shellbar-branding:** space key now triggers click event ([#13748](https://github.com/UI5/webcomponents/issues/13748)) ([17b6d45](https://github.com/UI5/webcomponents/commit/17b6d4548866360ed5e930e704219a0a65f716b1))
+* **ui5-shellbar-item:** fire click event when item is clicked in overflow popover ([#13747](https://github.com/UI5/webcomponents/issues/13747)) ([703bb33](https://github.com/UI5/webcomponents/commit/703bb33fbf7b98cc09901b756f72bbd49b9067ad))
+* **ui5-shellbar-search:** fix closing popup on tapping magnifier icon in mobile ([#13746](https://github.com/UI5/webcomponents/issues/13746)) ([182b9c3](https://github.com/UI5/webcomponents/commit/182b9c325a9813d0cb7e95a3702a9ea9e5e6dec3))
+* **ui5-shellbar:** ignore non-ShellBarItem children in overflow calculation ([#13744](https://github.com/UI5/webcomponents/issues/13744)) ([5898503](https://github.com/UI5/webcomponents/commit/5898503b03e68b6ebb83dd3fbc24f18b9d93f20f))
+* **ui5-shellbar:** return overflow button from notificationsDomRef wh… ([#13753](https://github.com/UI5/webcomponents/issues/13753)) ([bc210b2](https://github.com/UI5/webcomponents/commit/bc210b29f6e61bfe3292bde97db2b29975928077)), closes [#13752](https://github.com/UI5/webcomponents/issues/13752)
+
+
+
+
+
 ## [2.23.1](https://github.com/UI5/webcomponents/compare/v2.23.0...v2.23.1) (2026-06-11)
 
 

--- a/lerna.json
+++ b/lerna.json
@@ -14,7 +14,7 @@
     "packages/create-package",
     "packages/compat"
   ],
-  "version": "2.23.1",
+  "version": "2.23.2",
   "command": {
     "publish": {
       "allowBranch": "*",

--- a/lerna.json
+++ b/lerna.json
@@ -14,7 +14,7 @@
     "packages/create-package",
     "packages/compat"
   ],
-  "version": "2.23.0",
+  "version": "2.23.1",
   "command": {
     "publish": {
       "allowBranch": "*",

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.23.2](https://github.com/UI5/webcomponents/compare/v2.23.1...v2.23.2) (2026-06-26)
+
+**Note:** Version bump only for package @ui5/webcomponents-ai
+
+
+
+
+
 ## [2.23.1](https://github.com/UI5/webcomponents/compare/v2.23.0...v2.23.1) (2026-06-11)
 
 **Note:** Version bump only for package @ui5/webcomponents-ai

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.23.1](https://github.com/UI5/webcomponents/compare/v2.23.0...v2.23.1) (2026-06-11)
+
+**Note:** Version bump only for package @ui5/webcomponents-ai
+
+
+
+
+
 # [2.23.0](https://github.com/UI5/webcomponents/compare/v2.23.0-rc.2...v2.23.0) (2026-06-05)
 
 **Note:** Version bump only for package @ui5/webcomponents-ai

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents-ai",
-  "version": "2.23.1",
+  "version": "2.23.2",
   "description": "UI5 Web Components: webcomponents.ai",
   "ui5": {
     "webComponentsPackage": true
@@ -48,15 +48,15 @@
     "directory": "packages/ai"
   },
   "dependencies": {
-    "@ui5/webcomponents": "2.23.1",
-    "@ui5/webcomponents-base": "2.23.1",
-    "@ui5/webcomponents-icons": "2.23.1",
-    "@ui5/webcomponents-theming": "2.23.1"
+    "@ui5/webcomponents": "2.23.2",
+    "@ui5/webcomponents-base": "2.23.2",
+    "@ui5/webcomponents-icons": "2.23.2",
+    "@ui5/webcomponents-theming": "2.23.2"
   },
   "devDependencies": {
     "@custom-elements-manifest/analyzer": "^0.10.10",
     "@ui5/cypress-internal": "0.1.0",
-    "@ui5/webcomponents-tools": "2.23.1",
+    "@ui5/webcomponents-tools": "2.23.2",
     "cypress": "15.9.0",
     "vite": "5.4.21"
   }

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents-ai",
-  "version": "2.23.0",
+  "version": "2.23.1",
   "description": "UI5 Web Components: webcomponents.ai",
   "ui5": {
     "webComponentsPackage": true
@@ -48,15 +48,15 @@
     "directory": "packages/ai"
   },
   "dependencies": {
-    "@ui5/webcomponents": "2.23.0",
-    "@ui5/webcomponents-base": "2.23.0",
-    "@ui5/webcomponents-icons": "2.23.0",
-    "@ui5/webcomponents-theming": "2.23.0"
+    "@ui5/webcomponents": "2.23.1",
+    "@ui5/webcomponents-base": "2.23.1",
+    "@ui5/webcomponents-icons": "2.23.1",
+    "@ui5/webcomponents-theming": "2.23.1"
   },
   "devDependencies": {
     "@custom-elements-manifest/analyzer": "^0.10.10",
     "@ui5/cypress-internal": "0.1.0",
-    "@ui5/webcomponents-tools": "2.23.0",
+    "@ui5/webcomponents-tools": "2.23.1",
     "cypress": "15.9.0",
     "vite": "5.4.21"
   }

--- a/packages/base/CHANGELOG.md
+++ b/packages/base/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.23.1](https://github.com/UI5/webcomponents/compare/v2.23.0...v2.23.1) (2026-06-11)
+
+
+### Bug Fixes
+
+* **framework:** re-apply theme on secondary boot to detect OpenUI5 custom themes ([#13680](https://github.com/UI5/webcomponents/issues/13680)) ([feab9ea](https://github.com/UI5/webcomponents/commit/feab9ea62d3c126627be6eade10118a36bae3a6b))
+* **OpenUI5Support:** move popover to top of top layer ([#13671](https://github.com/UI5/webcomponents/issues/13671)) ([e90ebe5](https://github.com/UI5/webcomponents/commit/e90ebe58a21e01a241896f71e2d3ebc95aba8451))
+
+
+
+
+
 # [2.23.0](https://github.com/UI5/webcomponents/compare/v2.23.0-rc.2...v2.23.0) (2026-06-05)
 
 

--- a/packages/base/CHANGELOG.md
+++ b/packages/base/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.23.2](https://github.com/UI5/webcomponents/compare/v2.23.1...v2.23.2) (2026-06-26)
+
+
+### Bug Fixes
+
+* ensure global styles are updated by the newest runtime ([#13745](https://github.com/UI5/webcomponents/issues/13745)) ([3cdaa23](https://github.com/UI5/webcomponents/commit/3cdaa233d2d4bab8553e44d3d455cf466dbbe3d1))
+
+
+
+
+
 ## [2.23.1](https://github.com/UI5/webcomponents/compare/v2.23.0...v2.23.1) (2026-06-11)
 
 

--- a/packages/base/cypress/specs/LanguageAwareLifecycle.cy.tsx
+++ b/packages/base/cypress/specs/LanguageAwareLifecycle.cy.tsx
@@ -1,0 +1,104 @@
+import { setLanguage } from "../../src/config/Language.js";
+import { registerI18nLoader } from "../../src/i18nBundle.js";
+import parseProperties from "../../src/PropertiesFileFormat.js";
+import LanguageAwareLifecycle from "../../test/test-elements/LanguageAwareLifecycle.js";
+
+// Regression test for the language-aware lifecycle bug introduced by PR #13602.
+//
+// Before the fix, if setLanguage() was called without awaiting and a language-aware
+// component was inserted into the DOM while languageChangePending was true,
+// connectedCallback bailed out with a bare `return`. The deferred reRenderAllUI5Elements
+// call re-rendered the shadow DOM but the onEnterDOM lifecycle hook was never fired,
+// so consumers that register a ResizeHandler / add DOM listeners / set attributes
+// inside onEnterDOM saw those side effects silently drop.
+describe("Language-aware component lifecycle when setLanguage is not awaited", () => {
+	beforeEach(() => {
+		// Register a slow custom-language loader so setLanguage("bg") stays pending
+		// long enough for the component to be inserted before CLDR resolves.
+		cy.wrap({ registerI18nLoader })
+			.then(api => {
+				api.registerI18nLoader("lifecycle-lang-test", "bg", () => {
+					return new Promise(resolve => {
+						setTimeout(() => resolve(parseProperties("KEY=Value")), 50);
+					});
+				});
+			});
+
+		// Reset language back to en between tests
+		cy.wrap({ setLanguage })
+			.then(async api => {
+				await api.setLanguage("en");
+			});
+	});
+
+	it("fires onEnterDOM exactly once after the deferred first render", () => {
+		// Kick off a language change but do NOT await the promise - this is the
+		// pattern the Udex Footer's host app was using.
+		let languageReady: Promise<void>;
+		cy.wrap({ setLanguage })
+			.then(api => {
+				languageReady = api.setLanguage("bg");
+			});
+
+		cy.mount(<LanguageAwareLifecycle />);
+
+		// Wait for the language change to settle
+		cy.then(() => languageReady);
+
+		// After the deferred re-render, onEnterDOM must have fired exactly once
+		// and the component must be marked as fully connected.
+		cy.get<LanguageAwareLifecycle>("[ui5-language-aware-lifecycle]")
+			.should($el => {
+				const el = $el[0];
+				expect(el.enterDOMCount, "onEnterDOM call count").to.equal(1);
+				expect(el._fullyConnected, "_fullyConnected flag").to.equal(true);
+				expect(el.afterRenderingCount, "onAfterRendering call count").to.be.at.least(1);
+			});
+	});
+
+	it("does not fire onEnterDOM twice on subsequent language re-renders", () => {
+		let languageReady: Promise<void>;
+		cy.wrap({ setLanguage })
+			.then(api => {
+				languageReady = api.setLanguage("bg");
+			});
+
+		cy.mount(<LanguageAwareLifecycle />);
+
+		cy.then(() => languageReady);
+
+		// Change language a second time - this triggers reRenderAllUI5Elements
+		// again but the element is already fully connected, so onEnterDOM must
+		// NOT be called again.
+		cy.wrap({ setLanguage })
+			.then(async api => {
+				await api.setLanguage("en");
+			});
+
+		cy.get<LanguageAwareLifecycle>("[ui5-language-aware-lifecycle]")
+			.should($el => {
+				expect($el[0].enterDOMCount, "onEnterDOM should still be 1 after re-render").to.equal(1);
+			});
+	});
+
+	it("does not fire onEnterDOM if element is removed before deferred render", () => {
+		cy.wrap({ setLanguage })
+			.then(async api => {
+				// Insert then synchronously remove the element while the language
+				// change is still pending. The element is unregistered by
+				// disconnectedCallback, so reRenderAllUI5Elements must not touch it
+				// and its lifecycle hooks must stay silent.
+				const el = document.createElement("ui5-language-aware-lifecycle") as LanguageAwareLifecycle;
+
+				const languageReady = api.setLanguage("bg"); // NOT awaited yet
+				document.body.appendChild(el);
+				document.body.removeChild(el);
+
+				await languageReady;
+
+				expect(el.enterDOMCount, "onEnterDOM should not fire on removed element").to.equal(0);
+				expect(el.exitDOMCount, "onExitDOM should not fire (was never fully connected)").to.equal(0);
+				expect(el._fullyConnected, "_fullyConnected flag stays false").to.equal(false);
+			});
+	});
+});

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents-base",
-  "version": "2.23.1",
+  "version": "2.23.2",
   "description": "UI5 Web Components: webcomponents.base",
   "author": "SAP SE (https://www.sap.com)",
   "license": "Apache-2.0",
@@ -66,7 +66,7 @@
     "@openui5/sap.ui.core": "1.146.0",
     "@sap-theming/theming-base-content": "11.36.3",
     "@ui5/cypress-internal": "0.1.0",
-    "@ui5/webcomponents-tools": "2.23.1",
+    "@ui5/webcomponents-tools": "2.23.2",
     "clean-css": "^5.2.2",
     "cypress": "15.9.0",
     "mocha": "^11.7.2",

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents-base",
-  "version": "2.23.0",
+  "version": "2.23.1",
   "description": "UI5 Web Components: webcomponents.base",
   "author": "SAP SE (https://www.sap.com)",
   "license": "Apache-2.0",
@@ -66,7 +66,7 @@
     "@openui5/sap.ui.core": "1.146.0",
     "@sap-theming/theming-base-content": "11.36.3",
     "@ui5/cypress-internal": "0.1.0",
-    "@ui5/webcomponents-tools": "2.23.0",
+    "@ui5/webcomponents-tools": "2.23.1",
     "clean-css": "^5.2.2",
     "cypress": "15.9.0",
     "mocha": "^11.7.2",

--- a/packages/base/src/Boot.ts
+++ b/packages/base/src/Boot.ts
@@ -105,6 +105,7 @@ const secondaryBoot = async (): Promise<void> => {
 	await boot(); // make sure we're not in the middle of boot before re-running the skipped parts
 	await initF6Navigation();
 	attachOpenUI5SupportListeners();
+	await applyTheme(getTheme()); // Re-apply theme to detect external theme from OpenUI5 and clean up
 };
 
 /**

--- a/packages/base/src/FontFace.ts
+++ b/packages/base/src/FontFace.ts
@@ -1,4 +1,4 @@
-import { hasStyle, createStyle } from "./ManagedStyles.js";
+import { createOrUpdateStyle } from "./ManagedStyles.js";
 import { getFeature } from "./FeaturesRegistry.js";
 import fontFaceCSS from "./generated/css/FontFace.css.js";
 import type OpenUI5Support from "./features/OpenUI5Support.js";
@@ -20,9 +20,7 @@ const insertMainFontFace = () => {
 		return;
 	}
 
-	if (!hasStyle("data-ui5-font-face")) {
-		createStyle(fontFaceCSS, "data-ui5-font-face");
-	}
+	createOrUpdateStyle(fontFaceCSS, "data-ui5-font-face");
 };
 
 export default insertFontFace;

--- a/packages/base/src/ManagedStyles.ts
+++ b/packages/base/src/ManagedStyles.ts
@@ -27,6 +27,10 @@ const createStyle = (content: string, name: string, value = "", theme?: string) 
 };
 
 const updateStyle = (content: string, name: string, value = "", theme?: string) => {
+	if (isSSR) {
+		return;
+	}
+
 	const currentRuntimeIndex = getCurrentRuntimeIndex();
 
 	const stylesheet = document.adoptedStyleSheets.find(sh => (sh as Record<string, any>)._ui5StyleId === getStyleId(name, value));

--- a/packages/base/src/ScrollbarStyles.ts
+++ b/packages/base/src/ScrollbarStyles.ts
@@ -1,10 +1,8 @@
-import { hasStyle, createStyle } from "./ManagedStyles.js";
+import { createOrUpdateStyle } from "./ManagedStyles.js";
 import scrollbarStyles from "./generated/css/ScrollbarStyles.css.js";
 
 const insertScrollbarStyles = () => {
-	if (!hasStyle("data-ui5-scrollbar-styles")) {
-		createStyle(scrollbarStyles, "data-ui5-scrollbar-styles");
-	}
+	createOrUpdateStyle(scrollbarStyles, "data-ui5-scrollbar-styles");
 };
 
 export default insertScrollbarStyles;

--- a/packages/base/src/UI5Element.ts
+++ b/packages/base/src/UI5Element.ts
@@ -357,17 +357,24 @@ abstract class UI5Element extends HTMLElement {
 			await ctor._definePromise;
 		}
 
-		// Skip rendering while a language change is in progress to avoid rendering with not fully loaded locale data.
-		// Once the locale data is loaded, the language-aware component will be re-rendered.
-		if (ctor.getMetadata().isLanguageAware() && getLanguageChangePending()) {
-			return;
+		// Wait for any pending language change to finish before rendering to avoid rendering
+		// with not fully loaded locale data. Once it resolves, proceed with the normal render
+		// path so onEnterDOM and the rest of the lifecycle fire exactly as they would otherwise.
+		// Note: the reRenderAllUI5Elements call that closes out the language change may already
+		// have rendered this element via the deferred queue (since it was registered above), so
+		// we skip renderImmediately if the first render has already happened.
+		const languageChangePending = getLanguageChangePending();
+		if (ctor.getMetadata().isLanguageAware() && languageChangePending) {
+			await languageChangePending;
 		}
 
 		if (!this._inDOM) { // Component removed from DOM while _processChildren was running
 			return;
 		}
 
-		renderImmediately(this);
+		if (!this._rendered) {
+			renderImmediately(this);
+		}
 		this._domRefReadyPromise._deferredResolve!();
 		this._fullyConnected = true;
 		this.onEnterDOM();

--- a/packages/base/src/config/Language.ts
+++ b/packages/base/src/config/Language.ts
@@ -17,27 +17,33 @@ attachConfigurationReset(() => {
 	fetchDefaultLanguage = undefined;
 });
 
-// Flag indicating that a language change is in progress and not yet complete.
-// While this flag is true, language-aware components will not re-render.
-// These components may rely on language-specific data (e.g., CLDR, language bundles),
-// which might be unavailable during the loading phase.
-// During this phase, all re-rendering is postponed.
-// Once all necessary language data has been loaded, the language change
-// will trigger a re-render of all language-aware components.
-let languageChangePending = false;
+// Promise that resolves when the current language change (i18n bundles + CLDR data)
+// completes, or `null` when no language change is in flight. Consumers that need to
+// wait for locale data to be ready before rendering — most notably language-aware
+// UI5Element instances mounted while setLanguage is in flight — can await it.
+let languageChangePending: Promise<void> | null = null;
+
+const startLanguageChange = (language: string): Promise<void> => {
+	const changePromise = fireLanguageChange(language).then(() => {
+		if (isBooted()) {
+			return reRenderAllUI5Elements({ languageAware: true });
+		}
+	}).finally(() => {
+		// Only clear if no newer change has already replaced us
+		if (languageChangePending === changePromise) {
+			languageChangePending = null;
+		}
+	});
+	languageChangePending = changePromise;
+	return changePromise;
+};
 
 attachConfigChange("language", (language: string) => {
 	curLanguage = language;
-	languageChangePending = true;
-	fireLanguageChange(language).then(() => {
-		languageChangePending = false;
-		if (isBooted()) {
-			reRenderAllUI5Elements({ languageAware: true });
-		}
-	});
+	startLanguageChange(language);
 });
 
-const getLanguageChangePending = () => languageChangePending;
+const getLanguageChangePending = (): Promise<void> | null => languageChangePending;
 
 /**
  * Returns the currently configured language, or the browser language as a fallback.
@@ -64,18 +70,11 @@ const setLanguage = async (language: string): Promise<void> => {
 		return;
 	}
 
-	languageChangePending = true;
 	curLanguage = language;
 
 	fireConfigChange("language", language);
 
-	await fireLanguageChange(language);
-
-	languageChangePending = false;
-
-	if (isBooted()) {
-		await reRenderAllUI5Elements({ languageAware: true });
-	}
+	await startLanguageChange(language);
 };
 
 /**

--- a/packages/base/src/features/insertOpenUI5PopupStyles.ts
+++ b/packages/base/src/features/insertOpenUI5PopupStyles.ts
@@ -1,10 +1,8 @@
-import { hasStyle, createStyle } from "../ManagedStyles.js";
+import { createOrUpdateStyle } from "../ManagedStyles.js";
 import openUI5PopupStyles from "../generated/css/OpenUI5PopupStyles.css.js";
 
 const insertOpenUI5PopupStyles = () => {
-	if (!hasStyle("data-ui5-popup-styles")) {
-		createStyle(openUI5PopupStyles, "data-ui5-popup-styles");
-	}
+	createOrUpdateStyle(openUI5PopupStyles, "data-ui5-popup-styles");
 };
 
 export default insertOpenUI5PopupStyles;

--- a/packages/base/src/features/patchPopup.ts
+++ b/packages/base/src/features/patchPopup.ts
@@ -131,6 +131,7 @@ const openNativePopoverForOpenUI5 = (popup: OpenUI5Popup) => {
 	}
 
 	domRef.setAttribute("popover", "manual");
+	domRef.hidePopover();
 	domRef.showPopover();
 };
 

--- a/packages/base/test/test-elements/LanguageAwareLifecycle.tsx
+++ b/packages/base/test/test-elements/LanguageAwareLifecycle.tsx
@@ -1,0 +1,40 @@
+import UI5Element from "../../src/UI5Element.js";
+import customElement from "../../src/decorators/customElement.js";
+import jsxRenderer from "../../src/renderer/JsxRenderer.js";
+
+/**
+ * Language-aware test element that records how many times each lifecycle hook fires.
+ * Used by base/cypress/specs/LanguageAwareLifecycle.cy.tsx to verify that onEnterDOM
+ * still fires exactly once, even when connectedCallback runs while a language change
+ * is pending (see fix for the PR #13602 regression).
+ */
+@customElement({
+	tag: "ui5-language-aware-lifecycle",
+	renderer: jsxRenderer,
+	languageAware: true,
+})
+class LanguageAwareLifecycle extends UI5Element {
+	enterDOMCount = 0;
+	exitDOMCount = 0;
+	afterRenderingCount = 0;
+
+	onEnterDOM() {
+		this.enterDOMCount++;
+	}
+
+	onExitDOM() {
+		this.exitDOMCount++;
+	}
+
+	onAfterRendering() {
+		this.afterRenderingCount++;
+	}
+
+	static get template() {
+		return () => <div>lifecycle</div>;
+	}
+}
+
+LanguageAwareLifecycle.define();
+
+export default LanguageAwareLifecycle;

--- a/packages/compat/CHANGELOG.md
+++ b/packages/compat/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.23.2](https://github.com/UI5/webcomponents/compare/v2.23.1...v2.23.2) (2026-06-26)
+
+**Note:** Version bump only for package @ui5/webcomponents-compat
+
+
+
+
+
 ## [2.23.1](https://github.com/UI5/webcomponents/compare/v2.23.0...v2.23.1) (2026-06-11)
 
 **Note:** Version bump only for package @ui5/webcomponents-compat

--- a/packages/compat/CHANGELOG.md
+++ b/packages/compat/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.23.1](https://github.com/UI5/webcomponents/compare/v2.23.0...v2.23.1) (2026-06-11)
+
+**Note:** Version bump only for package @ui5/webcomponents-compat
+
+
+
+
+
 # [2.23.0](https://github.com/UI5/webcomponents/compare/v2.23.0-rc.2...v2.23.0) (2026-06-05)
 
 

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents-compat",
-  "version": "2.23.1",
+  "version": "2.23.2",
   "description": "UI5 Web Components: webcomponents.compat",
   "ui5": {
     "webComponentsPackage": true
@@ -48,15 +48,15 @@
     "directory": "packages/compat"
   },
   "dependencies": {
-    "@ui5/webcomponents": "2.23.1",
-    "@ui5/webcomponents-base": "2.23.1",
-    "@ui5/webcomponents-icons": "2.23.1",
-    "@ui5/webcomponents-theming": "2.23.1"
+    "@ui5/webcomponents": "2.23.2",
+    "@ui5/webcomponents-base": "2.23.2",
+    "@ui5/webcomponents-icons": "2.23.2",
+    "@ui5/webcomponents-theming": "2.23.2"
   },
   "devDependencies": {
     "@custom-elements-manifest/analyzer": "^0.10.10",
     "@ui5/cypress-internal": "0.1.0",
-    "@ui5/webcomponents-tools": "2.23.1",
+    "@ui5/webcomponents-tools": "2.23.2",
     "cypress": "15.9.0",
     "vite": "5.4.21"
   }

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents-compat",
-  "version": "2.23.0",
+  "version": "2.23.1",
   "description": "UI5 Web Components: webcomponents.compat",
   "ui5": {
     "webComponentsPackage": true
@@ -48,15 +48,15 @@
     "directory": "packages/compat"
   },
   "dependencies": {
-    "@ui5/webcomponents": "2.23.0",
-    "@ui5/webcomponents-base": "2.23.0",
-    "@ui5/webcomponents-icons": "2.23.0",
-    "@ui5/webcomponents-theming": "2.23.0"
+    "@ui5/webcomponents": "2.23.1",
+    "@ui5/webcomponents-base": "2.23.1",
+    "@ui5/webcomponents-icons": "2.23.1",
+    "@ui5/webcomponents-theming": "2.23.1"
   },
   "devDependencies": {
     "@custom-elements-manifest/analyzer": "^0.10.10",
     "@ui5/cypress-internal": "0.1.0",
-    "@ui5/webcomponents-tools": "2.23.0",
+    "@ui5/webcomponents-tools": "2.23.1",
     "cypress": "15.9.0",
     "vite": "5.4.21"
   }

--- a/packages/create-package/CHANGELOG.md
+++ b/packages/create-package/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.23.1](https://github.com/UI5/webcomponents/compare/v2.23.0...v2.23.1) (2026-06-11)
+
+**Note:** Version bump only for package @ui5/create-webcomponents-package
+
+
+
+
+
 # [2.23.0](https://github.com/UI5/webcomponents/compare/v2.23.0-rc.2...v2.23.0) (2026-06-05)
 
 **Note:** Version bump only for package @ui5/create-webcomponents-package

--- a/packages/create-package/CHANGELOG.md
+++ b/packages/create-package/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.23.2](https://github.com/UI5/webcomponents/compare/v2.23.1...v2.23.2) (2026-06-26)
+
+**Note:** Version bump only for package @ui5/create-webcomponents-package
+
+
+
+
+
 ## [2.23.1](https://github.com/UI5/webcomponents/compare/v2.23.0...v2.23.1) (2026-06-11)
 
 **Note:** Version bump only for package @ui5/create-webcomponents-package

--- a/packages/create-package/package.json
+++ b/packages/create-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/create-webcomponents-package",
-  "version": "2.23.1",
+  "version": "2.23.2",
   "description": "UI5 Web Components: create package",
   "author": "SAP SE (https://www.sap.com)",
   "license": "Apache-2.0",

--- a/packages/create-package/package.json
+++ b/packages/create-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/create-webcomponents-package",
-  "version": "2.23.0",
+  "version": "2.23.1",
   "description": "UI5 Web Components: create package",
   "author": "SAP SE (https://www.sap.com)",
   "license": "Apache-2.0",

--- a/packages/fiori/CHANGELOG.md
+++ b/packages/fiori/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.23.1](https://github.com/UI5/webcomponents/compare/v2.23.0...v2.23.1) (2026-06-11)
+
+**Note:** Version bump only for package @ui5/webcomponents-fiori
+
+
+
+
+
 # [2.23.0](https://github.com/UI5/webcomponents/compare/v2.23.0-rc.2...v2.23.0) (2026-06-05)
 
 

--- a/packages/fiori/CHANGELOG.md
+++ b/packages/fiori/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.23.2](https://github.com/UI5/webcomponents/compare/v2.23.1...v2.23.2) (2026-06-26)
+
+
+### Bug Fixes
+
+* **ui5-search:** keep popup open on item click when search event is prevented ([#13757](https://github.com/UI5/webcomponents/issues/13757)) ([32f551b](https://github.com/UI5/webcomponents/commit/32f551b5375978c878f757fa9d54eef2a5b2ede6)), closes [#13750](https://github.com/UI5/webcomponents/issues/13750)
+* **ui5-shellbar-branding:** space key now triggers click event ([#13748](https://github.com/UI5/webcomponents/issues/13748)) ([17b6d45](https://github.com/UI5/webcomponents/commit/17b6d4548866360ed5e930e704219a0a65f716b1))
+* **ui5-shellbar-item:** fire click event when item is clicked in overflow popover ([#13747](https://github.com/UI5/webcomponents/issues/13747)) ([703bb33](https://github.com/UI5/webcomponents/commit/703bb33fbf7b98cc09901b756f72bbd49b9067ad))
+* **ui5-shellbar-search:** fix closing popup on tapping magnifier icon in mobile ([#13746](https://github.com/UI5/webcomponents/issues/13746)) ([182b9c3](https://github.com/UI5/webcomponents/commit/182b9c325a9813d0cb7e95a3702a9ea9e5e6dec3))
+* **ui5-shellbar:** ignore non-ShellBarItem children in overflow calculation ([#13744](https://github.com/UI5/webcomponents/issues/13744)) ([5898503](https://github.com/UI5/webcomponents/commit/5898503b03e68b6ebb83dd3fbc24f18b9d93f20f))
+* **ui5-shellbar:** return overflow button from notificationsDomRef wh… ([#13753](https://github.com/UI5/webcomponents/issues/13753)) ([bc210b2](https://github.com/UI5/webcomponents/commit/bc210b29f6e61bfe3292bde97db2b29975928077)), closes [#13752](https://github.com/UI5/webcomponents/issues/13752)
+
+
+
+
+
 ## [2.23.1](https://github.com/UI5/webcomponents/compare/v2.23.0...v2.23.1) (2026-06-11)
 
 **Note:** Version bump only for package @ui5/webcomponents-fiori

--- a/packages/fiori/cypress/specs/Search.mobile.cy.tsx
+++ b/packages/fiori/cypress/specs/Search.mobile.cy.tsx
@@ -284,4 +284,45 @@ describe("Search Field on mobile device", () => {
 		cy.get("[ui5-search]")
 			.should("have.prop", "value", "Item 1");
 	});
+
+	it("should keep the popup open on item selection when preventDefault is called", () => {
+		cy.mount(
+			<>
+				<Search showClearIcon={true}>
+					<SearchItem text="Item 1" />
+					<SearchItem text="Item 2" />
+					<SearchItem text="Item 3" />
+				</Search>
+			</>
+		);
+
+		cy.get("[ui5-search]")
+			.then(search => {
+				search.get(0).addEventListener("ui5-search", (e: Event) => {
+					e.preventDefault();
+				});
+			});
+
+		cy.get("[ui5-search]")
+			.realClick();
+
+		cy.get("[ui5-search]")
+			.shadow()
+			.find<ResponsivePopover>("[ui5-responsive-popover]")
+			.ui5ResponsivePopoverOpened();
+
+		// Click an item in the popup
+		cy.get("[ui5-search-item]")
+			.eq(0)
+			.realClick();
+
+		// preventDefault was called, so the picker should remain open on mobile
+		cy.get("[ui5-search]")
+			.should("have.prop", "open", true);
+
+		cy.get("[ui5-search]")
+			.shadow()
+			.find<ResponsivePopover>("[ui5-responsive-popover]")
+			.should("have.prop", "open", true);
+	});
 });

--- a/packages/fiori/cypress/specs/ShellBar.cy.tsx
+++ b/packages/fiori/cypress/specs/ShellBar.cy.tsx
@@ -966,6 +966,36 @@ describe("Events", () => {
 				.should("have.been.calledOnce");
 		});
 
+		it("notificationsDomRef returns overflow button when notifications are in overflow", () => {
+			cy.viewport(320, 800);
+			cy.mount(
+				<ShellBar
+					primaryTitle="Product Title"
+					secondaryTitle="Second title"
+					showNotifications={true}
+					notificationsCount="5"
+					showProductSwitch={true}
+				>
+					<img slot="logo" src="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg" />
+					<Button slot="content">Button 1</Button>
+					<ToggleButton icon="sap-icon://da" slot="assistant" />
+				</ShellBar>
+			);
+
+			cy.get("[ui5-shellbar]").as("shellbar");
+
+			cy.get("@shellbar")
+				.shadow()
+				.find(".ui5-shellbar-overflow-button")
+				.should("exist")
+				.then(overflowBtn => {
+					cy.get("@shellbar").then($shellbar => {
+						const shellbar = $shellbar[0] as ShellBar;
+						expect(shellbar.notificationsDomRef).to.equal(overflowBtn[0]);
+					});
+				});
+		});
+
 		it("tests profileClick event", () => {
 			cy.mount(
 				<ShellBar>

--- a/packages/fiori/cypress/specs/ShellBar.cy.tsx
+++ b/packages/fiori/cypress/specs/ShellBar.cy.tsx
@@ -693,7 +693,7 @@ describe("Slots", () => {
 				.shadow()
 				.find(".ui5-shellbar-overflow-popover [data-action-id='search']")
 				.should("exist")
-				.click();
+				.realClick();
 
 			// Verify search is expanded
 			cy.get("@shellbar")
@@ -1810,6 +1810,70 @@ describe("Component Behavior", () => {
 
 			cy.get("[ui5-shellbar-item][icon='alert']")
 				.click();
+
+			cy.get("@alertClick")
+				.should("have.been.calledOnce");
+		});
+
+		it("tests 'click' on custom action in overflow popover", () => {
+			cy.viewport(320, 800);
+
+			cy.mount(
+				<ShellBar
+					primaryTitle="Product Title"
+					showNotifications
+					showProductSwitch
+				>
+					<ShellBarBranding slot="branding">
+						Product Title
+						<img src="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg" slot="logo" />
+					</ShellBarBranding>
+					<Button icon="nav-back" slot="startButton" />
+					<ShellBarItem id="overflow-accept" icon="accept" text="Accept" />
+					<ShellBarItem id="overflow-alert" icon="alert" text="Alert" />
+				</ShellBar>
+			);
+
+			cy.get("#overflow-accept").then($item => {
+				$item[0].addEventListener("click", cy.stub().as("acceptClick"));
+			});
+			cy.get("#overflow-alert").then($item => {
+				$item[0].addEventListener("click", cy.stub().as("alertClick"));
+			});
+
+			cy.get("[ui5-shellbar]")
+				.shadow()
+				.find(".ui5-shellbar-overflow-button")
+				.should("be.visible")
+				.click();
+
+			cy.get("[ui5-shellbar]")
+				.shadow()
+				.find(".ui5-shellbar-overflow-popover")
+				.should("have.attr", "open");
+
+			cy.get("#overflow-accept")
+				.shadow()
+				.find("[ui5-li]")
+				.realClick();
+
+			cy.get("@acceptClick")
+				.should("have.been.calledOnce");
+
+			cy.get("[ui5-shellbar]")
+				.shadow()
+				.find(".ui5-shellbar-overflow-button")
+				.click();
+
+			cy.get("[ui5-shellbar]")
+				.shadow()
+				.find(".ui5-shellbar-overflow-popover")
+				.should("have.attr", "open");
+
+			cy.get("#overflow-alert")
+				.shadow()
+				.find("[ui5-li]")
+				.realClick();
 
 			cy.get("@alertClick")
 				.should("have.been.calledOnce");

--- a/packages/fiori/cypress/specs/ShellBar.cy.tsx
+++ b/packages/fiori/cypress/specs/ShellBar.cy.tsx
@@ -1942,3 +1942,55 @@ describe("Start button spacing", () => {
 		cy.get("[ui5-shellbar]").shadow().find(".ui5-shellbar-start-button").should("have.css", "gap", "8px");
 	});
 });
+
+describe("Non-ShellBarItem children in default slot", () => {
+	it("should not throw 'processed too many times' when resizing across the overflow breakpoint with a stray <span> in the default slot", () => {
+		// Capture any errors thrown during the run — the bug surfaced as an
+		// uncaught Error: "Web component processed too many times this task,
+		// max allowed is: 10" from RenderQueue when the overflow algorithm
+		// failed to converge.
+		const errors: string[] = [];
+		cy.on("uncaught:exception", (err) => {
+			errors.push(err.message);
+			return false; // don't fail the test here; we assert below
+		});
+
+		cy.mount(
+			<ShellBar id="shellbar-stray" notificationsCount="72" showNotifications={true}>
+				<Button icon="menu2" slot="startButton"></Button>
+				<ShellBarBranding slot="branding">
+					Product Identifier
+					<img slot="logo" src="https://ui5.github.io/webcomponents/images/sap-logo-svg.svg" />
+				</ShellBarBranding>
+				<ShellBarSearch slot="searchField" showClearIcon placeholder="Search Apps, Products"></ShellBarSearch>
+				{/* The problem child — a stray non-ShellBarItem element in the default slot. */}
+				<span></span>
+				<Avatar slot="profile">
+					<img src="https://ui5.github.io/webcomponents/images/avatars/man_avatar_3.png" />
+				</Avatar>
+			</ShellBar>
+		);
+
+		cy.wait(RESIZE_THROTTLE_RATE);
+
+		// Oscillate across the overflow breakpoint several times. This is what
+		// triggered the runaway re-render in the regression — a single resize
+		// is not enough; the algorithm has to be invoked while the previous
+		// pass is still settling.
+		for (let i = 0; i < 6; i++) {
+			cy.viewport(1400, 800);
+			cy.wait(RESIZE_THROTTLE_RATE);
+			cy.viewport(320, 800);
+			cy.wait(RESIZE_THROTTLE_RATE);
+		}
+
+		// ShellBar must still be in the DOM and operating after the oscillation.
+		cy.get("#shellbar-stray").should("exist");
+
+		// And no "processed too many times" error must have fired.
+		cy.then(() => {
+			const matches = errors.filter(e => /processed too many times/i.test(e));
+			expect(matches, `unexpected RenderQueue errors:\n${matches.join("\n")}`).to.have.length(0);
+		});
+	});
+});

--- a/packages/fiori/cypress/specs/ShellBarBranding.cy.tsx
+++ b/packages/fiori/cypress/specs/ShellBarBranding.cy.tsx
@@ -109,4 +109,21 @@ describe("ShellBarBranding", () => {
 				.should("have.attr", "tabIndex", "0");
 		});
 	});
+
+	it("fires click event on Enter and Space", () => {
+			basicTemplate();
+
+			cy.get("[slot='branding']").then(branding => {
+				branding.get(0).addEventListener("ui5-click", cy.stub().as("brandingClick"));
+			});
+
+			cy.get("@shellbarBranding")
+				.find("a")
+				.focus()
+				.realPress("Enter")
+				.realPress("Space");
+
+			cy.get("@brandingClick")
+				.should("have.been.calledTwice");
+		});
 });

--- a/packages/fiori/cypress/specs/ShellBarSearch.mobile.cy.tsx
+++ b/packages/fiori/cypress/specs/ShellBarSearch.mobile.cy.tsx
@@ -124,4 +124,42 @@ describe("Mobile Behaviour", () => {
 
 		cy.get("@search").should("have.been.calledOnce");
 	});
+
+	it("should close popup when clicking magnifier icon on mobile", () => {
+		cy.mount(
+			<ShellBarSearch onSearch={cy.stub().as("search")}>
+				<SearchItem text="Item 1" />
+				<SearchItem text="Item 2" />
+			</ShellBarSearch>
+		);
+
+		// Open search dialog by clicking the search button
+		cy.get("[ui5-shellbar-search]")
+			.shadow()
+			.find("[ui5-button]")
+			.realClick();
+
+		// Verify dialog is open
+		cy.get("[ui5-shellbar-search]")
+			.should("have.prop", "open", true);
+
+		// Type in search field
+		cy.get("[ui5-shellbar-search]")
+			.shadow()
+			.find("[ui5-responsive-popover] header input")
+			.type("test");
+
+		// Click search/magnifier icon inside the mobile dialog
+		cy.get("[ui5-shellbar-search]")
+			.shadow()
+			.find("[ui5-responsive-popover] .ui5-shell-search-field-search-icon")
+			.realClick();
+
+		// Verify search event was fired
+		cy.get("@search").should("have.been.calledOnce");
+
+		// Verify popup is closed (this is the main fix)
+		cy.get("[ui5-shellbar-search]")
+			.should("have.prop", "open", false);
+	});
 });

--- a/packages/fiori/package.json
+++ b/packages/fiori/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents-fiori",
-  "version": "2.23.0",
+  "version": "2.23.1",
   "description": "UI5 Web Components: webcomponents.fiori",
   "ui5": {
     "webComponentsPackage": true
@@ -54,16 +54,16 @@
     "directory": "packages/fiori"
   },
   "dependencies": {
-    "@ui5/webcomponents": "2.23.0",
-    "@ui5/webcomponents-base": "2.23.0",
-    "@ui5/webcomponents-icons": "2.23.0",
-    "@ui5/webcomponents-theming": "2.23.0",
+    "@ui5/webcomponents": "2.23.1",
+    "@ui5/webcomponents-base": "2.23.1",
+    "@ui5/webcomponents-icons": "2.23.1",
+    "@ui5/webcomponents-theming": "2.23.1",
     "@zxing/library": "^0.21.3"
   },
   "devDependencies": {
     "@custom-elements-manifest/analyzer": "^0.10.10",
     "@ui5/cypress-internal": "0.1.0",
-    "@ui5/webcomponents-tools": "2.23.0",
+    "@ui5/webcomponents-tools": "2.23.1",
     "cypress": "15.9.0",
     "lit": "^2.0.0",
     "vite": "5.4.21",

--- a/packages/fiori/package.json
+++ b/packages/fiori/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents-fiori",
-  "version": "2.23.1",
+  "version": "2.23.2",
   "description": "UI5 Web Components: webcomponents.fiori",
   "ui5": {
     "webComponentsPackage": true
@@ -54,16 +54,16 @@
     "directory": "packages/fiori"
   },
   "dependencies": {
-    "@ui5/webcomponents": "2.23.1",
-    "@ui5/webcomponents-base": "2.23.1",
-    "@ui5/webcomponents-icons": "2.23.1",
-    "@ui5/webcomponents-theming": "2.23.1",
+    "@ui5/webcomponents": "2.23.2",
+    "@ui5/webcomponents-base": "2.23.2",
+    "@ui5/webcomponents-icons": "2.23.2",
+    "@ui5/webcomponents-theming": "2.23.2",
     "@zxing/library": "^0.21.3"
   },
   "devDependencies": {
     "@custom-elements-manifest/analyzer": "^0.10.10",
     "@ui5/cypress-internal": "0.1.0",
-    "@ui5/webcomponents-tools": "2.23.1",
+    "@ui5/webcomponents-tools": "2.23.2",
     "cypress": "15.9.0",
     "lit": "^2.0.0",
     "vite": "5.4.21",

--- a/packages/fiori/src/Search.ts
+++ b/packages/fiori/src/Search.ts
@@ -558,10 +558,6 @@ class Search extends SearchField {
 		const prevented = !this.fireDecoratorEvent("search", { item });
 
 		if (prevented) {
-			if (isPhone()) {
-				this.open = false;
-			}
-
 			return;
 		}
 

--- a/packages/fiori/src/Search.ts
+++ b/packages/fiori/src/Search.ts
@@ -425,9 +425,8 @@ class Search extends SearchField {
 		const innerInput = this.nativeInput!;
 
 		innerInput.setSelectionRange(this.value.length, this.value.length);
-		this.open = false;
-		this._isTyping = false;
-		this._valueBeforeArrowNav = undefined;
+
+		this._closePopupAndResetState();
 	}
 
 	_onMobileInputKeydown(e: KeyboardEvent) {
@@ -441,6 +440,12 @@ class Search extends SearchField {
 
 	_handleSearchEvent() {
 		this.fireDecoratorEvent("search", { item: this._proposedItem });
+	}
+
+	_closePopupAndResetState() {
+		this.open = false;
+		this._isTyping = false;
+		this._valueBeforeArrowNav = undefined;
 	}
 
 	_handleEscape() {

--- a/packages/fiori/src/SearchPopoverTemplate.tsx
+++ b/packages/fiori/src/SearchPopoverTemplate.tsx
@@ -39,7 +39,7 @@ export default function SearchPopoverTemplate(this: Search, headerTemplate?: Jsx
 			{isPhone() ? (headerTemplate ? headerTemplate.call(this) : (
 				<>
 					<header slot="header" class="ui5-search-popup-searching-header">
-						<Input class="ui5-search-popover-search-field" onInput={this._handleMobileInput} showClearIcon={this.showClearIcon} noTypeahead={this.noTypeahead} hint={InputKeyHint.Search} onKeyDown={this._onMobileInputKeydown}>
+						<Input value={this.value} class="ui5-search-popover-search-field" onInput={this._handleMobileInput} showClearIcon={this.showClearIcon} noTypeahead={this.noTypeahead} hint={InputKeyHint.Search} onKeyDown={this._onMobileInputKeydown}>
 							{this._flattenItems.map(item => {
 								return (<SuggestionItem text={item.text}></SuggestionItem>);
 							})}

--- a/packages/fiori/src/ShellBar.ts
+++ b/packages/fiori/src/ShellBar.ts
@@ -43,7 +43,7 @@ import ShellBarOverflow from "./shellbar/ShellBarOverflow.js";
 import ShellBarAccessibility from "./shellbar/ShellBarAccessibility.js";
 import ShellBarItemNavigation from "./shellbar/ShellBarItemNavigation.js";
 
-import ShellBarItem from "./ShellBarItem.js";
+import ShellBarItem, { isInstanceOfShellBarItem } from "./ShellBarItem.js";
 import ShellBarSpacer from "./ShellBarSpacer.js";
 import type ShellBarBranding from "./ShellBarBranding.js";
 import type { ShellBarOverflowResult } from "./shellbar/ShellBarOverflow.js";
@@ -764,7 +764,7 @@ class ShellBar extends UI5Element {
 		const result = this.overflow.updateOverflow({
 			actions: this.actions,
 			content: this.sortContent(this.content),
-			customItems: this.items,
+			customItems: this._validItems,
 			hiddenItemsIds: this.hiddenItemsIds,
 			showSearchField: this.enabledFeatures.search && this.showSearchField,
 			overflowOuter: this.overflowOuter!,
@@ -786,7 +786,7 @@ class ShellBar extends UI5Element {
 		const { hiddenItemsIds, showOverflowButton } = result;
 
 		// Update items overflow state
-		this.items.forEach(item => {
+		this._validItems.forEach(item => {
 			item.inOverflow = hiddenItemsIds.includes(item._id);
 			if (item.inOverflow) {
 				// clear the hidden class to ensure the item is visible in the overflow popover
@@ -862,9 +862,21 @@ class ShellBar extends UI5Element {
 	get overflowItems() {
 		return this.overflow.getOverflowItems({
 			actions: this.actions,
-			customItems: this.items,
+			customItems: this._validItems,
 			hiddenItemsIds: this.hiddenItemsIds,
 		});
+	}
+
+	/**
+	 * Only entries that are actually `ui5-shellbar-item` instances participate in the
+	 * overflow calculation and template rendering. The default slot's type is
+	 * `HTMLElement`, so any stray child (e.g. a bare `<span>`) ends up in `this.items`;
+	 * if such an element reaches the overflow algorithm it has no `_id` / `stableDomRef`,
+	 * which writes `undefined` back into reactive properties on every pass and re-enters
+	 * the render queue until `RenderQueue` throws "processed too many times".
+	 */
+	get _validItems(): ShellBarItem[] {
+		return this.items.filter(isInstanceOfShellBarItem);
 	}
 
 	/**

--- a/packages/fiori/src/ShellBar.ts
+++ b/packages/fiori/src/ShellBar.ts
@@ -1139,6 +1139,9 @@ class ShellBar extends UI5Element {
 	 * @since 1.0.0-rc.16
 	 */
 	get notificationsDomRef(): HTMLElement | null {
+		if (this.isHidden(ShellBarActions.Notifications)) {
+			return this.overflowDomRef;
+		}
 		return this.shadowRoot!.querySelector<HTMLElement>(`*[data-ui5-stable="notifications"]`);
 	}
 

--- a/packages/fiori/src/ShellBarBranding.ts
+++ b/packages/fiori/src/ShellBarBranding.ts
@@ -136,26 +136,34 @@ class ShellBarBranding extends UI5Element {
 		this.fireDecoratorEvent("click");
 	}
 
-	_onclick(e: MouseEvent) {
+	private _activate(e: Event) {
 		e.stopPropagation();
 		this._fireClick();
 	}
 
-	_onkeyup(e: KeyboardEvent) {
-		if (isSpace(e)) {
-			this._fireClick();
-		}
+	private _getAnchor() {
+		return this.shadowRoot?.querySelector("a") as HTMLAnchorElement | null;
+	}
+
+	_onclick(e: MouseEvent) {
+		this._activate(e);
 	}
 
 	_onkeydown(e: KeyboardEvent) {
-		if (isSpace(e)) {
+		if (isEnter(e) && !this.href) {
 			e.preventDefault();
+			this._getAnchor()?.click();
+		} else if (isSpace(e)) {
+			e.preventDefault();
+		}
+	}
+
+	_onkeyup(e: KeyboardEvent) {
+		if (!isSpace(e)) {
 			return;
 		}
 
-		if (isEnter(e)) {
-			this._fireClick();
-		}
+		this._getAnchor()?.click();
 	}
 }
 

--- a/packages/fiori/src/ShellBarItem.ts
+++ b/packages/fiori/src/ShellBarItem.ts
@@ -3,6 +3,7 @@ import property from "@ui5/webcomponents-base/dist/decorators/property.js";
 import event from "@ui5/webcomponents-base/dist/decorators/event-strict.js";
 import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
 import jsxRenderer from "@ui5/webcomponents-base/dist/renderer/JsxRenderer.js";
+import createInstanceChecker from "@ui5/webcomponents-base/dist/util/createInstanceChecker.js";
 import type { AccessibilityAttributes, UI5CustomEvent } from "@ui5/webcomponents-base";
 import Button from "@ui5/webcomponents/dist/Button.js";
 import ButtonBadge from "@ui5/webcomponents/dist/ButtonBadge.js";
@@ -109,6 +110,10 @@ class ShellBarItem extends UI5Element {
 		return this.getAttribute("stable-dom-ref") || `${this._id}-stable-dom-ref`;
 	}
 
+	get isShellBarItem(): boolean {
+		return true;
+	}
+
 	hasListItems() {
 		return this.inOverflow;
 	}
@@ -131,4 +136,5 @@ class ShellBarItem extends UI5Element {
 ShellBarItem.define();
 
 export default ShellBarItem;
+export const isInstanceOfShellBarItem = createInstanceChecker<ShellBarItem>("isShellBarItem");
 export type { ShellBarItemClickEventDetail, ShellBarItemAccessibilityAttributes };

--- a/packages/fiori/src/ShellBarItem.ts
+++ b/packages/fiori/src/ShellBarItem.ts
@@ -121,7 +121,7 @@ class ShellBarItem extends UI5Element {
 		return [domRef];
 	}
 
-	fireClickEvent(e: UI5CustomEvent<Button, "click">) {
+	fireClickEvent(e: UI5CustomEvent<Button, "click"> | UI5CustomEvent<ListItemStandard, "click">) {
 		return this.fireDecoratorEvent("click", {
 			targetRef: (e.target as HTMLElement),
 		});

--- a/packages/fiori/src/ShellBarItemTemplate.tsx
+++ b/packages/fiori/src/ShellBarItemTemplate.tsx
@@ -12,6 +12,7 @@ export default function ShellBarItemTemplate(this: ShellBarItem) {
 				data-count={this.count}
 				data-ui5-stable={this.stableDomRef}
 				accessibilityAttributes={this.accessibilityAttributes}
+				onClick={this.fireClickEvent}
 			>
 				{this.text}
 			</ListItemStandard>

--- a/packages/fiori/src/ShellBarSearch.ts
+++ b/packages/fiori/src/ShellBarSearch.ts
@@ -41,6 +41,7 @@ class ShellBarSearch extends Search {
 	_handleSearchIconPress() {
 		if (isPhone() && this.open) {
 			this._handleSearchEvent();
+			this._closePopupAndResetState();
 			return;
 		}
 

--- a/packages/fiori/src/ShellBarTemplate.tsx
+++ b/packages/fiori/src/ShellBarTemplate.tsx
@@ -153,7 +153,7 @@ export default function ShellBarTemplate(this: ShellBar) {
 						)}
 
 						{/* Custom Items */}
-						{this.items.map(item => (
+						{this._validItems.map(item => (
 							<div
 								key={item._id}
 								class={{

--- a/packages/fiori/test/pages/Search.html
+++ b/packages/fiori/test/pages/Search.html
@@ -221,6 +221,55 @@
 		<ui5-text style="padding-top: 0.25rem; font-style: italic;">The examples shows scoped search with scoped suggestions. Change scope to filter suggestions.</ui5-text>
 	</div>
 
+	<div class="container">
+		<ui5-label>Search with Grouped Suggestions and "Search in" group - Pick a scope from the suggestions</ui5-label>
+		<ui5-search id="search-in-scope" show-clear-icon scope-value="all" placeholder="Search ...">
+			<ui5-search-scope text="All" value="all" slot="scopes"></ui5-search-scope>
+			<ui5-search-scope text="Sales Orders" value="salesOrders" slot="scopes"></ui5-search-scope>
+			<ui5-search-scope text="Purchase Orders" value="purchaseOrders" slot="scopes"></ui5-search-scope>
+			<ui5-search-scope text="Customers" value="customers" slot="scopes"></ui5-search-scope>
+			<ui5-search-scope text="Products" value="products" slot="scopes"></ui5-search-scope>
+
+			<ui5-search-item-group header-text="Recent">
+				<ui5-search-item text="SO-1001 — Acme Corp" icon="sales-order"></ui5-search-item>
+				<ui5-search-item text="PO-4502 — Globex" icon="cart"></ui5-search-item>
+				<ui5-search-item text="Customer: Initech" icon="customer"></ui5-search-item>
+			</ui5-search-item-group>
+
+			<ui5-search-item-group id="search-in-group" header-text="Search in">
+				<ui5-search-item text="Sales Orders" icon="sales-order" data-scope="salesOrders"></ui5-search-item>
+				<ui5-search-item text="Purchase Orders" icon="cart" data-scope="purchaseOrders"></ui5-search-item>
+				<ui5-search-item text="Customers" icon="customer" data-scope="customers"></ui5-search-item>
+				<ui5-search-item text="Products" icon="product" data-scope="products"></ui5-search-item>
+			</ui5-search-item-group>
+		</ui5-search>
+		<ui5-text style="padding-top: 0.25rem; font-style: italic;">
+			Picking an item from the "Search in" group changes the active scope instead of completing the search.
+		</ui5-text>
+	</div>
+
+	<script>
+		(function () {
+			const searchInScope = document.getElementById('search-in-scope');
+
+			searchInScope.addEventListener('ui5-search', (event) => {
+				const item = event.detail.item;
+				const targetScope = item && item.dataset && item.dataset.scope;
+
+				if (!targetScope) {
+					return;
+				}
+
+				// Item belongs to the "Search in" group — switch scope rather than submitting a search.
+				// preventDefault keeps the popup open so the user can continue picking suggestions in the new scope.
+				event.preventDefault();
+				searchInScope.scopeValue = targetScope;
+				searchInScope.value = "";
+				searchInScope.focus();
+			});
+		}());
+	</script>
+
 
 	<div class="container">
 		<ui5-label>Search with Suggestions - Filters and noTypeAhead</ui5-label>

--- a/packages/fiori/test/pages/ShellBarSearch.html
+++ b/packages/fiori/test/pages/ShellBarSearch.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<meta charset="utf-8">
+	<title>Shell Bar</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+	<script src="%VITE_BUNDLE_PATH%" type="module"></script>
+</head>
+<ui5-shellbar slot="header" id="shellbar" notifications-count="10" show-notifications show-product-switch>
+	<ui5-shellbar-branding slot="branding">
+		VEGA CRM
+		<img slot="logo" src="https://ui5.github.io/webcomponents/nightly/images/sap-logo-svg.svg" />
+	</ui5-shellbar-branding>
+	<ui5-button id="menu-button" icon="menu2" slot="startButton" tooltip="Toggle side navigation"></ui5-button>
+	<ui5-tag design="Set2" color-scheme="7" slot="content" data-hide-order="2">Trial</ui5-tag>
+	<ui5-text slot="content" data-hide-order="1">30 days remaining</ui5-text>
+
+	<ui5-shellbar-spacer slot="content"></ui5-shellbar-spacer>
+
+	<ui5-toggle-button icon="sap-icon://da" slot="assistant"></ui5-toggle-button>
+
+	<ui5-shellbar-search slot="searchField" id="search-scope" scope-value="all" show-clear-icon
+		placeholder="Search Apps, Products">
+		<ui5-search-scope text="All" value="all" slot="scopes"></ui5-search-scope>
+		<ui5-search-scope text="Apps" value="apps" slot="scopes"></ui5-search-scope>
+		<ui5-search-scope text="Products" value="products" slot="scopes"></ui5-search-scope>
+	</ui5-shellbar-search>
+
+	<ui5-shellbar-item icon="sys-help" text="Help"></ui5-shellbar-item>
+	<ui5-avatar slot="profile">
+		<img src="https://ui5.github.io/webcomponents/nightly/images/avatars/man_avatar_3.png" />
+	</ui5-avatar>
+</ui5-shellbar>
+<body>
+</body>
+
+</html>

--- a/packages/fiori/test/pages/UXCIntegration.html
+++ b/packages/fiori/test/pages/UXCIntegration.html
@@ -1,0 +1,647 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+	<meta charset="UTF-8">
+	<title>UXC Integration</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+
+	<script data-ui5-config type="application/json">
+		{
+			"rtl": false
+		}
+	</script>
+
+	<style>
+		@media (width > 600px) {
+			.sideNavigation:not([collapsed]) {
+				width: 18rem;
+			}
+		}
+
+		.mainContent {
+			padding: var(--sapContent_Gap);
+		}
+
+		.quickCreateDialog::part(footer) {
+			padding-inline: 0;
+		}
+
+		/* Notifications */
+		.notificationsPopover {
+			width: 27rem;
+			max-height: 40rem;
+		}
+
+		.notificationsPopover::part(header) {
+			padding: 0;
+			box-shadow: none;
+		}
+
+		.notificationsPopover::part(content) {
+			padding: 0;
+		}
+
+		.notificationsPopoverHeader {
+			display: flex;
+			flex: 1;
+			flex-direction: column;
+		}
+
+		.notificationsPopoverList {
+			height: 100%;
+		}
+
+		.notificationsPopoverBar,
+		.notificationsPopoverBar::part(bar) {
+			box-shadow: none;
+		}
+		/* End notifications */
+
+		/* User Settings Dialog */
+		.ua-panel {
+			border-top: 2px solid lightgrey;
+			margin: 1rem 0;
+		}
+
+		.language-region-container {
+			display: flex;
+			min-height: 2.5rem;
+			align-item: flex-start;
+			flex-direction: column;
+			gap: 0.563rem;
+		}
+
+		.language-region-label {
+			display: flex;
+			flex: 1 0 0;
+			width: 100%;
+		}
+
+		.language-region-control {
+			display: flex;
+			gap: 0.188rem;
+			width: 100%;
+		}
+
+		.ui5-user-settings-appearance-view-additional-content-header {
+			display: flex;
+			justify-content: space-between;
+			align-items: center;
+			margin-bottom: 0.5rem;
+			width: 100%;
+		}
+
+		.ui5-user-settings-appearance-view-additional-content-description {
+			display: block;
+			color: var(--sapContent_LabelColor);
+			font-size: var(--sapFontSmallSize);
+		}
+	</style>
+
+	<script src="%VITE_BUNDLE_PATH%" type="module"></script>
+</head>
+
+<body style="background-color: var(--sapBackgroundColor); height: 50rem;">
+	<ui5-navigation-layout id="navigation-layout">
+		<ui5-shellbar slot="header" id="shellbar"
+			notifications-count="10" show-notifications show-product-switch>
+			<ui5-shellbar-branding slot="branding">
+				VEGA CRM
+				<img slot="logo" src="./img/sap-logo-svg.svg" />
+			</ui5-shellbar-branding>
+			<ui5-button id="menu-button" icon="menu2" slot="startButton" tooltip="Toggle side navigation"></ui5-button>
+			<ui5-tag design="Set2" color-scheme="7" slot="content" data-hide-order="2">Trial</ui5-tag>
+			<ui5-text slot="content" data-hide-order="1">30 days remaining</ui5-text>
+
+			<ui5-shellbar-spacer slot="content"></ui5-shellbar-spacer>
+
+			<ui5-toggle-button icon="sap-icon://da" slot="assistant"></ui5-toggle-button>
+
+			<ui5-shellbar-search slot="searchField" id="search-scope" scope-value="all" show-clear-icon placeholder="Search Apps, Products">
+				<ui5-search-scope text="All" value="all" slot="scopes"></ui5-search-scope>
+				<ui5-search-scope text="Apps" value="apps" slot="scopes"></ui5-search-scope>
+				<ui5-search-scope text="Products" value="products" slot="scopes"></ui5-search-scope>
+
+				<ui5-search-item-group id="search-in-group" header-text="Search in">
+					<ui5-search-item text="Apps" icon="business-objects-experience" data-scope="apps"></ui5-search-item>
+					<ui5-search-item text="Products" icon="product" data-scope="products"></ui5-search-item>
+				</ui5-search-item-group>
+			</ui5-shellbar-search>
+
+			<ui5-shellbar-item icon="sys-help" text="Help"></ui5-shellbar-item>
+			<ui5-avatar slot="profile">
+				<img src="./img/man_avatar_1.png" />
+			</ui5-avatar>
+		</ui5-shellbar>
+
+		<ui5-user-menu id="userMenu" show-manage-account show-other-accounts show-edit-accounts show-edit-button>
+			<ui5-user-menu-account slot="accounts"
+								   avatar-src="./img/man_avatar_1.png"
+								   title-text="Alain Chevalier 1"
+								   subtitle-text="alian.chevalier@sap.com"
+								   description="Delivery Manager, SAP SE"
+								   selected>
+			</ui5-user-menu-account>
+			<ui5-user-menu-account slot="accounts"
+								   avatar-initials="SD"
+								   title-text="John Walker"
+								   subtitle-text="john.walker@sap.com"
+								   description="Project Manager">
+			</ui5-user-menu-account>
+			<ui5-user-menu-account slot="accounts"
+								   avatar-initials="DS"
+								   title-text="David Wilson"
+								   subtitle-text="david.wilson@sap.com"
+								   description="Project Manager">
+			</ui5-user-menu-account>
+			<ui5-user-menu-item icon="action-settings" text="Setting" data-id="setting"></ui5-user-menu-item>
+			<ui5-user-menu-item icon="official-service" text="Legal Information">
+				<ui5-user-menu-item text="Terms of Use" data-id="terms-of-use"></ui5-user-menu-item>
+				<ui5-user-menu-item text="Private Policy" data-id="privacy-policy"></ui5-user-menu-item>
+			</ui5-user-menu-item>
+			<ui5-user-menu-item icon="message-information" text="About" data-id="about"></ui5-user-menu-item>
+			<ui5-user-menu-item icon="globe" text="Language" data-id="single-select" show-selection>
+				<ui5-user-menu-item-group check-mode="Single">
+					<ui5-user-menu-item text="English" data-id="single-select-item1" checked></ui5-user-menu-item>
+					<ui5-user-menu-item text="Deutsch" data-id="single-select-item2"></ui5-user-menu-item>
+				</ui5-user-menu-item-group>
+			</ui5-user-menu-item>
+		</ui5-user-menu>
+
+		<ui5-side-navigation id="side-navigation" class="sideNavigation" slot="sideContent" accessible-name="Main">
+			<ui5-side-navigation-item text="Home" icon="home" selected></ui5-side-navigation-item>
+			<ui5-side-navigation-item text="Favorites" expanded icon="favorite-list" unselectable>
+				<ui5-side-navigation-sub-item text="My Accounts"></ui5-side-navigation-sub-item>
+				<ui5-side-navigation-sub-item text="My Orders"></ui5-side-navigation-sub-item>
+			</ui5-side-navigation-item>
+			<ui5-side-navigation-item text="Customer Management" icon="account" expanded unselectable>
+				<ui5-side-navigation-sub-item text="Contacts"></ui5-side-navigation-sub-item>
+				<ui5-side-navigation-sub-item text="Companies"></ui5-side-navigation-sub-item>
+				<ui5-side-navigation-sub-item text="Partners"></ui5-side-navigation-sub-item>
+			</ui5-side-navigation-item>
+			<ui5-side-navigation-item text="Sales" icon="crm-sales" expanded unselectable>
+				<ui5-side-navigation-sub-item text="Leads"></ui5-side-navigation-sub-item>
+				<ui5-side-navigation-sub-item text="Opportunuties"></ui5-side-navigation-sub-item>
+				<ui5-side-navigation-sub-item text="Quotes"></ui5-side-navigation-sub-item>
+				<ui5-side-navigation-sub-item text="Orders"></ui5-side-navigation-sub-item>
+				<ui5-side-navigation-sub-item text="Invoices"></ui5-side-navigation-sub-item>
+			</ui5-side-navigation-item>
+			<ui5-side-navigation-item text="Products" icon="s4hana" expanded unselectable>
+				<ui5-side-navigation-sub-item text="Product Catalog"></ui5-side-navigation-sub-item>
+				<ui5-side-navigation-sub-item text="Pricing"></ui5-side-navigation-sub-item>
+				<ui5-side-navigation-sub-item text="Inventory Management"></ui5-side-navigation-sub-item>
+			</ui5-side-navigation-item>
+			<ui5-side-navigation-item text="Marketing" icon="business-by-design" expanded unselectable>
+				<ui5-side-navigation-sub-item text="Campaigns"></ui5-side-navigation-sub-item>
+				<ui5-side-navigation-sub-item text="E-Mail Marketing"></ui5-side-navigation-sub-item>
+				<ui5-side-navigation-sub-item text="Marketing Automation"></ui5-side-navigation-sub-item>
+			</ui5-side-navigation-item>
+			<ui5-side-navigation-item text="Reports" icon="manager-insight" expanded unselectable>
+				<ui5-side-navigation-sub-item text="Sales Reports"></ui5-side-navigation-sub-item>
+				<ui5-side-navigation-sub-item text="Customer Reports"></ui5-side-navigation-sub-item>
+			</ui5-side-navigation-item>
+			<ui5-side-navigation-item slot="fixedItems" id="quick-create" text="Quick Create" icon="add" design="Action" unselectable></ui5-side-navigation-item>
+			<ui5-side-navigation-item slot="fixedItems" text="Product Settings" icon="settings"></ui5-side-navigation-item>
+		</ui5-side-navigation>
+
+		<div class="mainContent">
+			<ui5-title id="content-title">Home</ui5-title>
+			<br />
+			<ui5-text>Content...</ui5-text>
+		</div>
+	</ui5-navigation-layout>
+
+	<ui5-dialog id="quick-create-dialog" class="quickCreateDialog" header-text="Create New Item" draggable resizable>
+		<ui5-text>Create new item...</ui5-text>
+		<ui5-bar slot="footer" design="Footer">
+			<ui5-button slot="endContent" design="Emphasized">Create</ui5-button>
+			<ui5-button slot="endContent" id="quick-create-dialog-close">Close</ui5-button>
+		</ui5-bar>
+	</ui5-dialog>
+
+	<ui5-responsive-popover
+		id="popover-with-notifications"
+		placement="Bottom"
+		class="notificationsPopover"
+		horizontal-align="End">
+		<div class="notificationsPopoverHeader" slot="header">
+			<ui5-bar class="notificationsPopoverBar" design="Header">
+				<ui5-title level="H5" slot="startContent">Notifications</ui5-title>
+				<ui5-button id="clear-all" design="Transparent" slot="endContent">Clear All</ui5-button>
+				<ui5-button id="btn-sort" design="Transparent" icon="sort" tooltip="Sort" slot="endContent"></ui5-button>
+				<ui5-button design="Transparent" icon="action-settings" tooltip="Go to settings" slot="endContent"></ui5-button>
+			</ui5-bar>
+		</div>
+
+		<ui5-notification-list class="notificationsPopoverList">
+			<ui5-li-notification-group id="notificationsListGroupGrowing"
+									   title-text="Today"
+									   loading-delay="0"
+									   growing="Button">
+				<ui5-li-notification title-text="Start Your Day with Your Sales Target!" show-close>
+					<ui5-avatar icon="crm-sales" color-scheme="Accent10" shape="Square" size="XS" slot="avatar"></ui5-avatar>
+					<span slot="footnotes">Sales</span>
+					<span slot="footnotes">11:13</span>
+					<ui5-menu slot="menu">
+						<ui5-menu-item text="Unsubscribe"></ui5-menu-item>
+					</ui5-menu>
+					Good morning! Don’t forget your daily sales target is $2,000.
+				</ui5-li-notification>
+				<ui5-li-notification title-text="Upcoming Client Meeting Reminder" importance="Important" show-close>
+					<ui5-avatar icon="crm-sales" color-scheme="Accent10" shape="Square" size="XS" slot="avatar"></ui5-avatar>
+					<span slot="footnotes">Sales</span>
+					<span slot="footnotes">11:05</span>
+					<ui5-menu slot="menu">
+						<ui5-menu-item text="Open in calendar"></ui5-menu-item>
+						<ui5-menu-item text="Unsubscribe"></ui5-menu-item>
+					</ui5-menu>
+					You have a client meeting scheduled at 3 PM today with Acme Corp.
+				</ui5-li-notification>
+				<ui5-li-notification title-text="Follow-Up Needed for Prospect" show-close>
+					<ui5-avatar icon="crm-sales" color-scheme="Accent10" shape="Square" size="XS" slot="avatar"></ui5-avatar>
+					<span slot="footnotes">Sales</span>
+					<span slot="footnotes">11:00</span>
+					<ui5-menu slot="menu">
+						<ui5-menu-item text="Follow-up meeting"></ui5-menu-item>
+						<ui5-menu-item text="Unsubscribe"></ui5-menu-item>
+					</ui5-menu>
+					Reminder to follow up with John Doe from XYZ Ltd.
+				</ui5-li-notification>
+			</ui5-li-notification-group>
+
+			<ui5-li-notification-group title-text="Yesterday" collapsed>
+				<ui5-li-notification title-text="New Sales Lead Assigned" show-close>
+					<ui5-avatar icon="crm-sales" color-scheme="Accent10" shape="Square" size="XS" slot="avatar"></ui5-avatar>
+					<span slot="footnotes">Sales</span>
+					<span slot="footnotes">1 Day</span>
+					<ui5-menu slot="menu">
+						<ui5-menu-item text="Unsubscribe"></ui5-menu-item>
+					</ui5-menu>
+					A new lead, Jane Smith from Innovative Tech, has been assigned to you.
+				</ui5-li-notification>
+			</ui5-li-notification-group>
+		</ui5-notification-list>
+	</ui5-responsive-popover>
+
+	<ui5-menu header-text="Sort By" id="sort-menu">
+		<ui5-menu-item text="Date"></ui5-menu-item>
+		<ui5-menu-item text="Importance"></ui5-menu-item>
+	</ui5-menu>
+
+	<ui5-dialog id="clear-all-dialog" header-text="Clear All Notifications">
+		<ui5-text>Are you sure you want to clear all the notifications?</ui5-text>
+		<ui5-bar slot="footer" design="Footer">
+			<ui5-button id="clear-all-action" class="dialogCloser" design="Emphasized" slot="endContent" style="min-width: 4rem;">OK</ui5-button>
+			<ui5-button class="dialogCloser" slot="endContent" style="min-width: 4rem;">Cancel</ui5-button>
+		</ui5-bar>
+	</ui5-dialog>
+
+	<ui5-user-settings-dialog id="settings" header-text="Settings" show-search-field>
+		<ui5-user-settings-item icon="user-settings" text="User Account" tooltip="User Account" header-text="User Account" selected>
+			<ui5-user-settings-account-view show-manage-account="true">
+				<ui5-user-menu-account slot="account"
+									   avatar-src="./img/man_avatar_1.png"
+									   title-text="Alain Chevalier"
+									   subtitle-text="alian.chevalier@sap.com"
+									   description="Delivery Manager, SAP SE"
+									   selected>
+				</ui5-user-menu-account>
+				<ui5-label for="reset-all-button">Personalization</ui5-label><br/>
+				<ui5-button id="reset-all-button">Reset All Personalization</ui5-button>
+				<ui5-panel fixed class="ua-panel">
+					<ui5-text>
+						Reset your personalization settings for the launchpad (such as theme, language, user activities, and home page content).
+					</ui5-text>
+				</ui5-panel>
+			</ui5-user-settings-account-view>
+		</ui5-user-settings-item>
+
+		<ui5-user-settings-item icon="palette" text="Appearance" tooltip="Appearance" header-text="Appearance">
+			<ui5-user-settings-appearance-view text="Themes">
+				<div slot="additionalContent">
+					<div class="ui5-user-settings-appearance-view-additional-content-header">
+						<ui5-text id="touch-input-label">Optimize for Touch Input</ui5-text>
+						<ui5-switch accessible-name-ref="touch-input-label"></ui5-switch>
+					</div>
+					<ui5-text class="ui5-user-settings-appearance-view-additional-content-description">
+						Increases the size and spacing of controls to allow you to interact with them more easily using your fingertip.
+					</ui5-text>
+				</div>
+				<ui5-user-settings-appearance-view-group header-text="Horizon">
+					<ui5-user-settings-appearance-view-item item-key="sap_horizon" text="Morning Horizon" selected></ui5-user-settings-appearance-view-item>
+					<ui5-user-settings-appearance-view-item item-key="sap_horizon_dark" text="Evening Horizon"></ui5-user-settings-appearance-view-item>
+					<ui5-user-settings-appearance-view-item item-key="sap_horizon_hcb" text="Horizon High Contrast Black"></ui5-user-settings-appearance-view-item>
+					<ui5-user-settings-appearance-view-item item-key="sap_horizon_hcw" text="Horizon High Contrast White"></ui5-user-settings-appearance-view-item>
+				</ui5-user-settings-appearance-view-group>
+				<ui5-user-settings-appearance-view-group header-text="Quartz">
+					<ui5-user-settings-appearance-view-item item-key="sap_fiori_3" text="Quartz Light"></ui5-user-settings-appearance-view-item>
+					<ui5-user-settings-appearance-view-item item-key="sap_fiori_3_dark" text="Quartz Dark"></ui5-user-settings-appearance-view-item>
+					<ui5-user-settings-appearance-view-item item-key="sap_fiori_3_hcb" text="Quartz High Contrast Black"></ui5-user-settings-appearance-view-item>
+					<ui5-user-settings-appearance-view-item item-key="sap_fiori_3_hcw" text="Quartz High Contrast White"></ui5-user-settings-appearance-view-item>
+				</ui5-user-settings-appearance-view-group>
+			</ui5-user-settings-appearance-view>
+		</ui5-user-settings-item>
+
+		<ui5-user-settings-item icon="bell" text="Notifications" tooltip="Notifications" header-text="Notifications">
+			<ui5-user-settings-view>
+				<ui5-checkbox checked text="Show High-Priority Notification Alerts"></ui5-checkbox>
+			</ui5-user-settings-view>
+		</ui5-user-settings-item>
+
+		<ui5-user-settings-item icon="reset" slot="fixedItems" text="Reset Settings" tooltip="Reset Settings" header-text="Reset Settings">
+			<ui5-user-settings-view text="Reset Personalization">
+				<ui5-button id="resetPersonalization">Reset Personalization content</ui5-button>
+				<ui5-toast id="toastReset">Changes Reset.</ui5-toast>
+			</ui5-user-settings-view>
+			<ui5-user-settings-view text="Reset All Settings">
+				<ui5-button id="resetAll">Reset All Settings content</ui5-button>
+				<ui5-toast id="toastResetAll">All changes Reset.</ui5-toast>
+			</ui5-user-settings-view>
+		</ui5-user-settings-item>
+	</ui5-user-settings-dialog>
+
+	<ui5-dialog id="additionalDialog" state="Information" header-text="Change Display Language">
+		<ui5-text>Changing the display language to [New Language] will update the language across the user interface.</ui5-text>
+		<ui5-toolbar slot="footer">
+			<ui5-toolbar-button class="dialogCloser" design="Emphasized" text="Change Language"></ui5-toolbar-button>
+			<ui5-toolbar-button class="dialogCloser" design="Transparent" text="Cancel"></ui5-toolbar-button>
+		</ui5-toolbar>
+	</ui5-dialog>
+
+	<script type="module">
+		import { setTheme } from "@ui5/webcomponents-base/dist/config/Theme.js";
+
+		const shellbar = document.getElementById("shellbar");
+
+		[...document.querySelectorAll("ui5-toggle-button")].forEach(el => {
+			el.addEventListener("click", event => {
+				const toggleButton = event.target;
+				toggleButton.icon = toggleButton.pressed ? "sap-icon://da-2" : "sap-icon://da";
+			});
+		});
+
+		/* Side navigation */
+		const menuButton = document.getElementById("menu-button");
+		const navigationLayout = document.getElementById("navigation-layout");
+		menuButton.addEventListener("click", () => {
+			navigationLayout.mode = navigationLayout.isSideCollapsed() ? "Expanded" : "Collapsed";
+		});
+
+		const sideNavigation = document.getElementById("side-navigation");
+		sideNavigation.addEventListener("selection-change", event => {
+			const contentTitle = document.getElementById("content-title");
+			contentTitle.textContent = event.detail.item?.text;
+		});
+		/* End side navigation */
+
+		/* Quick create dialog */
+		const quickCreate = document.getElementById("quick-create");
+		const quickCreateDialog = document.getElementById("quick-create-dialog");
+		quickCreate.accessibilityAttributes = {
+			hasPopup: "dialog"
+		};
+		quickCreate.addEventListener("click", () => {
+			quickCreateDialog.open = true;
+		});
+		document.getElementById("quick-create-dialog-close").addEventListener("click", () => {
+			quickCreateDialog.open = false;
+		});
+		/* End quick create dialog */
+
+		/* Notifications */
+		const notificationsPopover = document.querySelector(".notificationsPopover");
+		const notificationList = document.querySelector(".notificationsPopoverList");
+		const btnClearAll = document.querySelector("#clear-all");
+		const clearAllDialog = document.querySelector("#clear-all-dialog");
+		const dialogClosers = [...clearAllDialog.querySelectorAll(".dialogCloser")];
+		const btnClearAllAction = document.querySelector("#clear-all-action");
+		const notificationsListGroupGrowing = document.querySelector("#notificationsListGroupGrowing");
+		const btnOpenMenuSort = document.getElementById("btn-sort");
+		const menu = document.getElementById("sort-menu");
+
+		const itemsToLoad = 10;
+		let itemsLoaded = 6;
+
+		shellbar.addEventListener("notifications-click", e => {
+			e.preventDefault();
+			notificationsPopover.opener = e.detail.targetRef;
+			notificationsPopover.open = true;
+		});
+
+		notificationList.addEventListener("item-close", e => {
+			let visibleItems = 0;
+
+			e.detail.item.hidden = true;
+
+			Array.from(e.detail.item.parentElement.childNodes).forEach((element) => {
+				if (element.nodeName === "UI5-LI-NOTIFICATION" && !element.hidden) {
+					visibleItems++;
+				}
+			});
+
+			if (visibleItems === 0) {
+				e.detail.item.parentElement.hidden = true;
+			}
+		});
+
+		const insertItems = (list) => {
+			for (let i = itemsLoaded + 1; i <= itemsLoaded + itemsToLoad; i++) {
+				list.insertAdjacentHTML("beforeend",
+					`<ui5-li-notification title-text="Notification Title ${i}" show-close>
+						<ui5-avatar icon="expense-report" color-scheme="Accent1" shape="Square" size="XS" slot="avatar"></ui5-avatar>
+						<span slot="footnotes">Product Name</span>
+						<span slot="footnotes">Now</span>
+						<ui5-menu slot="menu">
+							<ui5-menu-item text="Unsubscribe"></ui5-menu-item>
+						</ui5-menu>
+						Description ${i}
+					</ui5-li-notification>`);
+			}
+
+			itemsLoaded += itemsToLoad;
+		};
+
+		notificationsListGroupGrowing.addEventListener("load-more", () => {
+			const focusIndex = notificationsListGroupGrowing.items.length;
+
+			notificationsListGroupGrowing.loading = true;
+			setTimeout(() => {
+				insertItems(notificationsListGroupGrowing);
+				notificationsListGroupGrowing.loading = false;
+
+				setTimeout(() => {
+					notificationsListGroupGrowing.items[focusIndex]?.focus();
+				}, 500);
+			}, 2000);
+		});
+
+		btnClearAll.accessibilityAttributes = {
+			hasPopup: "dialog",
+			controls: clearAllDialog.id,
+		};
+
+		btnClearAll.addEventListener("click", () => {
+			clearAllDialog.open = true;
+		});
+
+		dialogClosers.forEach(btn => {
+			btn.addEventListener("click", () => {
+				clearAllDialog.open = false;
+			});
+		});
+
+		btnClearAllAction.addEventListener("click", () => {
+			notificationList.innerHTML = `<ui5-illustrated-message name="NoNotifications"></ui5-illustrated-message>`;
+		});
+
+		btnOpenMenuSort.addEventListener("click", () => {
+			menu.opener = btnOpenMenuSort;
+			menu.open = true;
+		});
+		/* End Notifications */
+
+		/* User Menu */
+		const userMenu = document.getElementById("userMenu");
+
+		shellbar.addEventListener("ui5-profile-click", (event) => {
+			userMenu.opener = event.detail.targetRef;
+			userMenu.open = true;
+		});
+
+		userMenu.addEventListener("item-click", function (event) {
+			const item = event.detail.item.getAttribute("data-id");
+
+			switch (item) {
+				case "setting":
+					settingsDialog.open = true;
+					break;
+				default:
+					console.log("User menu item:", item);
+			}
+		});
+
+		userMenu.addEventListener("sign-out-click", function (event) {
+			const result = prompt("Sign Out", "Are you sure you want to sign out?");
+			if (result) {
+				userMenu.open = false;
+			}
+			event.preventDefault();
+		});
+		/* End User Menu */
+
+		/* User Settings Dialog */
+		const settingsDialog = document.getElementById("settings");
+		const settingsDialogItems = [...document.getElementsByTagName("ui5-user-settings-item")];
+		const appearanceView = document.querySelector("ui5-user-settings-appearance-view");
+		const additionalDialog = document.getElementById("additionalDialog");
+		const additionalDialogClosers = [...additionalDialog.querySelectorAll(".dialogCloser")];
+		const resetAllButton = document.getElementById("reset-all-button");
+		const resetAll = document.getElementById("resetAll");
+		const resetPersonalization = document.getElementById("resetPersonalization");
+		const toastReset = document.getElementById("toastReset");
+		const toastResetAll = document.getElementById("toastResetAll");
+
+		additionalDialogClosers.forEach(btn => {
+			btn.addEventListener("click", () => {
+				additionalDialog.open = false;
+			});
+		});
+
+		appearanceView.addEventListener("selection-change", (e) => {
+			const selectedItem = e.detail.item;
+
+			if (selectedItem?.itemKey) {
+				setTheme(selectedItem.itemKey);
+			}
+		});
+
+		resetAllButton.addEventListener("click", function () {
+			additionalDialog.open = true;
+		});
+
+		resetPersonalization.addEventListener("click", function () {
+			toastReset.open = true;
+		});
+
+		resetAll.addEventListener("click", function () {
+			toastResetAll.open = true;
+		});
+
+		settingsDialog.addEventListener("selection-change", function (event) {
+			if (event.detail.item?.text === "Language and Region") {
+				event.detail.item.loading = true;
+				event.detail.item.loadingReason = "Language & Region loading data...";
+				setTimeout(function () {
+					event.detail.item.loading = false;
+				}, 500);
+			}
+		});
+
+		settingsDialogItems.forEach((settingsDialogItem) => {
+			settingsDialogItem.addEventListener("selection-change", function (event) {
+				console.log(`Settings selection: ${event.detail.view?.text}`);
+			});
+		});
+		/* End User Settings Dialog */
+
+		/* Search */
+		const scopeData = [
+			{ name: "Laptop", scope: "products" },
+			{ name: "Leave Requests", scope: "apps" },
+			{ name: "Log work", scope: "apps" },
+			{ name: "Manage Products", scope: "apps" },
+			{ name: "Mobile Phones", scope: "products" },
+			{ name: "Tablet", scope: "products" },
+		];
+
+		const searchScope = document.getElementById("search-scope");
+		const searchInGroup = document.getElementById("search-in-group");
+
+		function createScopeItems(scope) {
+			const filterData = !scope ? scopeData : scopeData.filter(item => item.scope === scope);
+
+			filterData.forEach(item => {
+				const searchItem = document.createElement("ui5-search-item");
+				searchItem.text = item.name;
+				searchItem.scopeName = item.scope;
+				// Insert before the "Search in" group so it stays at the bottom of the popup.
+				searchScope.insertBefore(searchItem, searchInGroup);
+			});
+		}
+
+		createScopeItems();
+
+		searchScope.addEventListener("ui5-scope-change", (event) => {
+			const scope = event.detail.scope.value === "all" ? "" : event.detail.scope.value;
+
+			// Remove only the scope-driven suggestion items; keep the "Search in" group intact.
+			[...searchScope.children].forEach(child => {
+				if (child.tagName === "UI5-SEARCH-ITEM") {
+					child.remove();
+				}
+			});
+
+			createScopeItems(scope);
+		});
+
+		// Items in the "Search in" group act as scope switchers rather than search submissions.
+		searchScope.addEventListener("ui5-search", (event) => {
+			const item = event.detail.item;
+			const targetScope = item && item.dataset && item.dataset.scope;
+
+			if (!targetScope) {
+				return;
+			}
+
+			// preventDefault keeps the popup open so the user can continue picking suggestions in the new scope.
+			event.preventDefault();
+			searchScope.scopeValue = targetScope;
+			searchScope.value = "";
+			searchScope.focus();
+		});
+		/* End Search */
+	</script>
+</body>
+
+</html>

--- a/packages/icons-business-suite/CHANGELOG.md
+++ b/packages/icons-business-suite/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.23.2](https://github.com/UI5/webcomponents/compare/v2.23.1...v2.23.2) (2026-06-26)
+
+**Note:** Version bump only for package @ui5/webcomponents-icons-business-suite
+
+
+
+
+
 ## [2.23.1](https://github.com/UI5/webcomponents/compare/v2.23.0...v2.23.1) (2026-06-11)
 
 **Note:** Version bump only for package @ui5/webcomponents-icons-business-suite

--- a/packages/icons-business-suite/CHANGELOG.md
+++ b/packages/icons-business-suite/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.23.1](https://github.com/UI5/webcomponents/compare/v2.23.0...v2.23.1) (2026-06-11)
+
+**Note:** Version bump only for package @ui5/webcomponents-icons-business-suite
+
+
+
+
+
 # [2.23.0](https://github.com/UI5/webcomponents/compare/v2.23.0-rc.2...v2.23.0) (2026-06-05)
 
 **Note:** Version bump only for package @ui5/webcomponents-icons-business-suite

--- a/packages/icons-business-suite/package.json
+++ b/packages/icons-business-suite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents-icons-business-suite",
-  "version": "2.23.0",
+  "version": "2.23.1",
   "description": "UI5 Web Components: SAP Fiori Tools icon set",
   "author": "SAP SE (https://www.sap.com)",
   "license": "Apache-2.0",
@@ -27,9 +27,9 @@
     "directory": "packages/icons-business-suite"
   },
   "dependencies": {
-    "@ui5/webcomponents-base": "2.23.0"
+    "@ui5/webcomponents-base": "2.23.1"
   },
   "devDependencies": {
-    "@ui5/webcomponents-tools": "2.23.0"
+    "@ui5/webcomponents-tools": "2.23.1"
   }
 }

--- a/packages/icons-business-suite/package.json
+++ b/packages/icons-business-suite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents-icons-business-suite",
-  "version": "2.23.1",
+  "version": "2.23.2",
   "description": "UI5 Web Components: SAP Fiori Tools icon set",
   "author": "SAP SE (https://www.sap.com)",
   "license": "Apache-2.0",
@@ -27,9 +27,9 @@
     "directory": "packages/icons-business-suite"
   },
   "dependencies": {
-    "@ui5/webcomponents-base": "2.23.1"
+    "@ui5/webcomponents-base": "2.23.2"
   },
   "devDependencies": {
-    "@ui5/webcomponents-tools": "2.23.1"
+    "@ui5/webcomponents-tools": "2.23.2"
   }
 }

--- a/packages/icons-tnt/CHANGELOG.md
+++ b/packages/icons-tnt/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.23.1](https://github.com/UI5/webcomponents/compare/v2.23.0...v2.23.1) (2026-06-11)
+
+**Note:** Version bump only for package @ui5/webcomponents-icons-tnt
+
+
+
+
+
 # [2.23.0](https://github.com/UI5/webcomponents/compare/v2.23.0-rc.2...v2.23.0) (2026-06-05)
 
 **Note:** Version bump only for package @ui5/webcomponents-icons-tnt

--- a/packages/icons-tnt/CHANGELOG.md
+++ b/packages/icons-tnt/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.23.2](https://github.com/UI5/webcomponents/compare/v2.23.1...v2.23.2) (2026-06-26)
+
+**Note:** Version bump only for package @ui5/webcomponents-icons-tnt
+
+
+
+
+
 ## [2.23.1](https://github.com/UI5/webcomponents/compare/v2.23.0...v2.23.1) (2026-06-11)
 
 **Note:** Version bump only for package @ui5/webcomponents-icons-tnt

--- a/packages/icons-tnt/package.json
+++ b/packages/icons-tnt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents-icons-tnt",
-  "version": "2.23.1",
+  "version": "2.23.2",
   "description": "UI5 Web Components: SAP Fiori Tools icon set",
   "author": "SAP SE (https://www.sap.com)",
   "license": "Apache-2.0",
@@ -27,9 +27,9 @@
     "directory": "packages/icons-tnt"
   },
   "dependencies": {
-    "@ui5/webcomponents-base": "2.23.1"
+    "@ui5/webcomponents-base": "2.23.2"
   },
   "devDependencies": {
-    "@ui5/webcomponents-tools": "2.23.1"
+    "@ui5/webcomponents-tools": "2.23.2"
   }
 }

--- a/packages/icons-tnt/package.json
+++ b/packages/icons-tnt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents-icons-tnt",
-  "version": "2.23.0",
+  "version": "2.23.1",
   "description": "UI5 Web Components: SAP Fiori Tools icon set",
   "author": "SAP SE (https://www.sap.com)",
   "license": "Apache-2.0",
@@ -27,9 +27,9 @@
     "directory": "packages/icons-tnt"
   },
   "dependencies": {
-    "@ui5/webcomponents-base": "2.23.0"
+    "@ui5/webcomponents-base": "2.23.1"
   },
   "devDependencies": {
-    "@ui5/webcomponents-tools": "2.23.0"
+    "@ui5/webcomponents-tools": "2.23.1"
   }
 }

--- a/packages/icons/CHANGELOG.md
+++ b/packages/icons/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.23.1](https://github.com/UI5/webcomponents/compare/v2.23.0...v2.23.1) (2026-06-11)
+
+**Note:** Version bump only for package @ui5/webcomponents-icons
+
+
+
+
+
 # [2.23.0](https://github.com/UI5/webcomponents/compare/v2.23.0-rc.2...v2.23.0) (2026-06-05)
 
 **Note:** Version bump only for package @ui5/webcomponents-icons

--- a/packages/icons/CHANGELOG.md
+++ b/packages/icons/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.23.2](https://github.com/UI5/webcomponents/compare/v2.23.1...v2.23.2) (2026-06-26)
+
+**Note:** Version bump only for package @ui5/webcomponents-icons
+
+
+
+
+
 ## [2.23.1](https://github.com/UI5/webcomponents/compare/v2.23.0...v2.23.1) (2026-06-11)
 
 **Note:** Version bump only for package @ui5/webcomponents-icons

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents-icons",
-  "version": "2.23.1",
+  "version": "2.23.2",
   "description": "UI5 Web Components: webcomponents.SAP-icons",
   "author": "SAP SE (https://www.sap.com)",
   "license": "Apache-2.0",
@@ -27,9 +27,9 @@
     "directory": "packages/icons"
   },
   "dependencies": {
-    "@ui5/webcomponents-base": "2.23.1"
+    "@ui5/webcomponents-base": "2.23.2"
   },
   "devDependencies": {
-    "@ui5/webcomponents-tools": "2.23.1"
+    "@ui5/webcomponents-tools": "2.23.2"
   }
 }

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents-icons",
-  "version": "2.23.0",
+  "version": "2.23.1",
   "description": "UI5 Web Components: webcomponents.SAP-icons",
   "author": "SAP SE (https://www.sap.com)",
   "license": "Apache-2.0",
@@ -27,9 +27,9 @@
     "directory": "packages/icons"
   },
   "dependencies": {
-    "@ui5/webcomponents-base": "2.23.0"
+    "@ui5/webcomponents-base": "2.23.1"
   },
   "devDependencies": {
-    "@ui5/webcomponents-tools": "2.23.0"
+    "@ui5/webcomponents-tools": "2.23.1"
   }
 }

--- a/packages/localization/CHANGELOG.md
+++ b/packages/localization/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.23.1](https://github.com/UI5/webcomponents/compare/v2.23.0...v2.23.1) (2026-06-11)
+
+**Note:** Version bump only for package @ui5/webcomponents-localization
+
+
+
+
+
 # [2.23.0](https://github.com/UI5/webcomponents/compare/v2.23.0-rc.2...v2.23.0) (2026-06-05)
 
 **Note:** Version bump only for package @ui5/webcomponents-localization

--- a/packages/localization/CHANGELOG.md
+++ b/packages/localization/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.23.2](https://github.com/UI5/webcomponents/compare/v2.23.1...v2.23.2) (2026-06-26)
+
+**Note:** Version bump only for package @ui5/webcomponents-localization
+
+
+
+
+
 ## [2.23.1](https://github.com/UI5/webcomponents/compare/v2.23.0...v2.23.1) (2026-06-11)
 
 **Note:** Version bump only for package @ui5/webcomponents-localization

--- a/packages/localization/package.json
+++ b/packages/localization/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents-localization",
-  "version": "2.23.0",
+  "version": "2.23.1",
   "description": "Localization for UI5 Web Components",
   "author": "SAP SE (https://www.sap.com)",
   "license": "Apache-2.0",
@@ -33,13 +33,13 @@
     "@babel/generator": "^7.24.6",
     "@babel/parser": "^7.24.6",
     "@openui5/sap.ui.core": "1.146.0",
-    "@ui5/webcomponents-tools": "2.23.0",
+    "@ui5/webcomponents-tools": "2.23.1",
     "babel-plugin-amd-to-esm": "^2.0.3",
     "estree-walk": "^2.2.0",
     "resolve": "^1.20.0"
   },
   "dependencies": {
     "@types/openui5": "^1.146.0",
-    "@ui5/webcomponents-base": "2.23.0"
+    "@ui5/webcomponents-base": "2.23.1"
   }
 }

--- a/packages/localization/package.json
+++ b/packages/localization/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents-localization",
-  "version": "2.23.1",
+  "version": "2.23.2",
   "description": "Localization for UI5 Web Components",
   "author": "SAP SE (https://www.sap.com)",
   "license": "Apache-2.0",
@@ -33,13 +33,13 @@
     "@babel/generator": "^7.24.6",
     "@babel/parser": "^7.24.6",
     "@openui5/sap.ui.core": "1.146.0",
-    "@ui5/webcomponents-tools": "2.23.1",
+    "@ui5/webcomponents-tools": "2.23.2",
     "babel-plugin-amd-to-esm": "^2.0.3",
     "estree-walk": "^2.2.0",
     "resolve": "^1.20.0"
   },
   "dependencies": {
     "@types/openui5": "^1.146.0",
-    "@ui5/webcomponents-base": "2.23.1"
+    "@ui5/webcomponents-base": "2.23.2"
   }
 }

--- a/packages/main/CHANGELOG.md
+++ b/packages/main/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.23.2](https://github.com/UI5/webcomponents/compare/v2.23.1...v2.23.2) (2026-06-26)
+
+
+### Bug Fixes
+
+* ensure global styles are updated by the newest runtime ([#13745](https://github.com/UI5/webcomponents/issues/13745)) ([3cdaa23](https://github.com/UI5/webcomponents/commit/3cdaa233d2d4bab8553e44d3d455cf466dbbe3d1))
+
+
+
+
+
 ## [2.23.1](https://github.com/UI5/webcomponents/compare/v2.23.0...v2.23.1) (2026-06-11)
 
 

--- a/packages/main/CHANGELOG.md
+++ b/packages/main/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.23.1](https://github.com/UI5/webcomponents/compare/v2.23.0...v2.23.1) (2026-06-11)
+
+
+### Bug Fixes
+
+* **OpenUI5Support:** move popover to top of top layer ([#13671](https://github.com/UI5/webcomponents/issues/13671)) ([e90ebe5](https://github.com/UI5/webcomponents/commit/e90ebe58a21e01a241896f71e2d3ebc95aba8451))
+
+
+
+
+
 # [2.23.0](https://github.com/UI5/webcomponents/compare/v2.23.0-rc.2...v2.23.0) (2026-06-05)
 
 

--- a/packages/main/cypress/specs/OpenUI5andWebCPopups.webCPopoverOpenUI5Dialog.cy.tsx
+++ b/packages/main/cypress/specs/OpenUI5andWebCPopups.webCPopoverOpenUI5Dialog.cy.tsx
@@ -1,0 +1,149 @@
+// Popover is intentionally imported dynamically inside onOpenUI5InitMethod
+// to reproduce the problematic import order:
+//   1. OpenUI5 initializes and places an OpenUI5-wrapped web component in DOM
+//   2. After a delay, a separate script loads OpenUI5Support + native web components
+//   3. OpenUI5Support.init() patches Popup
+//   4. Popover and Button are registered
+// Without the fix, opening an OpenUI5 Dialog on top of a WebC Popover would
+// not move the dialog to the top of the top layer.
+
+function onOpenUI5InitMethod(win: any) {
+	// Step 1: place the OpenUI5-wrapped web component (triggers OpenUI5's own WC runtime)
+	(win as any).sap.ui.require(
+		["sap/f/gen/ui5/webcomponents/dist/Button"],
+		(WrappedButton: any) => {
+			new WrappedButton({
+				text: `Web Component via OpenUI5 ${(win as any).sap.ui.getVersionInfo().version}`,
+			}).placeAt("content");
+		}
+	);
+
+	// Step 2: after a delay, load the native web components (simulates a separate app script)
+	setTimeout(async () => {
+		const OpenUI5Support = (await import("@ui5/webcomponents-base/dist/features/OpenUI5Support.js")).default;
+
+		await (OpenUI5Support as any).init();
+
+		await import("../../src/Popover.js");
+		await import("../../src/Button.js");
+
+		const btnPopup = document.getElementById("btnPopup");
+		const popup = document.getElementById("popup") as any;
+
+		btnPopup?.addEventListener("click", () => {
+			popup.opener = btnPopup;
+			popup.open = true;
+		});
+
+		document.getElementById("nestedOpener")?.addEventListener("click", () => {
+			(win as any).sap.ui.require(["sap/m/Dialog", "sap/m/Text"], (Dialog: any, Text: any) => {
+				new Dialog("openUI5Dialog", {
+					content: new Text({ text: "Observe the backdrop" }),
+					afterClose: function () {
+						this.destroy();
+					}
+				}).open();
+				popup.open = false;
+			});
+		});
+
+		(win as any).openUI5InitDone = true;
+	}, 1000);
+}
+
+function mountFixtures() {
+	cy.mount(
+		<>
+			<div id="content"></div>
+			{/* @ts-ignore */}
+			<ui5-button id="btnPopup">Open Popover web component</ui5-button>
+			{/* @ts-ignore */}
+			<ui5-popover id="popup" header-text="Popover">
+				<div>2. Click the button</div>
+				{/* @ts-ignore */}
+				<ui5-button id="nestedOpener">Open Dialog OpenUI5</ui5-button>
+				{/* @ts-ignore */}
+			</ui5-popover>
+		</>
+	);
+
+	cy.window().then((win) => {
+		if (!(win as any).sap?.ui) {
+			(win as any).onOpenUI5Init = function () {
+				onOpenUI5InitMethod(win);
+			};
+		} else {
+			onOpenUI5InitMethod(win);
+		}
+	});
+
+	cy.document().then((doc) => {
+		const ui5Script = doc.createElement("script");
+		ui5Script.src = "https://ui5.sap.com/resources/sap-ui-core.js";
+		ui5Script.id = "sap-ui-bootstrap";
+		ui5Script.setAttribute("data-sap-ui-libs", "sap.m, sap.f");
+		ui5Script.setAttribute("data-sap-ui-oninit", "onOpenUI5Init");
+		doc.head.appendChild(ui5Script);
+	});
+}
+
+function cleanupFixtures() {
+	cy.window().then((win) => {
+		delete (win as any).openUI5InitDone;
+		const sap = (win as any).sap;
+		if (sap?.ui?.require) {
+			sap.ui.require(["sap/ui/core/Element"], (Element: any) => {
+				const el = Element.getElementById("openUI5Dialog");
+				if (el) {
+					el.destroy();
+				}
+			});
+		}
+	});
+
+	cy.document().then((doc) => {
+		const ui5Script = doc.head.querySelector("[data-sap-ui-oninit]") as HTMLScriptElement;
+		if (ui5Script) {
+			ui5Script.remove();
+		}
+	});
+}
+
+describe("WebC Popover + OpenUI5 Dialog integration", () => {
+	beforeEach(() => { mountFixtures(); });
+	afterEach(() => { cleanupFixtures(); });
+
+	it("Opening OpenUI5 Dialog from inside WebC Popover moves the dialog to the top of the top layer", () => {
+		// Wait for OpenUI5 to initialize, OpenUI5Support to patch Popup, and Popover to be registered
+		cy.window({ timeout: 15000 }).should((win) => {
+			expect((win as any).openUI5InitDone).to.be.true;
+		});
+
+		cy.get("#btnPopup")
+			.should("be.visible")
+			.realClick();
+
+		cy.get("#popup").should("be.visible");
+
+		cy.get("#nestedOpener")
+			.should("be.visible")
+			.realClick();
+
+		// The popover should close
+		cy.get("#popup")
+			.should("not.be.visible");
+
+		// The OpenUI5 Dialog should be visible
+		cy.get("#openUI5Dialog")
+			.should("be.visible");
+
+		// The dialog DOM element should be promoted to the native top layer
+		cy.get("#openUI5Dialog").then(($dialog) => {
+			expect($dialog[0].matches(":popover-open")).to.be.true;
+		});
+
+		cy.get("#sap-ui-blocklayer-popup").then(($blockLayer) => {
+			expect($blockLayer[0].matches(":popover-open")).to.exist;
+		});
+	});
+});

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents",
-  "version": "2.23.1",
+  "version": "2.23.2",
   "description": "UI5 Web Components: webcomponents.main",
   "ui5": {
     "webComponentsPackage": true
@@ -54,17 +54,17 @@
     "directory": "packages/main"
   },
   "dependencies": {
-    "@ui5/webcomponents-base": "2.23.1",
-    "@ui5/webcomponents-icons": "2.23.1",
-    "@ui5/webcomponents-icons-business-suite": "2.23.1",
-    "@ui5/webcomponents-icons-tnt": "2.23.1",
-    "@ui5/webcomponents-localization": "2.23.1",
-    "@ui5/webcomponents-theming": "2.23.1"
+    "@ui5/webcomponents-base": "2.23.2",
+    "@ui5/webcomponents-icons": "2.23.2",
+    "@ui5/webcomponents-icons-business-suite": "2.23.2",
+    "@ui5/webcomponents-icons-tnt": "2.23.2",
+    "@ui5/webcomponents-localization": "2.23.2",
+    "@ui5/webcomponents-theming": "2.23.2"
   },
   "devDependencies": {
     "@custom-elements-manifest/analyzer": "^0.10.10",
     "@ui5/cypress-internal": "0.1.0",
-    "@ui5/webcomponents-tools": "2.23.1",
+    "@ui5/webcomponents-tools": "2.23.2",
     "cypress": "15.9.0",
     "jsdom": "^26.0.0",
     "lit": "^2.0.0",

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents",
-  "version": "2.23.0",
+  "version": "2.23.1",
   "description": "UI5 Web Components: webcomponents.main",
   "ui5": {
     "webComponentsPackage": true
@@ -54,17 +54,17 @@
     "directory": "packages/main"
   },
   "dependencies": {
-    "@ui5/webcomponents-base": "2.23.0",
-    "@ui5/webcomponents-icons": "2.23.0",
-    "@ui5/webcomponents-icons-business-suite": "2.23.0",
-    "@ui5/webcomponents-icons-tnt": "2.23.0",
-    "@ui5/webcomponents-localization": "2.23.0",
-    "@ui5/webcomponents-theming": "2.23.0"
+    "@ui5/webcomponents-base": "2.23.1",
+    "@ui5/webcomponents-icons": "2.23.1",
+    "@ui5/webcomponents-icons-business-suite": "2.23.1",
+    "@ui5/webcomponents-icons-tnt": "2.23.1",
+    "@ui5/webcomponents-localization": "2.23.1",
+    "@ui5/webcomponents-theming": "2.23.1"
   },
   "devDependencies": {
     "@custom-elements-manifest/analyzer": "^0.10.10",
     "@ui5/cypress-internal": "0.1.0",
-    "@ui5/webcomponents-tools": "2.23.0",
+    "@ui5/webcomponents-tools": "2.23.1",
     "cypress": "15.9.0",
     "jsdom": "^26.0.0",
     "lit": "^2.0.0",

--- a/packages/main/src/Popup.ts
+++ b/packages/main/src/Popup.ts
@@ -20,7 +20,7 @@ import {
 	getAllAccessibleDescriptionRefTexts,
 	deregisterUI5Element,
 } from "@ui5/webcomponents-base/dist/util/AccessibilityTextsHelper.js";
-import { hasStyle, createStyle } from "@ui5/webcomponents-base/dist/ManagedStyles.js";
+import { createOrUpdateStyle } from "@ui5/webcomponents-base/dist/ManagedStyles.js";
 import { isEnter, isTabPrevious } from "@ui5/webcomponents-base/dist/Keys.js";
 import { getFocusedElement, isFocusedElementWithinNode } from "@ui5/webcomponents-base/dist/util/PopupUtils.js";
 import ResizeHandler from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
@@ -37,9 +37,7 @@ import popupBlockLayerStyles from "./generated/themes/PopupBlockLayer.css.js";
 import globalStyles from "./generated/themes/PopupGlobal.css.js";
 
 const createBlockingStyle = (): void => {
-	if (!hasStyle("data-ui5-popup-scroll-blocker")) {
-		createStyle(globalStyles, "data-ui5-popup-scroll-blocker");
-	}
+	createOrUpdateStyle(globalStyles, "data-ui5-popup-scroll-blocker");
 };
 
 createBlockingStyle();

--- a/packages/main/test/pages/PopoverAndOpenUI5Dialog.html
+++ b/packages/main/test/pages/PopoverAndOpenUI5Dialog.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+	<meta charset="UTF-8" />
+	<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+	<title>Vite + JS</title>
+
+	<script id="sap-ui-bootstrap" src="https://ui5.sap.com/resources/sap-ui-core.js"
+		data-sap-ui-libs="sap.m, sap.ui.core, sap.f" data-sap-ui-preload="async"></script>
+
+	<script>
+		sap.ui.getCore().attachInit(function () {
+			sap.ui.require(
+				['sap/f/gen/ui5/webcomponents/dist/Button'],
+				(Button) => {
+					new Button({
+						text: `Web Component via OpenUI5 ${sap.ui.getVersionInfo().version
+							}`,
+					}).placeAt('content');
+				}
+			);
+
+			setTimeout(async () => {
+				const OpenUI5Support = (await import("../../../base/src/features/OpenUI5Support.ts")).default;
+				await OpenUI5Support.init();
+
+				await import("../../src/Popover.ts");
+				await import("../../src/Button.ts");
+			}, 1000);
+		});
+	</script>
+</head>
+
+<body class="openui51auto">
+	<div id="content"></div>
+	<br />
+	<div>1. Click the button</div>
+	<br />
+	<ui5-button id="btnPopup">Open Popover web component</ui5-button>
+	<ui5-popover id="popup" header-text="Popover">
+		<div>2. Click the button</div>
+		<ui5-button id="nestedOpener">Open Dialog OpenUI5</ui5-button>
+	</ui5-popover>
+
+	<script>
+		btnPopup.addEventListener('click', () => {
+			popup.opener = btnPopup;
+			popup.open = true;
+		});
+		nestedOpener.addEventListener('click', () => {
+			const dialog = new sap.m.Dialog({
+				content: new sap.m.Text({ text: 'Observe the backdrop' }),
+			});
+			dialog.open();
+			popup.open = false;
+		});
+	</script>
+</body>
+
+</html>

--- a/packages/theming/CHANGELOG.md
+++ b/packages/theming/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.23.2](https://github.com/UI5/webcomponents/compare/v2.23.1...v2.23.2) (2026-06-26)
+
+**Note:** Version bump only for package @ui5/webcomponents-theming
+
+
+
+
+
 ## [2.23.1](https://github.com/UI5/webcomponents/compare/v2.23.0...v2.23.1) (2026-06-11)
 
 **Note:** Version bump only for package @ui5/webcomponents-theming

--- a/packages/theming/CHANGELOG.md
+++ b/packages/theming/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.23.1](https://github.com/UI5/webcomponents/compare/v2.23.0...v2.23.1) (2026-06-11)
+
+**Note:** Version bump only for package @ui5/webcomponents-theming
+
+
+
+
+
 # [2.23.0](https://github.com/UI5/webcomponents/compare/v2.23.0-rc.2...v2.23.0) (2026-06-05)
 
 **Note:** Version bump only for package @ui5/webcomponents-theming

--- a/packages/theming/package.json
+++ b/packages/theming/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents-theming",
-  "version": "2.23.1",
+  "version": "2.23.2",
   "description": "UI5 Web Components: webcomponents.theming",
   "author": "SAP SE (https://www.sap.com)",
   "license": "Apache-2.0",
@@ -30,10 +30,10 @@
   },
   "dependencies": {
     "@sap-theming/theming-base-content": "11.36.3",
-    "@ui5/webcomponents-base": "2.23.1"
+    "@ui5/webcomponents-base": "2.23.2"
   },
   "devDependencies": {
-    "@ui5/webcomponents-tools": "2.23.1",
+    "@ui5/webcomponents-tools": "2.23.2",
     "globby": "^13.1.1",
     "json-beautify": "^1.1.1",
     "postcss": "^8.4.5",

--- a/packages/theming/package.json
+++ b/packages/theming/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents-theming",
-  "version": "2.23.0",
+  "version": "2.23.1",
   "description": "UI5 Web Components: webcomponents.theming",
   "author": "SAP SE (https://www.sap.com)",
   "license": "Apache-2.0",
@@ -30,10 +30,10 @@
   },
   "dependencies": {
     "@sap-theming/theming-base-content": "11.36.3",
-    "@ui5/webcomponents-base": "2.23.0"
+    "@ui5/webcomponents-base": "2.23.1"
   },
   "devDependencies": {
-    "@ui5/webcomponents-tools": "2.23.0",
+    "@ui5/webcomponents-tools": "2.23.1",
     "globby": "^13.1.1",
     "json-beautify": "^1.1.1",
     "postcss": "^8.4.5",

--- a/packages/tools/CHANGELOG.md
+++ b/packages/tools/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.23.1](https://github.com/UI5/webcomponents/compare/v2.23.0...v2.23.1) (2026-06-11)
+
+**Note:** Version bump only for package @ui5/webcomponents-tools
+
+
+
+
+
 # [2.23.0](https://github.com/UI5/webcomponents/compare/v2.23.0-rc.2...v2.23.0) (2026-06-05)
 
 **Note:** Version bump only for package @ui5/webcomponents-tools

--- a/packages/tools/CHANGELOG.md
+++ b/packages/tools/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.23.2](https://github.com/UI5/webcomponents/compare/v2.23.1...v2.23.2) (2026-06-26)
+
+**Note:** Version bump only for package @ui5/webcomponents-tools
+
+
+
+
+
 ## [2.23.1](https://github.com/UI5/webcomponents/compare/v2.23.0...v2.23.1) (2026-06-11)
 
 **Note:** Version bump only for package @ui5/webcomponents-tools

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents-tools",
-  "version": "2.23.1",
+  "version": "2.23.2",
   "description": "UI5 Web Components: webcomponents.tools",
   "author": "SAP SE (https://www.sap.com)",
   "license": "Apache-2.0",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents-tools",
-  "version": "2.23.0",
+  "version": "2.23.1",
   "description": "UI5 Web Components: webcomponents.tools",
   "author": "SAP SE (https://www.sap.com)",
   "license": "Apache-2.0",

--- a/packages/website/CHANGELOG.md
+++ b/packages/website/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.23.1](https://github.com/UI5/webcomponents/compare/v2.23.0...v2.23.1) (2026-06-11)
+
+**Note:** Version bump only for package @ui5/webcomponents-website
+
+
+
+
+
 # [2.23.0](https://github.com/UI5/webcomponents/compare/v2.23.0-rc.2...v2.23.0) (2026-06-05)
 
 

--- a/packages/website/CHANGELOG.md
+++ b/packages/website/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.23.2](https://github.com/UI5/webcomponents/compare/v2.23.1...v2.23.2) (2026-06-26)
+
+**Note:** Version bump only for package @ui5/webcomponents-website
+
+
+
+
+
 ## [2.23.1](https://github.com/UI5/webcomponents/compare/v2.23.0...v2.23.1) (2026-06-11)
 
 **Note:** Version bump only for package @ui5/webcomponents-website

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents-website",
-  "version": "2.23.0",
+  "version": "2.23.1",
   "private": true,
   "scripts": {
     "generate-local-cdn": "rimraf ./local-cdn && node ./build-scripts/local-cdn.mjs",

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/webcomponents-website",
-  "version": "2.23.1",
+  "version": "2.23.2",
   "private": true,
   "scripts": {
     "generate-local-cdn": "rimraf ./local-cdn && node ./build-scripts/local-cdn.mjs",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7665,17 +7665,17 @@ __metadata:
   dependencies:
     "@custom-elements-manifest/analyzer": "npm:^0.10.10"
     "@ui5/cypress-internal": "npm:0.1.0"
-    "@ui5/webcomponents": "npm:2.23.0"
-    "@ui5/webcomponents-base": "npm:2.23.0"
-    "@ui5/webcomponents-icons": "npm:2.23.0"
-    "@ui5/webcomponents-theming": "npm:2.23.0"
-    "@ui5/webcomponents-tools": "npm:2.23.0"
+    "@ui5/webcomponents": "npm:2.23.1"
+    "@ui5/webcomponents-base": "npm:2.23.1"
+    "@ui5/webcomponents-icons": "npm:2.23.1"
+    "@ui5/webcomponents-theming": "npm:2.23.1"
+    "@ui5/webcomponents-tools": "npm:2.23.1"
     cypress: "npm:15.9.0"
     vite: "npm:5.4.21"
   languageName: unknown
   linkType: soft
 
-"@ui5/webcomponents-base@npm:2.23.0, @ui5/webcomponents-base@workspace:packages/base":
+"@ui5/webcomponents-base@npm:2.23.1, @ui5/webcomponents-base@workspace:packages/base":
   version: 0.0.0-use.local
   resolution: "@ui5/webcomponents-base@workspace:packages/base"
   dependencies:
@@ -7684,7 +7684,7 @@ __metadata:
     "@openui5/sap.ui.core": "npm:1.146.0"
     "@sap-theming/theming-base-content": "npm:11.36.3"
     "@ui5/cypress-internal": "npm:0.1.0"
-    "@ui5/webcomponents-tools": "npm:2.23.0"
+    "@ui5/webcomponents-tools": "npm:2.23.1"
     clean-css: "npm:^5.2.2"
     cypress: "npm:15.9.0"
     lit-html: "npm:^2.0.1"
@@ -7708,11 +7708,11 @@ __metadata:
   dependencies:
     "@custom-elements-manifest/analyzer": "npm:^0.10.10"
     "@ui5/cypress-internal": "npm:0.1.0"
-    "@ui5/webcomponents": "npm:2.23.0"
-    "@ui5/webcomponents-base": "npm:2.23.0"
-    "@ui5/webcomponents-icons": "npm:2.23.0"
-    "@ui5/webcomponents-theming": "npm:2.23.0"
-    "@ui5/webcomponents-tools": "npm:2.23.0"
+    "@ui5/webcomponents": "npm:2.23.1"
+    "@ui5/webcomponents-base": "npm:2.23.1"
+    "@ui5/webcomponents-icons": "npm:2.23.1"
+    "@ui5/webcomponents-theming": "npm:2.23.1"
+    "@ui5/webcomponents-tools": "npm:2.23.1"
     cypress: "npm:15.9.0"
     vite: "npm:5.4.21"
   languageName: unknown
@@ -7724,11 +7724,11 @@ __metadata:
   dependencies:
     "@custom-elements-manifest/analyzer": "npm:^0.10.10"
     "@ui5/cypress-internal": "npm:0.1.0"
-    "@ui5/webcomponents": "npm:2.23.0"
-    "@ui5/webcomponents-base": "npm:2.23.0"
-    "@ui5/webcomponents-icons": "npm:2.23.0"
-    "@ui5/webcomponents-theming": "npm:2.23.0"
-    "@ui5/webcomponents-tools": "npm:2.23.0"
+    "@ui5/webcomponents": "npm:2.23.1"
+    "@ui5/webcomponents-base": "npm:2.23.1"
+    "@ui5/webcomponents-icons": "npm:2.23.1"
+    "@ui5/webcomponents-theming": "npm:2.23.1"
+    "@ui5/webcomponents-tools": "npm:2.23.1"
     "@zxing/library": "npm:^0.21.3"
     cypress: "npm:15.9.0"
     lit: "npm:^2.0.0"
@@ -7737,34 +7737,34 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@ui5/webcomponents-icons-business-suite@npm:2.23.0, @ui5/webcomponents-icons-business-suite@workspace:packages/icons-business-suite":
+"@ui5/webcomponents-icons-business-suite@npm:2.23.1, @ui5/webcomponents-icons-business-suite@workspace:packages/icons-business-suite":
   version: 0.0.0-use.local
   resolution: "@ui5/webcomponents-icons-business-suite@workspace:packages/icons-business-suite"
   dependencies:
-    "@ui5/webcomponents-base": "npm:2.23.0"
-    "@ui5/webcomponents-tools": "npm:2.23.0"
+    "@ui5/webcomponents-base": "npm:2.23.1"
+    "@ui5/webcomponents-tools": "npm:2.23.1"
   languageName: unknown
   linkType: soft
 
-"@ui5/webcomponents-icons-tnt@npm:2.23.0, @ui5/webcomponents-icons-tnt@workspace:packages/icons-tnt":
+"@ui5/webcomponents-icons-tnt@npm:2.23.1, @ui5/webcomponents-icons-tnt@workspace:packages/icons-tnt":
   version: 0.0.0-use.local
   resolution: "@ui5/webcomponents-icons-tnt@workspace:packages/icons-tnt"
   dependencies:
-    "@ui5/webcomponents-base": "npm:2.23.0"
-    "@ui5/webcomponents-tools": "npm:2.23.0"
+    "@ui5/webcomponents-base": "npm:2.23.1"
+    "@ui5/webcomponents-tools": "npm:2.23.1"
   languageName: unknown
   linkType: soft
 
-"@ui5/webcomponents-icons@npm:2.23.0, @ui5/webcomponents-icons@workspace:packages/icons":
+"@ui5/webcomponents-icons@npm:2.23.1, @ui5/webcomponents-icons@workspace:packages/icons":
   version: 0.0.0-use.local
   resolution: "@ui5/webcomponents-icons@workspace:packages/icons"
   dependencies:
-    "@ui5/webcomponents-base": "npm:2.23.0"
-    "@ui5/webcomponents-tools": "npm:2.23.0"
+    "@ui5/webcomponents-base": "npm:2.23.1"
+    "@ui5/webcomponents-tools": "npm:2.23.1"
   languageName: unknown
   linkType: soft
 
-"@ui5/webcomponents-localization@npm:2.23.0, @ui5/webcomponents-localization@workspace:packages/localization":
+"@ui5/webcomponents-localization@npm:2.23.1, @ui5/webcomponents-localization@workspace:packages/localization":
   version: 0.0.0-use.local
   resolution: "@ui5/webcomponents-localization@workspace:packages/localization"
   dependencies:
@@ -7773,21 +7773,21 @@ __metadata:
     "@babel/parser": "npm:^7.24.6"
     "@openui5/sap.ui.core": "npm:1.146.0"
     "@types/openui5": "npm:^1.146.0"
-    "@ui5/webcomponents-base": "npm:2.23.0"
-    "@ui5/webcomponents-tools": "npm:2.23.0"
+    "@ui5/webcomponents-base": "npm:2.23.1"
+    "@ui5/webcomponents-tools": "npm:2.23.1"
     babel-plugin-amd-to-esm: "npm:^2.0.3"
     estree-walk: "npm:^2.2.0"
     resolve: "npm:^1.20.0"
   languageName: unknown
   linkType: soft
 
-"@ui5/webcomponents-theming@npm:2.23.0, @ui5/webcomponents-theming@workspace:packages/theming":
+"@ui5/webcomponents-theming@npm:2.23.1, @ui5/webcomponents-theming@workspace:packages/theming":
   version: 0.0.0-use.local
   resolution: "@ui5/webcomponents-theming@workspace:packages/theming"
   dependencies:
     "@sap-theming/theming-base-content": "npm:11.36.3"
-    "@ui5/webcomponents-base": "npm:2.23.0"
-    "@ui5/webcomponents-tools": "npm:2.23.0"
+    "@ui5/webcomponents-base": "npm:2.23.1"
+    "@ui5/webcomponents-tools": "npm:2.23.1"
     globby: "npm:^13.1.1"
     json-beautify: "npm:^1.1.1"
     postcss: "npm:^8.4.5"
@@ -7795,7 +7795,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@ui5/webcomponents-tools@npm:2.23.0, @ui5/webcomponents-tools@workspace:packages/tools":
+"@ui5/webcomponents-tools@npm:2.23.1, @ui5/webcomponents-tools@workspace:packages/tools":
   version: 0.0.0-use.local
   resolution: "@ui5/webcomponents-tools@workspace:packages/tools"
   dependencies:
@@ -7889,19 +7889,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@ui5/webcomponents@npm:2.23.0, @ui5/webcomponents@workspace:packages/main":
+"@ui5/webcomponents@npm:2.23.1, @ui5/webcomponents@workspace:packages/main":
   version: 0.0.0-use.local
   resolution: "@ui5/webcomponents@workspace:packages/main"
   dependencies:
     "@custom-elements-manifest/analyzer": "npm:^0.10.10"
     "@ui5/cypress-internal": "npm:0.1.0"
-    "@ui5/webcomponents-base": "npm:2.23.0"
-    "@ui5/webcomponents-icons": "npm:2.23.0"
-    "@ui5/webcomponents-icons-business-suite": "npm:2.23.0"
-    "@ui5/webcomponents-icons-tnt": "npm:2.23.0"
-    "@ui5/webcomponents-localization": "npm:2.23.0"
-    "@ui5/webcomponents-theming": "npm:2.23.0"
-    "@ui5/webcomponents-tools": "npm:2.23.0"
+    "@ui5/webcomponents-base": "npm:2.23.1"
+    "@ui5/webcomponents-icons": "npm:2.23.1"
+    "@ui5/webcomponents-icons-business-suite": "npm:2.23.1"
+    "@ui5/webcomponents-icons-tnt": "npm:2.23.1"
+    "@ui5/webcomponents-localization": "npm:2.23.1"
+    "@ui5/webcomponents-theming": "npm:2.23.1"
+    "@ui5/webcomponents-tools": "npm:2.23.1"
     cypress: "npm:15.9.0"
     jsdom: "npm:^26.0.0"
     lit: "npm:^2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7665,17 +7665,17 @@ __metadata:
   dependencies:
     "@custom-elements-manifest/analyzer": "npm:^0.10.10"
     "@ui5/cypress-internal": "npm:0.1.0"
-    "@ui5/webcomponents": "npm:2.23.1"
-    "@ui5/webcomponents-base": "npm:2.23.1"
-    "@ui5/webcomponents-icons": "npm:2.23.1"
-    "@ui5/webcomponents-theming": "npm:2.23.1"
-    "@ui5/webcomponents-tools": "npm:2.23.1"
+    "@ui5/webcomponents": "npm:2.23.2"
+    "@ui5/webcomponents-base": "npm:2.23.2"
+    "@ui5/webcomponents-icons": "npm:2.23.2"
+    "@ui5/webcomponents-theming": "npm:2.23.2"
+    "@ui5/webcomponents-tools": "npm:2.23.2"
     cypress: "npm:15.9.0"
     vite: "npm:5.4.21"
   languageName: unknown
   linkType: soft
 
-"@ui5/webcomponents-base@npm:2.23.1, @ui5/webcomponents-base@workspace:packages/base":
+"@ui5/webcomponents-base@npm:2.23.2, @ui5/webcomponents-base@workspace:packages/base":
   version: 0.0.0-use.local
   resolution: "@ui5/webcomponents-base@workspace:packages/base"
   dependencies:
@@ -7684,7 +7684,7 @@ __metadata:
     "@openui5/sap.ui.core": "npm:1.146.0"
     "@sap-theming/theming-base-content": "npm:11.36.3"
     "@ui5/cypress-internal": "npm:0.1.0"
-    "@ui5/webcomponents-tools": "npm:2.23.1"
+    "@ui5/webcomponents-tools": "npm:2.23.2"
     clean-css: "npm:^5.2.2"
     cypress: "npm:15.9.0"
     lit-html: "npm:^2.0.1"
@@ -7708,11 +7708,11 @@ __metadata:
   dependencies:
     "@custom-elements-manifest/analyzer": "npm:^0.10.10"
     "@ui5/cypress-internal": "npm:0.1.0"
-    "@ui5/webcomponents": "npm:2.23.1"
-    "@ui5/webcomponents-base": "npm:2.23.1"
-    "@ui5/webcomponents-icons": "npm:2.23.1"
-    "@ui5/webcomponents-theming": "npm:2.23.1"
-    "@ui5/webcomponents-tools": "npm:2.23.1"
+    "@ui5/webcomponents": "npm:2.23.2"
+    "@ui5/webcomponents-base": "npm:2.23.2"
+    "@ui5/webcomponents-icons": "npm:2.23.2"
+    "@ui5/webcomponents-theming": "npm:2.23.2"
+    "@ui5/webcomponents-tools": "npm:2.23.2"
     cypress: "npm:15.9.0"
     vite: "npm:5.4.21"
   languageName: unknown
@@ -7724,11 +7724,11 @@ __metadata:
   dependencies:
     "@custom-elements-manifest/analyzer": "npm:^0.10.10"
     "@ui5/cypress-internal": "npm:0.1.0"
-    "@ui5/webcomponents": "npm:2.23.1"
-    "@ui5/webcomponents-base": "npm:2.23.1"
-    "@ui5/webcomponents-icons": "npm:2.23.1"
-    "@ui5/webcomponents-theming": "npm:2.23.1"
-    "@ui5/webcomponents-tools": "npm:2.23.1"
+    "@ui5/webcomponents": "npm:2.23.2"
+    "@ui5/webcomponents-base": "npm:2.23.2"
+    "@ui5/webcomponents-icons": "npm:2.23.2"
+    "@ui5/webcomponents-theming": "npm:2.23.2"
+    "@ui5/webcomponents-tools": "npm:2.23.2"
     "@zxing/library": "npm:^0.21.3"
     cypress: "npm:15.9.0"
     lit: "npm:^2.0.0"
@@ -7737,34 +7737,34 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@ui5/webcomponents-icons-business-suite@npm:2.23.1, @ui5/webcomponents-icons-business-suite@workspace:packages/icons-business-suite":
+"@ui5/webcomponents-icons-business-suite@npm:2.23.2, @ui5/webcomponents-icons-business-suite@workspace:packages/icons-business-suite":
   version: 0.0.0-use.local
   resolution: "@ui5/webcomponents-icons-business-suite@workspace:packages/icons-business-suite"
   dependencies:
-    "@ui5/webcomponents-base": "npm:2.23.1"
-    "@ui5/webcomponents-tools": "npm:2.23.1"
+    "@ui5/webcomponents-base": "npm:2.23.2"
+    "@ui5/webcomponents-tools": "npm:2.23.2"
   languageName: unknown
   linkType: soft
 
-"@ui5/webcomponents-icons-tnt@npm:2.23.1, @ui5/webcomponents-icons-tnt@workspace:packages/icons-tnt":
+"@ui5/webcomponents-icons-tnt@npm:2.23.2, @ui5/webcomponents-icons-tnt@workspace:packages/icons-tnt":
   version: 0.0.0-use.local
   resolution: "@ui5/webcomponents-icons-tnt@workspace:packages/icons-tnt"
   dependencies:
-    "@ui5/webcomponents-base": "npm:2.23.1"
-    "@ui5/webcomponents-tools": "npm:2.23.1"
+    "@ui5/webcomponents-base": "npm:2.23.2"
+    "@ui5/webcomponents-tools": "npm:2.23.2"
   languageName: unknown
   linkType: soft
 
-"@ui5/webcomponents-icons@npm:2.23.1, @ui5/webcomponents-icons@workspace:packages/icons":
+"@ui5/webcomponents-icons@npm:2.23.2, @ui5/webcomponents-icons@workspace:packages/icons":
   version: 0.0.0-use.local
   resolution: "@ui5/webcomponents-icons@workspace:packages/icons"
   dependencies:
-    "@ui5/webcomponents-base": "npm:2.23.1"
-    "@ui5/webcomponents-tools": "npm:2.23.1"
+    "@ui5/webcomponents-base": "npm:2.23.2"
+    "@ui5/webcomponents-tools": "npm:2.23.2"
   languageName: unknown
   linkType: soft
 
-"@ui5/webcomponents-localization@npm:2.23.1, @ui5/webcomponents-localization@workspace:packages/localization":
+"@ui5/webcomponents-localization@npm:2.23.2, @ui5/webcomponents-localization@workspace:packages/localization":
   version: 0.0.0-use.local
   resolution: "@ui5/webcomponents-localization@workspace:packages/localization"
   dependencies:
@@ -7773,21 +7773,21 @@ __metadata:
     "@babel/parser": "npm:^7.24.6"
     "@openui5/sap.ui.core": "npm:1.146.0"
     "@types/openui5": "npm:^1.146.0"
-    "@ui5/webcomponents-base": "npm:2.23.1"
-    "@ui5/webcomponents-tools": "npm:2.23.1"
+    "@ui5/webcomponents-base": "npm:2.23.2"
+    "@ui5/webcomponents-tools": "npm:2.23.2"
     babel-plugin-amd-to-esm: "npm:^2.0.3"
     estree-walk: "npm:^2.2.0"
     resolve: "npm:^1.20.0"
   languageName: unknown
   linkType: soft
 
-"@ui5/webcomponents-theming@npm:2.23.1, @ui5/webcomponents-theming@workspace:packages/theming":
+"@ui5/webcomponents-theming@npm:2.23.2, @ui5/webcomponents-theming@workspace:packages/theming":
   version: 0.0.0-use.local
   resolution: "@ui5/webcomponents-theming@workspace:packages/theming"
   dependencies:
     "@sap-theming/theming-base-content": "npm:11.36.3"
-    "@ui5/webcomponents-base": "npm:2.23.1"
-    "@ui5/webcomponents-tools": "npm:2.23.1"
+    "@ui5/webcomponents-base": "npm:2.23.2"
+    "@ui5/webcomponents-tools": "npm:2.23.2"
     globby: "npm:^13.1.1"
     json-beautify: "npm:^1.1.1"
     postcss: "npm:^8.4.5"
@@ -7795,7 +7795,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@ui5/webcomponents-tools@npm:2.23.1, @ui5/webcomponents-tools@workspace:packages/tools":
+"@ui5/webcomponents-tools@npm:2.23.2, @ui5/webcomponents-tools@workspace:packages/tools":
   version: 0.0.0-use.local
   resolution: "@ui5/webcomponents-tools@workspace:packages/tools"
   dependencies:
@@ -7889,19 +7889,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@ui5/webcomponents@npm:2.23.1, @ui5/webcomponents@workspace:packages/main":
+"@ui5/webcomponents@npm:2.23.2, @ui5/webcomponents@workspace:packages/main":
   version: 0.0.0-use.local
   resolution: "@ui5/webcomponents@workspace:packages/main"
   dependencies:
     "@custom-elements-manifest/analyzer": "npm:^0.10.10"
     "@ui5/cypress-internal": "npm:0.1.0"
-    "@ui5/webcomponents-base": "npm:2.23.1"
-    "@ui5/webcomponents-icons": "npm:2.23.1"
-    "@ui5/webcomponents-icons-business-suite": "npm:2.23.1"
-    "@ui5/webcomponents-icons-tnt": "npm:2.23.1"
-    "@ui5/webcomponents-localization": "npm:2.23.1"
-    "@ui5/webcomponents-theming": "npm:2.23.1"
-    "@ui5/webcomponents-tools": "npm:2.23.1"
+    "@ui5/webcomponents-base": "npm:2.23.2"
+    "@ui5/webcomponents-icons": "npm:2.23.2"
+    "@ui5/webcomponents-icons-business-suite": "npm:2.23.2"
+    "@ui5/webcomponents-icons-tnt": "npm:2.23.2"
+    "@ui5/webcomponents-localization": "npm:2.23.2"
+    "@ui5/webcomponents-theming": "npm:2.23.2"
+    "@ui5/webcomponents-tools": "npm:2.23.2"
     cypress: "npm:15.9.0"
     jsdom: "npm:^26.0.0"
     lit: "npm:^2.0.0"


### PR DESCRIPTION
## Summary

Backport of #13798 to the 2.23.x line, in preparation for the 2.23.3 patch release. Cherry-picked cleanly onto `v2.23.2`.

## Why

PR #13602 shipped in 2.23.0 and introduced a bug where language-aware components mounted while `setLanguage()` was in flight silently skipped `onEnterDOM`, breaking any consumer that registers listeners there (e.g. UDEX Footer's `ResizeHandler.register` — reported issue on their side today).

## Change

Replaces the early-return in `connectedCallback` with an `await` on the pending language change promise, and refactors `languageChangePending` in `Language.ts` from a boolean flag into a `Promise<void> | null` handle. Full rationale, design, and test coverage: see #13798.

## Verified locally

- New `packages/base/cypress/specs/LanguageAwareLifecycle.cy.tsx` (3 cases): 3/3 pass with the fix, 2/3 fail without it.
- Existing `main/cypress/specs/DatePicker_cldr_race.cy.tsx` (from #13602): still passes.
- Existing `base/cypress/specs/i18n_texts.cy.tsx`: still passes.
- `yarn lint` clean.

## Related

- #13798 — same fix on `main`.
- #13602 — original PR that introduced the regression.
- Reporter: UDEX (Digital Design System) Footer component.