### PR TITLE
fix(ui5-menu): add missing aria-checked attribute on menuitemradio and menuitemcheckbox

### DIFF
--- a/packages/main/cypress/specs/Menu.cy.tsx
+++ b/packages/main/cypress/specs/Menu.cy.tsx
@@ -1143,6 +1143,70 @@ describe("Menu interaction", () => {
 				.should("have.attr", "accessible-name", "Select an option from the menu");
 		});
 
+		it("aria-checked is applied to menuitemradio and menuitemcheckbox items", () => {
+			cy.mount(
+				<>
+					<Button id="btnOpen">Open Menu</Button>
+					<Menu open opener="btnOpen">
+						<MenuItem text="Regular Item"></MenuItem>
+						<MenuItemGroup checkMode="Single" id="groupSingle">
+							<MenuItem text="Radio Checked" checked></MenuItem>
+							<MenuItem text="Radio Unchecked"></MenuItem>
+						</MenuItemGroup>
+						<MenuItemGroup checkMode="Multiple" id="groupMulti">
+							<MenuItem text="Checkbox Checked" checked></MenuItem>
+							<MenuItem text="Checkbox Unchecked"></MenuItem>
+						</MenuItemGroup>
+					</Menu>
+				</>
+			);
+
+			cy.get("[ui5-menu]").as("menu");
+
+			cy.get("@menu")
+				.find("[text='Regular Item']")
+				.shadow()
+				.find("li")
+				.should("have.attr", "role", "menuitem")
+				.and("not.have.attr", "aria-checked");
+
+			cy.get("@menu")
+				.find("[id='groupSingle']")
+				.as("groupSingle");
+
+			cy.get("@groupSingle")
+				.find("[text='Radio Checked']")
+				.shadow()
+				.find("li")
+				.should("have.attr", "role", "menuitemradio")
+				.and("have.attr", "aria-checked", "true");
+
+			cy.get("@groupSingle")
+				.find("[text='Radio Unchecked']")
+				.shadow()
+				.find("li")
+				.should("have.attr", "role", "menuitemradio")
+				.and("have.attr", "aria-checked", "false");
+
+			cy.get("@menu")
+				.find("[id='groupMulti']")
+				.as("groupMulti");
+
+			cy.get("@groupMulti")
+				.find("[text='Checkbox Checked']")
+				.shadow()
+				.find("li")
+				.should("have.attr", "role", "menuitemcheckbox")
+				.and("have.attr", "aria-checked", "true");
+
+			cy.get("@groupMulti")
+				.find("[text='Checkbox Unchecked']")
+				.shadow()
+				.find("li")
+				.should("have.attr", "role", "menuitemcheckbox")
+				.and("have.attr", "aria-checked", "false");
+		});
+
 		it("Menu items - navigation in endContent", () => {
 			cy.mount(
 				<>

--- a/packages/main/src/MenuItem.ts
+++ b/packages/main/src/MenuItem.ts
@@ -484,7 +484,7 @@ class MenuItem extends ListItem implements IMenuItem {
 			ariaKeyShortcuts: this.accessibilityAttributes.ariaKeyShortcuts,
 			ariaExpanded: this.hasSubmenu ? this.isSubMenuOpen : undefined,
 			ariaHidden: !!this.additionalText && !!this.accessibilityAttributes.ariaKeyShortcuts ? true : undefined,
-			ariaChecked: this._markChecked ? true : undefined,
+			ariaChecked: this._isCheckable ? this._markChecked : undefined,
 		};
 
 		return { ...super._accInfo, ...accInfoSettings };


### PR DESCRIPTION
Issue description:
- The AMP accessibility tool reports: 'Ensure aria Role, states and properties are valid — This LI (role=menuitemradio) needs an aria-checked attribute and that attribute needs to be the text value of either 'true' or 'false'.'
Menu items with role='menuitemradio' or role='menuitemcheckbox' were only setting aria-checked='true' when checked, leaving it absent otherwise. The ARIA spec requires aria-checked to be present with a consistent boolean value on both roles.

Solution:
- Set aria-checked to the item's checked boolean for all checkable items (Single/Multiple group modes), and leave it absent only for regular menu items (role='menuitem').
