### PR TITLE
test(cypress-internal): add screenshot delay override via env variable

### DIFF
--- a/packages/cypress-internal/src/commands.ts
+++ b/packages/cypress-internal/src/commands.ts
@@ -73,6 +73,16 @@ realEventCommandsRest.forEach(cmd => {
 	});
 });
 
+Cypress.Commands.overwrite("screenshot", (originalFn, ...args) => {
+	const delay = Number(Cypress.env("SCREENSHOT_DELAY") ?? 0);
+
+	if (delay > 0) {
+		return cy.wait(delay).then(() => (originalFn as any)(...args));
+	}
+
+	return (originalFn as any)(...args);
+});
+
 declare global {
 	namespace Cypress {
 		interface Chainable {


### PR DESCRIPTION
Overrides the Cypress screenshot command to wait a configurable delay before capturing. Delay defaults to 0 (no-op) and can be set via the SCREENSHOT_DELAY env variable (e.g. --env SCREENSHOT_DELAY=500).