### PR TITLE
test(ui5-date-picker, ui5-dialog): skip flaky tests

### DIFF
--- a/packages/main/cypress/specs/DatePicker.cy.tsx
+++ b/packages/main/cypress/specs/DatePicker.cy.tsx
@@ -4,7 +4,7 @@ import DatePicker from "../../src/DatePicker.js";
 import Label from "../../src/Label.js";
 import { DATEPICKER_POPOVER_ACCESSIBLE_NAME } from "../../src/generated/i18n/i18n-defaults.js";
 
-describe("Date Picker Tests", () => {
+describe.skip("Date Picker Tests", () => {
 	it("input renders", () => {
 		cy.mount(<DatePicker></DatePicker>);
 

--- a/packages/main/cypress/specs/Dialog.cy.tsx
+++ b/packages/main/cypress/specs/Dialog.cy.tsx
@@ -696,7 +696,7 @@ describe("Dialog general interaction", () => {
 		});
 	});
 
-	it("dialog remains anchored after resizing in RTL mode", () => {
+	it.skip("dialog remains anchored after resizing in RTL mode", () => {
 		cy.mount(
 			<>
 				<div dir="rtl">


### PR DESCRIPTION
Skip all DatePicker tests due to recurring LocaleData failures (_getDeep crash in getFirstDayOfWeek) that are hard to reproduce locally but consistently fail in CI.

Skip "dialog remains anchored after resizing in RTL mode" due to an intermittent assertion mismatch (expected 320, got 715) in the RTL resize anchoring logic.

Both tests need to be investigated and fixed before being re-enabled.
