### PR TITLE
fix(ui5-multi-input): prevent F4 from focusing browser address bar in MS Edge

### DIFF
--- a/packages/main/src/MultiInput.ts
+++ b/packages/main/src/MultiInput.ts
@@ -280,6 +280,7 @@ class MultiInput extends Input implements IFormInputElement {
 		}
 
 		if (isShow(e)) {
+			e.preventDefault();
 			this.valueHelpPress();
 		}
 


### PR DESCRIPTION
Fixes: #13837 

On MS Edge (Windows), pressing F4 in a focused MultiInput would
trigger the browser's default "focus address bar" behavior in
addition to firing the value-help-trigger event.
