### PR TITLE
ci(dev-close-notice): refresh 2026 dev-close windows through 2.29

### DIFF
--- a/.github/workflows/pr-dev-close-notice.yaml
+++ b/.github/workflows/pr-dev-close-notice.yaml
@@ -45,7 +45,11 @@ jobs:
           script: |
             // Add new entries here when the release schedule is known.
             const DEV_CLOSE_PERIODS = [
-              { release: "next", devCloseStart: "2026-06-24", releaseDate: "2026-07-09" },
+              { release: "2.25", devCloseStart: "2026-07-22", releaseDate: "2026-07-29" },
+              { release: "2.26", devCloseStart: "2026-08-19", releaseDate: "2026-08-26" },
+              { release: "2.27", devCloseStart: "2026-09-16", releaseDate: "2026-09-23" },
+              { release: "2.28", devCloseStart: "2026-10-14", releaseDate: "2026-10-21" },
+              { release: "2.29", devCloseStart: "2026-11-11", releaseDate: "2026-11-18" },
             ];
 
             const today = new Date();

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,10 @@ cypress-logs
 cypress/screenshots
 cypress/videos
 
+# Claude
+.claude/playwright-*
+.playwright-mcp/
+
 # scoping feature generated entry points for vite consumption
 packages/compat/test/pages/scoped
 packages/main/test/pages/scoped


### PR DESCRIPTION
## What

Updates `DEV_CLOSE_PERIODS` in `pr-dev-close-notice.yaml` to match the [release plan](https://github.com/UI5/webcomponents/issues/10568) — versions 2.25 through 2.29.

## Why

The array previously held only a single stale 2.24 entry (window ended 2026-07-09). As a result the notice workflow was inactive during the current **2.25 dev close (2026-07-22 → 2026-07-29)**. Verified locally that today resolves to the 2.25 window with the new entries.

| Version | Dev Close | Release |
|---------|-----------|---------|
| 2.25 | 2026-07-22 | 2026-07-29 |
| 2.26 | 2026-08-19 | 2026-08-26 |
| 2.27 | 2026-09-16 | 2026-09-23 |
| 2.28 | 2026-10-14 | 2026-10-21 |
| 2.29 | 2026-11-11 | 2026-11-18 |

Also adds a `.gitignore` entry for local Claude/Playwright artifacts.