### PR TITLE
fix(ui5-menu-separator): fix a11y semantics by refactoring to extend UI5Element

### DIFF
--- a/packages/main/cypress/specs/Menu.cy.tsx
+++ b/packages/main/cypress/specs/Menu.cy.tsx
@@ -3,6 +3,7 @@ import SplitButton from "../../src/SplitButton.js";
 import Menu from "../../src/Menu.js";
 import MenuItem from "../../src/MenuItem.js";
 import MenuItemGroup from "../../src/MenuItemGroup.js";
+import MenuSeparator from "../../src/MenuSeparator.js";
 
 import openFolder from "@ui5/webcomponents-icons/dist/open-folder.js";
 import addFolder from "@ui5/webcomponents-icons/dist/add-folder.js";
@@ -1205,6 +1206,28 @@ describe("Menu interaction", () => {
 				.find("li")
 				.should("have.attr", "role", "menuitemcheckbox")
 				.and("have.attr", "aria-checked", "false");
+		});
+
+		it("Menu separator has correct accessibility semantics", () => {
+			cy.mount(
+				<>
+					<Button id="btnOpen">Open Menu</Button>
+					<Menu open opener="btnOpen">
+						<MenuItem text="Item 1"></MenuItem>
+						<MenuSeparator></MenuSeparator>
+						<MenuItem text="Item 2"></MenuItem>
+					</Menu>
+				</>
+			);
+
+			cy.get("[ui5-menu-separator]")
+				.shadow()
+				.find("li")
+				.should("have.attr", "role", "separator")
+				.and("not.have.attr", "tabindex")
+				.and("not.have.attr", "aria-disabled")
+				.and("not.have.attr", "aria-labelledby")
+				.and("not.have.attr", "aria-describedby");
 		});
 
 		it("Menu items - navigation in endContent", () => {

--- a/packages/main/cypress/specs/Menu.cy.tsx
+++ b/packages/main/cypress/specs/Menu.cy.tsx
@@ -1223,11 +1223,22 @@ describe("Menu interaction", () => {
 			cy.get("[ui5-menu-separator]")
 				.shadow()
 				.find("li")
-				.should("have.attr", "role", "separator")
-				.and("not.have.attr", "tabindex")
-				.and("not.have.attr", "aria-disabled")
-				.and("not.have.attr", "aria-labelledby")
-				.and("not.have.attr", "aria-describedby");
+				.as("separator");
+
+			cy.get("@separator")
+				.should("have.attr", "role", "separator");
+
+			cy.get("@separator")
+				.should("not.have.attr", "tabindex");
+
+			cy.get("@separator")
+				.should("not.have.attr", "aria-disabled");
+
+			cy.get("@separator")
+				.should("not.have.attr", "aria-labelledby");
+
+			cy.get("@separator")
+				.should("not.have.attr", "aria-describedby");
 		});
 
 		it("Menu items - navigation in endContent", () => {

--- a/packages/main/src/MenuSeparator.ts
+++ b/packages/main/src/MenuSeparator.ts
@@ -1,54 +1,33 @@
+import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
+import jsxRenderer from "@ui5/webcomponents-base/dist/renderer/JsxRenderer.js";
 import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
-import jsxRendererer from "@ui5/webcomponents-base/dist/renderer/JsxRenderer.js";
-import type { ClassMap } from "@ui5/webcomponents-base/dist/types.js";
 import menuSeparatorTemplate from "./MenuSeparatorTemplate.js";
 import menuSeparatorCss from "./generated/themes/MenuSeparator.css.js";
-import ListItemBase from "./ListItemBase.js";
 import type { IMenuItem } from "./Menu.js";
 import createInstanceChecker from "@ui5/webcomponents-base/dist/util/createInstanceChecker.js";
+import type { ListItemBaseClickEventDetail } from "./ListItemBase.js";
+
 /**
  * @class
  * The `ui5-menu-separator` represents a horizontal line to separate menu items inside a `ui5-menu`.
  * @constructor
- * @extends ListItemBase
+ * @extends UI5Element
  * @implements {IMenuItem}
  * @public
  * @since 2.0.0
  */
 @customElement({
 	tag: "ui5-menu-separator",
-	renderer: jsxRendererer,
+	renderer: jsxRenderer,
 	styles: [menuSeparatorCss],
 	template: menuSeparatorTemplate,
 })
 
-class MenuSeparator extends ListItemBase implements IMenuItem {
-	eventDetails!: ListItemBase["eventDetails"];
+class MenuSeparator extends UI5Element implements IMenuItem {
+	eventDetails!: { click?: ListItemBaseClickEventDetail };
 
 	get isSeparator() {
 		return true;
-	}
-
-	get classes(): ClassMap {
-		return {
-			main: {
-				"ui5-menu-separator": true,
-			},
-		};
-	}
-
-	/**
-	 * @override
-	 */
-	get _focusable() {
-		return false;
-	}
-
-	/**
-	 * @override
-	 */
-	get _pressable() {
-		return false;
 	}
 }
 

--- a/packages/main/src/MenuSeparator.ts
+++ b/packages/main/src/MenuSeparator.ts
@@ -1,8 +1,8 @@
-import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
-import jsxRenderer from "@ui5/webcomponents-base/dist/renderer/JsxRenderer.js";
 import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
+import jsxRenderer from "@ui5/webcomponents-base/dist/renderer/JsxRenderer.js";
 import menuSeparatorTemplate from "./MenuSeparatorTemplate.js";
 import menuSeparatorCss from "./generated/themes/MenuSeparator.css.js";
+import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
 import type { IMenuItem } from "./Menu.js";
 import createInstanceChecker from "@ui5/webcomponents-base/dist/util/createInstanceChecker.js";
 import type { ListItemBaseClickEventDetail } from "./ListItemBase.js";

--- a/packages/main/src/MenuSeparatorTemplate.tsx
+++ b/packages/main/src/MenuSeparatorTemplate.tsx
@@ -1,12 +1,10 @@
 import type MenuSeparator from "./MenuSeparator.js";
-import ListItemCustom from "./ListItemCustom.js";
 
 export default function MenuSeparatorTemplate(this: MenuSeparator) {
 	return (
-		<ListItemCustom
+		<li
+			role="separator"
 			class="ui5-menu-separator"
-			_forcedAccessibleRole="separator"
-			disabled={true}
 		/>
 	);
 }


### PR DESCRIPTION
**Issue**:

The ui5-menu-separator was incorrectly extending ListItemCustom, which caused
it to inherit list item a11y infrastructure unsuitable for a static, non-interactive
separator. The rendered DOM contained tabindex='-1', aria-disabled='true',
aria-labelledby referencing an 'Is Active' text, and an empty aria-describedby —
all semantically incorrect for a visual-only separator.

According to the WAI-ARIA 'separator' role specification, aria-valuenow,
aria-valuemin, and aria-valuemax are only required when the separator is focusable
(i.e. an interactive splitter widget). A static visual separator must NOT be
focusable and must carry none of those attributes. The previous implementation
violated this by exposing a focusable element with incorrect state announcements.

**Solution**:

MenuSeparator now extends UI5Element directly instead of ListItemBase/ListItemCustom.
The IMenuItem interface is retained for slot compatibility with ui5-menu, and the
isSeparator duck-type property is kept for the isInstanceOfMenuSeparator checker.
The template is reduced to a bare <li role='separator' />  no tabindex, no
aria-disabled, no aria-labelledby, no aria-describedby. The :host CSS border
styling is unaffected as it applies to the custom element itself.