### PR TITLE
chore(docs): Fix broken link in Pull Request Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 ### PR checklist
 - [ ] Check the [Development Hints](https://ui5.github.io/webcomponents/docs/contributing/DoD/)
 
-- [ ] Follow the [Commit message Guidelines](https://github.com/UI5/webcomponents/blob/main/docs/5-contributing/02-conventions-and-guidelines.md#commit-message-style)
+- [ ] Follow the [Commit message Guidelines](https://github.com/UI5/webcomponents/blob/main/docs/08-contributing/02-conventions-and-guidelines.md#commit-message-style)
 
 For example: `fix(ui5-*): correct/fix sth` or `feat(ui5-*): add/introduce sth`. If you don't want the change to be part of the release changelog - use `chore`, `refactor` or `docs`.
 


### PR DESCRIPTION
### Small Broken Link fix

Hi colleagues!

On the processing of opening another PR, I noticed that the link to the commit message guidelines is broken. 
Here is a simple PR to change it.

In regards to the DCO, this is my SAP-managed account, but I have signed it regardless.

Thanks for taking the time and for your great work.


**Thank you for your contribution!** 👏


### PR checklist
- [x] Check the [Development Hints](https://ui5.github.io/webcomponents/docs/contributing/DoD/)

- [x] Follow the [Commit message Guidelines](https://github.com/UI5/webcomponents/blob/main/docs/5-contributing/02-conventions-and-guidelines.md#commit-message-style)

For example: `fix(ui5-*): correct/fix sth` or `feat(ui5-*): add/introduce sth`. If you don't want the change to be part of the release changelog - use `chore`, `refactor` or `docs`.

- [x] Add proper description about the background of the change and the change itself

- [ ] Link to an existing issue (if available)

Use `Fixes: {#PR_NUMBER}` to close the issue automatically when the PR is merged
or `Related to: {#PR_NUMBER}` to just create a link between the PR and the issue.

- [x] Read the [Contributing Guidelines](https://github.com/UI5/webcomponents/blob/main/CONTRIBUTING.md)
