### PR TITLE
ci(release-1.24): bump workflows to Node 22 + migrate release.yaml to GitHub App token

### DIFF
--- a/.github/workflows/ci-test-storybook.yaml
+++ b/.github/workflows/ci-test-storybook.yaml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4.1.0
       with:
-        node-version: 20
+        node-version: 22
         cache: 'yarn'
 
     - name: Install and Build

--- a/.github/workflows/ci-test-website.yaml
+++ b/.github/workflows/ci-test-website.yaml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4.1.0
       with:
-        node-version: 20
+        node-version: 22
         cache: 'yarn'
 
     - name: Install and Build

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -16,7 +16,7 @@ jobs:
 
     - uses: actions/setup-node@v4.1.0
       with:
-        node-version: 20
+        node-version: 22
         cache: 'yarn'
 
     - name: Install Dependencies

--- a/.github/workflows/issues-handling.yaml
+++ b/.github/workflows/issues-handling.yaml
@@ -16,7 +16,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-node@v4.1.0
       with:
-        node-version: 20
+        node-version: 22
         cache: 'yarn'
 
     - name: Install

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,7 +13,7 @@ jobs:
 
     - uses: actions/setup-node@v4.1.0
       with:
-        node-version: 20
+        node-version: 22
         cache: 'yarn'
 
     - name: Install Dependencies

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,10 +37,17 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
+      - name: Generate App Token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - name: Setup Node
@@ -57,7 +64,7 @@ jobs:
 
       - name: Version Bump
         env:
-          GH_TOKEN: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git config user.name "${{ secrets.UI5_WEBCOMP_BOT_NAME }}"
           git config user.email "${{ secrets.UI5_WEBCOMP_BOT_EMAIL }}"
@@ -75,9 +82,9 @@ jobs:
       - name: Merge Release Changelog
         uses: actions/github-script@v7
         env:
-            GH_TOKEN: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+            GH_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
-            github-token: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+            github-token: ${{ steps.app-token.outputs.token }}
             script: |
               const mergeReleaseChangelog = (await import('${{ github.workspace }}/.github/actions/mergeReleaseChangelog.mjs')).default;
               await mergeReleaseChangelog({ github , context });
@@ -86,9 +93,9 @@ jobs:
         uses: actions/github-script@v7
         env:
             NODE_OPTIONS: '--max-old-space-size=12096'
-            GH_TOKEN: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+            GH_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
-            github-token: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+            github-token: ${{ steps.app-token.outputs.token }}
             script: |
               const commentOnFixedIssues = (await import('${{ github.workspace }}/.github/actions/commentOnFixedIssues.mjs')).default;
               await commentOnFixedIssues({ github, context });
@@ -122,10 +129,17 @@ jobs:
       pages: write
     runs-on: ubuntu-latest
     steps:
+      - name: Generate App Token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - name: Setup Node
@@ -142,7 +156,7 @@ jobs:
 
       - name: Version Bump
         env:
-          GH_TOKEN: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git config user.name "${{ secrets.UI5_WEBCOMP_BOT_NAME }}"
           git config user.email "${{ secrets.UI5_WEBCOMP_BOT_EMAIL }}"
@@ -173,9 +187,9 @@ jobs:
         uses: actions/github-script@v7
         env:
             NODE_OPTIONS: '--max-old-space-size=12096'
-            GH_TOKEN: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+            GH_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
-            github-token: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+            github-token: ${{ steps.app-token.outputs.token }}
             script: |
               const commentOnFixedIssues = (await import('${{ github.workspace }}/.github/actions/commentOnFixedIssues.mjs')).default;
               await commentOnFixedIssues({ github, context });
@@ -191,10 +205,17 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
+      - name: Generate App Token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - name: Setup Node
@@ -211,7 +232,7 @@ jobs:
 
       - name: Version Bump
         env:
-          GH_TOKEN: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git config user.name "${{ secrets.UI5_WEBCOMP_BOT_NAME }}"
           git config user.email "${{ secrets.UI5_WEBCOMP_BOT_EMAIL }}"
@@ -236,10 +257,17 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
+      - name: Generate App Token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - name: Setup Node
@@ -256,7 +284,7 @@ jobs:
 
       - name: Version Bump
         env:
-          GH_TOKEN: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git config user.name "${{ secrets.UI5_WEBCOMP_BOT_NAME }}"
           git config user.email "${{ secrets.UI5_WEBCOMP_BOT_EMAIL }}"
@@ -283,10 +311,17 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
+      - name: Generate App Token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - name: Setup Node
@@ -300,7 +335,7 @@ jobs:
 
       - name: Version Bump
         env:
-          GH_TOKEN: ${{ secrets.UI5_WEBCOMP_BOT_GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
             git config user.name "${{ secrets.UI5_WEBCOMP_BOT_NAME }}"
             git config user.email "${{ secrets.UI5_WEBCOMP_BOT_EMAIL }}"


### PR DESCRIPTION
## What

Two CI fixes for the `release-1.24` branch:

### 1. Node 20 → 22
Bump `node-version` from 20 to 22 in the workflows still pinned to Node 20:
- `ci-test.yaml`, `ci-test-storybook.yaml`, `ci-test-website.yaml`, `lint.yaml`, `issues-handling.yaml`

Node 20 is [deprecated on GitHub Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). `deploy.yaml` and `release.yaml` were already on 22, so this aligns the whole branch.

### 2. PAT → GitHub App token in `release.yaml`
Downport the v2 token migration. The `UI5_WEBCOMP_BOT_GH_TOKEN` secret was removed after the migration on `main`, so on `release-1.24` it resolved empty and `actions/checkout` failed with:

> `Error: Input required and not supplied: token`

Each of the 5 release jobs now generates a short-lived token via `actions/create-github-app-token` (`RELEASE_APP_ID` / `RELEASE_APP_KEY`) and uses `steps.app-token.outputs.token` for `checkout`, `GH_TOKEN`, and `github-token` — matching `main`.

## Notes
- `reset-gh-pages.yaml` and `issues-handling.yaml` still reference the old PAT and would need the same treatment, but are **out of scope** for this PR.
- The earlier `chore(ci): add GitHub environment for OIDC token protection` commit is a separate change (npm/OIDC `environment:` blocks) and does not address the checkout token.