### PR TITLE
docs(ui5-panel): add accessible name to custom header sample

### DIFF
--- a/packages/website/docs/_samples/main/Panel/CustomHeader/sample.html
+++ b/packages/website/docs/_samples/main/Panel/CustomHeader/sample.html
@@ -22,7 +22,7 @@
     <!-- playground-fold-end -->
 
 
-        <ui5-panel>
+        <ui5-panel accessible-name="Countries">
 
             <div slot="header" class="header">
                 <ui5-title level="H4">Countries</ui5-title>

--- a/packages/website/docs/_samples/main/Panel/CustomHeader/sample.tsx
+++ b/packages/website/docs/_samples/main/Panel/CustomHeader/sample.tsx
@@ -12,7 +12,7 @@ const Title = createReactComponent(TitleClass);
 function App() {
   return (
     <>
-      <Panel>
+      <Panel accessibleName="Countries">
         <div slot="header" className="header">
           <Title level="H4">Countries</Title>
           <div>


### PR DESCRIPTION
- custom header title is now being read by screen readers.