### PR TITLE
fix(ui5-page): keep responsive paddings at fractional breakpoint widths

### DIFF
--- a/packages/fiori/src/themes/Page.css
+++ b/packages/fiori/src/themes/Page.css
@@ -52,26 +52,24 @@
 	padding: 0;
 }
 
-/* S Size */
-@container (max-width: 599px) {
-	:host([floating-footer]) .ui5-page-footer-root,
-	.ui5-page-content-root {
-		padding: 0 1rem;
-	}
+/* S Size (default, progressively overridden by larger sizes) */
+:host([floating-footer]) .ui5-page-footer-root,
+.ui5-page-content-root {
+	padding: 0 1rem;
+}
 
-	::slotted([ui5-bar][slot="header"]),
-	::slotted([ui5-bar][design="Footer"]) {
-		box-sizing: border-box;
-		padding: 0 .25rem;
-	}
+::slotted([ui5-bar][slot="header"]),
+::slotted([ui5-bar][design="Footer"]) {
+	box-sizing: border-box;
+	padding: 0 .25rem;
+}
 
-	::slotted([ui5-bar][design="FloatingFooter"]) {
-		width: calc(100% - 0.5rem);
-	}
+::slotted([ui5-bar][design="FloatingFooter"]) {
+	width: calc(100% - 0.5rem);
 }
 
 /* M Size */
-@container (min-width: 600px) and (max-width: 1023px) {
+@container (min-width: 600px) {
 	:host([floating-footer]) .ui5-page-footer-root,
 	.ui5-page-content-root {
 		padding: 0 2rem;
@@ -89,7 +87,7 @@
 }
 
 /* L Size */
-@container (min-width: 1024px) and (max-width: 1439px) {
+@container (min-width: 1024px) {
 	:host([floating-footer]) .ui5-page-footer-root,
 	.ui5-page-content-root {
 		padding: 0 2rem;


### PR DESCRIPTION
## Description

The `ui5-page` responsive paddings used container queries with **gaps between the breakpoints** (e.g. `max-width: 599px` / `min-width: 600px`). At fractional container widths such as `599.2px`, `1023.2px` or `1439.2px`, the value fell between two breakpoints, so no rule matched and the content and header lost their paddings.

## Fix

Make the **S** size the unconditional default and use cumulative `min-width` container queries for **M/L/XL** so the sizes layer via the cascade with no gaps — in line with the existing `DynamicPage` implementation.

Fixes #13854

Related: #13725 (same class of issue on `DynamicPage`)