### PR TITLE
fix(ui5-color-palette): fix hover background shape mismatch in color palette popover buttons

### DIFF
--- a/packages/main/src/themes/ColorPalette.css
+++ b/packages/main/src/themes/ColorPalette.css
@@ -117,8 +117,6 @@
 .ui5-cp-more-colors {
 	padding: 0.0625rem;
 	--_ui5_button_border_radius: 0;
-	--sapButton_Lite_BorderColor: transparent;
-	--sapButton_Lite_Hover_BorderColor: transparent;
-	--sapButton_Lite_TextColor: var(--sapTextColor);
-	--sapButton_Lite_Hover_TextColor: var(--sapTextColor);
+	--sapButton_Lite_TextColor: var(--_ui5_color-palette-button-text-color);
+	--sapButton_Lite_Hover_TextColor: var(--_ui5_color-palette-button-text-color);
 }

--- a/packages/main/src/themes/ColorPalette.css
+++ b/packages/main/src/themes/ColorPalette.css
@@ -108,6 +108,17 @@
 	flex-direction: column;
 }
 
+.ui5-cp-default-color-button-wrapper:hover,
+.ui5-cp-more-colors-wrapper:hover {
+	background-color: var(--sapButton_Lite_Hover_Background);
+}
+
+.ui5-cp-default-color-button-wrapper .ui5-cp-default-color-button,
+.ui5-cp-more-colors-wrapper .ui5-cp-more-colors {
+	--sapButton_Lite_Hover_Background: transparent;
+	--sapButton_Lite_Hover_BorderColor: transparent;
+}
+
 .ui5-cp-separator {
 	height: 0.0625rem;
 	background: var(--sapToolbar_SeparatorColor);

--- a/packages/main/src/themes/ColorPalette.css
+++ b/packages/main/src/themes/ColorPalette.css
@@ -117,6 +117,4 @@
 .ui5-cp-more-colors {
 	padding: 0.0625rem;
 	--_ui5_button_border_radius: 0;
-	--sapButton_Lite_TextColor: var(--_ui5_color-palette-button-text-color);
-	--sapButton_Lite_Hover_TextColor: var(--_ui5_color-palette-button-text-color);
 }

--- a/packages/main/src/themes/ColorPalette.css
+++ b/packages/main/src/themes/ColorPalette.css
@@ -127,4 +127,9 @@
 .ui5-cp-default-color-button,
 .ui5-cp-more-colors {
 	padding: 0.0625rem;
+	--_ui5_button_border_radius: 0;
+	--sapButton_Lite_BorderColor: transparent;
+	--sapButton_Lite_Hover_BorderColor: transparent;
+	--sapButton_Lite_TextColor: var(--sapTextColor);
+	--sapButton_Lite_Hover_TextColor: var(--sapTextColor);
 }

--- a/packages/main/src/themes/ColorPalette.css
+++ b/packages/main/src/themes/ColorPalette.css
@@ -108,17 +108,6 @@
 	flex-direction: column;
 }
 
-.ui5-cp-default-color-button-wrapper:hover,
-.ui5-cp-more-colors-wrapper:hover {
-	background-color: var(--sapButton_Lite_Hover_Background);
-}
-
-.ui5-cp-default-color-button-wrapper .ui5-cp-default-color-button,
-.ui5-cp-more-colors-wrapper .ui5-cp-more-colors {
-	--sapButton_Lite_Hover_Background: transparent;
-	--sapButton_Lite_Hover_BorderColor: transparent;
-}
-
 .ui5-cp-separator {
 	height: 0.0625rem;
 	background: var(--sapToolbar_SeparatorColor);

--- a/packages/main/src/themes/ColorPalette.css
+++ b/packages/main/src/themes/ColorPalette.css
@@ -116,5 +116,5 @@
 .ui5-cp-default-color-button,
 .ui5-cp-more-colors {
 	padding: 0.0625rem;
-	--_ui5_button_border_radius: 0;
+	border-radius: 0;
 }

--- a/packages/main/src/themes/base/ColorPalette-parameters.css
+++ b/packages/main/src/themes/base/ColorPalette-parameters.css
@@ -23,4 +23,5 @@
 	--_ui5_color-palette-item-mobile-focus-sides-inset: 0.25rem 0.25rem;
 	--_ui5_color-palette-item-after-mobile-focus-border: var(--_ui5_color-palette-item-after-focus-color);
 	--_ui5-color-palette-item-background-color: transparent;
+	--_ui5_color-palette-button-text-color: var(--sapTextColor);
 }

--- a/packages/main/src/themes/base/ColorPalette-parameters.css
+++ b/packages/main/src/themes/base/ColorPalette-parameters.css
@@ -23,5 +23,4 @@
 	--_ui5_color-palette-item-mobile-focus-sides-inset: 0.25rem 0.25rem;
 	--_ui5_color-palette-item-after-mobile-focus-border: var(--_ui5_color-palette-item-after-focus-color);
 	--_ui5-color-palette-item-background-color: transparent;
-	--_ui5_color-palette-button-text-color: var(--sapTextColor);
 }


### PR DESCRIPTION
**Issue:**

The Default Color and More colors... buttons inside the color palette popover are placed in wrapper elements (ui5-cp-default-color-button-wrapper and ui5-cp-more-colors-wrapper) that have a specific shape due to the popover's border-radius clipping. On hover, the button rendered its own background with four fully rounded corners, visually conflicting with the wrapper shape.

**Solution:**

Apply the hover background color on the wrapper elements instead of letting the button render it. The button's own hover background and border are overridden to transparent via CSS custom properties scoped to those wrappers, so the highlight takes the correct shape of the wrapper.

Fixes: https://github.com/UI5/webcomponents/issues/13763

