### PR TITLE
docs(ui5-toolbar): clarify default slot accepts any component via ToolbarItem

### DIFF
--- a/packages/main/src/Toolbar.ts
+++ b/packages/main/src/Toolbar.ts
@@ -160,7 +160,7 @@ class Toolbar extends UI5Element {
 	/**
 	 * Defines the items of the component.
 	 *
-	 * **Note:** **Note:** Use `ui5-toolbar-button`, `ui5-toolbar-select`, `ui5-toolbar-separator` and `ui5-toolbar-spacer` for the most common toolbar actions. To place any other UI5 Web Component into the toolbar and have it participate in overflow handling, wrap it in a `ui5-toolbar-item`.
+	 * **Note:** Use `ui5-toolbar-button`, `ui5-toolbar-select`, `ui5-toolbar-separator` and `ui5-toolbar-spacer` for the most common toolbar actions. To place any other UI5 Web Component into the toolbar and have it participate in overflow handling, wrap it in a `ui5-toolbar-item`.
 	 * @public
 	 */
 	@slot({

--- a/packages/main/src/Toolbar.ts
+++ b/packages/main/src/Toolbar.ts
@@ -160,7 +160,7 @@ class Toolbar extends UI5Element {
 	/**
 	 * Defines the items of the component.
 	 *
-	 * **Note:** Currently only `ui5-toolbar-button`, `ui5-toolbar-select`, `ui5-toolbar-separator` and `ui5-toolbar-spacer` are allowed here.
+	 * **Note:** Use `ToolbarButton`, `ToolbarSelect`, `ToolbarSeparator` and `ToolbarSpacer` for the most common toolbar actions. To place any other UI5 Web Component into the toolbar and have it participate in overflow handling, wrap it in a `ToolbarItem`.
 	 * @public
 	 */
 	@slot({

--- a/packages/main/src/Toolbar.ts
+++ b/packages/main/src/Toolbar.ts
@@ -160,7 +160,7 @@ class Toolbar extends UI5Element {
 	/**
 	 * Defines the items of the component.
 	 *
-	 * **Note:** Use `ToolbarButton`, `ToolbarSelect`, `ToolbarSeparator` and `ToolbarSpacer` for the most common toolbar actions. To place any other UI5 Web Component into the toolbar and have it participate in overflow handling, wrap it in a `ToolbarItem`.
+	 * **Note:** **Note:** Use `ui5-toolbar-button`, `ui5-toolbar-select`, `ui5-toolbar-separator` and `ui5-toolbar-spacer` for the most common toolbar actions. To place any other UI5 Web Component into the toolbar and have it participate in overflow handling, wrap it in a `ui5-toolbar-item`.
 	 * @public
 	 */
 	@slot({


### PR DESCRIPTION
The previous JSDoc comment didn't mention `ToolbarItem`. AI Agents/MCP servers in particular took this at face value and never recommended `ToolbarItem` without being explicitly prompted.