### PR TITLE
fix(ui5-shellbar-search): keep ShellBar state in sync on empty Enter

### DIFF
--- a/packages/fiori/cypress/specs/ShellBar.cy.tsx
+++ b/packages/fiori/cypress/specs/ShellBar.cy.tsx
@@ -541,6 +541,33 @@ describe("Slots", () => {
 			cy.get("#search").should("have.prop", "collapsed", true);
 		});
 
+		it("Test pressing Enter on empty search collapses it and keeps ShellBar state in sync", () => {
+			cy.mount(
+				<ShellBar id="shellbar" showSearchField={true}>
+					<ShellBarSearch id="search" slot="searchField"></ShellBarSearch>
+				</ShellBar>
+			);
+
+			// Initially expanded, ShellBar reflects the expanded state
+			cy.get("#search").should("have.prop", "collapsed", false);
+			cy.get("#shellbar").invoke("prop", "showSearchField").should("equal", true);
+
+			// Focus the input and press Enter without a value
+			cy.get("#search")
+				.shadow()
+				.find("input")
+				.realClick();
+
+			cy.get("#search")
+				.shadow()
+				.find("input")
+				.realPress("Enter");
+
+			// The search collapses AND the ShellBar's own state collapses in sync
+			cy.get("#search").should("have.prop", "collapsed", true);
+			cy.get("#shellbar").invoke("prop", "showSearchField").should("equal", false);
+		});
+
 		it("Test showSearchField property is false when using collapsed search field", () => {
 			cy.mount(
 				<ShellBar id="shellbar">

--- a/packages/fiori/src/ShellBarSearch.ts
+++ b/packages/fiori/src/ShellBarSearch.ts
@@ -56,6 +56,9 @@ class ShellBarSearch extends Search {
 
 	_handleEnter() {
 		if (!this.value && !this.collapsed) {
+			// Fire `ui5-search` so a host ShellBar collapses in sync; also collapse
+			// locally for standalone usage (host converges on the same state).
+			this._handleSearchEvent();
 			this.collapsed = true;
 
 			setTimeout(() => {


### PR DESCRIPTION
SNOW: DINC0942674

## Problem

Focus the shellbar search (empty, expanded) and press Enter. The search field collapses to an icon, but the ShellBar keeps its expanded layout. The two get out of sync.

## Cause

`ShellBarSearch._handleEnter()` (added in #13523) collapses the field on empty Enter by setting `this.collapsed = true` directly. It skips `super._handleEnter()`, so the `ui5-search` event never fires.

The ShellBar tracks the search state separately through its adaptor, which only reacts to `ui5-open`, `ui5-close`, and `ui5-search`. With no event, the adaptor never learns the field collapsed, so `showSearchField` stays `true`.

## Fix

Fire `ui5-search` before collapsing. The adaptor then flips `showSearchField` to `false`, so both stay in sync. Standalone usage still self-collapses and restores focus to the button.

## Tests

Added a test in `ShellBar.cy.tsx`: mount the search inside a ShellBar, press Enter on empty, and check both `collapsed === true` and `showSearchField === false`. The existing standalone test from #13523 still passes.