### PR TITLE
ci: disable npm provenance in rc-release publish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -225,6 +225,8 @@ jobs:
             });
 
       - name: Publish
+        env:
+          NPM_CONFIG_PROVENANCE: false
         run: |
           yarn lerna publish from-git --yes
 


### PR DESCRIPTION
## Problem

The rc-release publish is failing repeatedly with:

```
lerna WARN notice Package failed to publish: @ui5/webcomponents-tools
lerna ERR! TLOG_CREATE_ENTRY_ERROR error creating tlog entry - (409) an equivalent entry already exists in the transparency log
lerna ERR! errno "undefined" is not a valid exit code - exiting with code 1
```

npm publishes with **provenance** (auto-enabled in CI because the job grants `id-token: write`), which writes an attestation to Sigstore's public **Rekor transparency log**. That log is append-only/immutable. When a publish is retried after a transient registry hiccup, the retry re-attempts the same Rekor entry and Rekor rejects it with a **409**. lerna then aborts the entire `publish from-git` — so `@ui5/webcomponents-tools` (an early dependency) fails and **all packages queued after it never publish**.

At rc.2 this left 11 of 12 packages unpublished on npm.

## Fix

Set `NPM_CONFIG_PROVENANCE: false` on the rc-release Publish step so no Rekor entry is written and the collision can't happen.

## Note

The stuck rc.2 will need a fresh version bump (rc.3) to release, since the affected versions can't be re-attempted cleanly.