### PR TITLE
docs(ui5-list, ui5-li-custom): document edit-mode keyboard navigation

### DIFF
--- a/packages/main/src/List.ts
+++ b/packages/main/src/List.ts
@@ -152,20 +152,45 @@ type ListAccessibilityAttributes = {
  *
  * ### Keyboard Handling
  *
+ * The `ui5-list` follows the SAP Fiori "Intentional Edit Pattern" (forms-editing variant)
+ * and exposes two interaction modes:
+ *
+ * - **Navigation mode** (default) - Arrow keys move focus between items; [Tab] leaves the list.
+ * - **Edit mode** (toggled by [F2] or [F7]) - [Tab] walks through the interactive elements
+ *   inside items (buttons, links, inputs, checkboxes, etc.) and continues into the next item.
+ *
  * #### Basic Navigation
- * The `ui5-list` provides advanced keyboard handling.
- * When a list is focused the user can use the following keyboard
- * shortcuts in order to perform a navigation:
+ * The `ui5-list` provides advanced keyboard handling for navigation between items.
+ * When an item is focused the user can use the following keyboard shortcuts:
  *
  * - [Up] or [Down] - Navigates up and down the items
  * - [Home] - Navigates to first item
  * - [End] - Navigates to the last item
+ * - [Tab] or [Shift] + [Tab] - Moves focus out of the list, to the next/previous control in the tab chain
  *
  * The user can use the following keyboard shortcuts to perform actions (such as select, delete),
  * when the `selectionMode` property is in use:
  *
  * - [Space] - Select an item (if `type` is 'Active') when `selectionMode` is selection
  * - [Delete] - Delete an item if `selectionMode` property is `Delete`
+ *
+ * #### Edit Mode - Reaching Interactive Elements Inside Items
+ * Interactive elements inside a list item (buttons, links, inputs, etc.) are not reached
+ * by [Tab] from navigation mode. To activate them, the user first enters edit mode.
+ *
+ * - [F2] - Toggles edit mode on the focused item. Pressing [F2] again returns focus to the item level.
+ * - [F7] - While focus is on an item, moves focus to the last remembered internal element
+ *   (or to the first interactive element if none is remembered).
+ *   While focus is on an interactive element, saves its position and moves focus back to the item level.
+ * - [Tab] or [Shift] + [Tab] - While in edit mode, moves focus through the interactive
+ *   elements within an item, then continues into the next/previous item's interactive elements,
+ *   and exits the list after the last/first element.
+ * - [Up] or [Down] - While focus is on an interactive element inside an item, moves focus
+ *   to the element at the same index in the previous/next item. Items with no interactive
+ *   elements are skipped, and boundaries of `ui5-li-group` are crossed.
+ *
+ * **Note:** In `selectionMode="Delete"`, the per-item delete button is reachable through
+ * the edit-mode [Tab] flow described above, in addition to the [Delete] shortcut.
  *
  * #### Fast Navigation
  * This component provides a build in fast navigation group which can be used via [F6] / [Shift] + [F6] / [Ctrl] + [Alt/Option] / [Down] or [Ctrl] + [Alt/Option] + [Up].

--- a/packages/main/src/List.ts
+++ b/packages/main/src/List.ts
@@ -178,7 +178,9 @@ type ListAccessibilityAttributes = {
  * Interactive elements inside a list item (buttons, links, inputs, etc.) are not reached
  * by [Tab] from navigation mode. To activate them, the user first enters edit mode.
  *
- * - [F2] - Toggles edit mode on the focused item. Pressing [F2] again returns focus to the item level.
+ * - [F2] - While focus is on an item, moves focus to the first interactive element inside it.
+ *   While focus is on an interactive element, moves focus back to the item level.
+ *   Unlike [F7], [F2] does not remember the previous position — it always lands on the first interactive element.
  * - [F7] - While focus is on an item, moves focus to the last remembered internal element
  *   (or to the first interactive element if none is remembered).
  *   While focus is on an interactive element, saves its position and moves focus back to the item level.

--- a/packages/main/src/ListItemCustom.ts
+++ b/packages/main/src/ListItemCustom.ts
@@ -34,14 +34,16 @@ import ListItemCustomCss from "./generated/themes/ListItemCustom.css.js";
  *
  * To activate an interactive element inside a `ui5-li-custom`:
  *
- * - [F2] or [F7] on the focused item - moves focus to the first interactive element
- *   inside the item (or to the last remembered position).
+ * - [F2] on the focused item - moves focus to the first interactive element inside the item.
+ *   Pressing [F2] again returns focus to the item level.
+ * - [F7] on the focused item - moves focus to the last remembered interactive element
+ *   inside the item (or to the first interactive element if none is remembered).
+ *   Pressing [F7] again saves the current position and returns focus to the item level.
  * - [Tab] or [Shift] + [Tab] then walks through the interactive elements within the item
  *   and continues into the next/previous item.
  * - [Up] or [Down] while focused on an interactive element moves focus to the element
  *   at the same index in the previous/next item; items with no interactive elements
  *   are skipped and `ui5-li-group` boundaries are crossed.
- * - [F2] or [F7] again returns focus to the item level.
  *
  * See the `ui5-list` "Keyboard Handling" section for the full behavior.
  *

--- a/packages/main/src/ListItemCustom.ts
+++ b/packages/main/src/ListItemCustom.ts
@@ -25,6 +25,26 @@ import ListItemCustomCss from "./generated/themes/ListItemCustom.css.js";
  * the same way as the standard `ui5-li`.
  *
  * The component accepts arbitrary HTML content to allow full customization.
+ *
+ * ### Keyboard Handling
+ *
+ * Interactive elements placed in the default slot (buttons, links, inputs, etc.)
+ * are **not** reached by [Tab] from outside the list. This follows the SAP Fiori
+ * "Intentional Edit Pattern" and preserves fast keyboard navigation between items.
+ *
+ * To activate an interactive element inside a `ui5-li-custom`:
+ *
+ * - [F2] or [F7] on the focused item - moves focus to the first interactive element
+ *   inside the item (or to the last remembered position).
+ * - [Tab] or [Shift] + [Tab] then walks through the interactive elements within the item
+ *   and continues into the next/previous item.
+ * - [Up] or [Down] while focused on an interactive element moves focus to the element
+ *   at the same index in the previous/next item; items with no interactive elements
+ *   are skipped and `ui5-li-group` boundaries are crossed.
+ * - [F2] or [F7] again returns focus to the item level.
+ *
+ * See the `ui5-list` "Keyboard Handling" section for the full behavior.
+ *
  * @csspart native-li - Used to style the main li tag of the list item
  * @csspart content - Used to style the content area of the list item
  * @csspart detail-button - Used to style the button rendered when the list item is of type detail

--- a/packages/website/docs/_components_pages/main/List/List.mdx
+++ b/packages/website/docs/_components_pages/main/List/List.mdx
@@ -15,6 +15,7 @@ import MultipleDrag from "../../../_samples/main/List/MultipleDrag/MultipleDrag.
 import WrappingBehavior from "../../../_samples/main/List/WrappingBehavior/WrappingBehavior.md";
 import StickyHeader from "../../../_samples/main/List/StickyHeader/StickyHeader.md";
 import AccessibleRole from "../../../_samples/main/List/AccessibleRole/AccessibleRole.md";
+import KeyboardHandling from "../../../_samples/main/List/KeyboardHandling/KeyboardHandling.md";
 
 <%COMPONENT_OVERVIEW%>
 
@@ -96,3 +97,24 @@ Child `ui5-li` items automatically inherit the matching ARIA role - `menuitem` f
 Setting an explicit `accessible-role` attribute on an individual `ui5-li` takes precedence over the role inherited from the parent list.
 
 <AccessibleRole />
+
+### Keyboard Handling
+The `ui5-list` implements the SAP Fiori <b>Intentional Edit Pattern</b>. Interactive elements
+inside a list item (such as buttons, links or inputs in a `ui5-li-custom`) are <b>not</b> reached
+by <kbd>Tab</kbd> from outside the list — that keeps navigation between items fast.
+
+To activate them, <kbd>Tab</kbd> into the list, use <kbd>↓</kbd> to focus a row, then enter edit mode:
+
+- <kbd>F2</kbd> or <kbd>F7</kbd> — moves focus to the first interactive element inside the item.
+  Press again to return focus to the item level.
+- <kbd>Tab</kbd> / <kbd>Shift</kbd>+<kbd>Tab</kbd> — while in edit mode, walks through the
+  interactive elements within an item, then continues into the next/previous item, and exits
+  the list after the last/first element.
+- <kbd>↑</kbd> / <kbd>↓</kbd> — while focus is on an interactive element, jumps to the element
+  at the same index in the previous/next item. Items with no interactive elements are skipped
+  and `ui5-li-group` boundaries are crossed.
+
+Try it in the sample below — <kbd>Tab</kbd> into the list, use <kbd>↓</kbd> to focus a row,
+then press <kbd>F2</kbd> or <kbd>F7</kbd> to step into the row's buttons.
+
+<KeyboardHandling />

--- a/packages/website/docs/_samples/main/List/KeyboardHandling/KeyboardHandling.md
+++ b/packages/website/docs/_samples/main/List/KeyboardHandling/KeyboardHandling.md
@@ -1,0 +1,6 @@
+import html from '!!raw-loader!./sample.html';
+import js from '!!raw-loader!./main.js';
+import css from '!!raw-loader!./main.css';
+import react from '!!raw-loader!./sample.tsx';
+
+<Editor html={html} js={js} css={css} react={react} />

--- a/packages/website/docs/_samples/main/List/KeyboardHandling/main.css
+++ b/packages/website/docs/_samples/main/List/KeyboardHandling/main.css
@@ -1,0 +1,14 @@
+.kbd-sample__row {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	width: 100%;
+	padding: 0.5rem 0;
+}
+
+.kbd-sample__text {
+	display: flex;
+	flex-direction: column;
+	flex: 1;
+	min-width: 0;
+}

--- a/packages/website/docs/_samples/main/List/KeyboardHandling/main.js
+++ b/packages/website/docs/_samples/main/List/KeyboardHandling/main.js
@@ -1,0 +1,9 @@
+import "@ui5/webcomponents/dist/List.js";
+import "@ui5/webcomponents/dist/ListItemCustom.js";
+import "@ui5/webcomponents/dist/ListItemStandard.js";
+import "@ui5/webcomponents/dist/Button.js";
+import "@ui5/webcomponents/dist/Title.js";
+import "@ui5/webcomponents/dist/Label.js";
+
+import "@ui5/webcomponents-icons/dist/edit.js";
+import "@ui5/webcomponents-icons/dist/delete.js";

--- a/packages/website/docs/_samples/main/List/KeyboardHandling/sample.html
+++ b/packages/website/docs/_samples/main/List/KeyboardHandling/sample.html
@@ -1,0 +1,60 @@
+<!-- playground-fold -->
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>Sample</title>
+	<link rel="stylesheet" href="./main.css">
+</head>
+
+<body style="background-color: var(--sapBackgroundColor)">
+	<!-- playground-fold-end -->
+	<ui5-list header-text="Products (focus a row, then press F2 or F7)">
+		<ui5-li-custom accessible-name="Ergonomic keyboard">
+			<div class="kbd-sample__row">
+				<div class="kbd-sample__text">
+					<ui5-title size="H6">Ergonomic Keyboard</ui5-title>
+					<ui5-label>In stock</ui5-label>
+				</div>
+				<ui5-button icon="edit" design="Transparent" accessible-name="Edit ergonomic keyboard" tooltip="Edit"></ui5-button>
+				<ui5-button icon="delete" design="Transparent" accessible-name="Delete ergonomic keyboard" tooltip="Delete"></ui5-button>
+			</div>
+		</ui5-li-custom>
+		<ui5-li-custom accessible-name="Wireless mouse">
+			<div class="kbd-sample__row">
+				<div class="kbd-sample__text">
+					<ui5-title size="H6">Wireless Mouse</ui5-title>
+					<ui5-label>In stock</ui5-label>
+				</div>
+				<ui5-button icon="edit" design="Transparent" accessible-name="Edit wireless mouse" tooltip="Edit"></ui5-button>
+				<ui5-button icon="delete" design="Transparent" accessible-name="Delete wireless mouse" tooltip="Delete"></ui5-button>
+			</div>
+		</ui5-li-custom>
+		<ui5-li-custom accessible-name="27-inch monitor">
+			<div class="kbd-sample__row">
+				<div class="kbd-sample__text">
+					<ui5-title size="H6">27-inch Monitor</ui5-title>
+					<ui5-label>Low stock</ui5-label>
+				</div>
+				<ui5-button icon="edit" design="Transparent" accessible-name="Edit 27-inch monitor" tooltip="Edit"></ui5-button>
+				<ui5-button icon="delete" design="Transparent" accessible-name="Delete 27-inch monitor" tooltip="Delete"></ui5-button>
+			</div>
+		</ui5-li-custom>
+	</ui5-list>
+
+	<br>
+
+	<ui5-list header-text="Delete mode - per-item delete button is Tab-reachable in edit mode" selection-mode="Delete">
+		<ui5-li>Draft: Q3 report</ui5-li>
+		<ui5-li>Draft: Onboarding checklist</ui5-li>
+		<ui5-li>Draft: Release notes</ui5-li>
+	</ui5-list>
+
+	<!-- playground-fold -->
+	<script type="module" src="main.js"></script>
+</body>
+
+</html>
+<!-- playground-fold-end -->

--- a/packages/website/docs/_samples/main/List/KeyboardHandling/sample.tsx
+++ b/packages/website/docs/_samples/main/List/KeyboardHandling/sample.tsx
@@ -1,0 +1,83 @@
+import createReactComponent from "@ui5/webcomponents-base/dist/createReactComponent.js";
+import ListClass from "@ui5/webcomponents/dist/List.js";
+import ListItemCustomClass from "@ui5/webcomponents/dist/ListItemCustom.js";
+import ListItemStandardClass from "@ui5/webcomponents/dist/ListItemStandard.js";
+import ButtonClass from "@ui5/webcomponents/dist/Button.js";
+import TitleClass from "@ui5/webcomponents/dist/Title.js";
+import LabelClass from "@ui5/webcomponents/dist/Label.js";
+import "@ui5/webcomponents-icons/dist/edit.js";
+import "@ui5/webcomponents-icons/dist/delete.js";
+
+const List = createReactComponent(ListClass);
+const ListItemCustom = createReactComponent(ListItemCustomClass);
+const ListItemStandard = createReactComponent(ListItemStandardClass);
+const Button = createReactComponent(ButtonClass);
+const Title = createReactComponent(TitleClass);
+const Label = createReactComponent(LabelClass);
+
+const rowStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: "0.5rem",
+  width: "100%",
+  padding: "0.5rem 0",
+};
+
+const textStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  flex: 1,
+  minWidth: 0,
+};
+
+function App() {
+  return (
+    <>
+      <List headerText="Products (focus a row, then press F2 or F7)">
+        <ListItemCustom accessibleName="Ergonomic keyboard">
+          <div style={rowStyle}>
+            <div style={textStyle}>
+              <Title size="H6">Ergonomic Keyboard</Title>
+              <Label>In stock</Label>
+            </div>
+            <Button icon="edit" design="Transparent" accessibleName="Edit ergonomic keyboard" tooltip="Edit" />
+            <Button icon="delete" design="Transparent" accessibleName="Delete ergonomic keyboard" tooltip="Delete" />
+          </div>
+        </ListItemCustom>
+        <ListItemCustom accessibleName="Wireless mouse">
+          <div style={rowStyle}>
+            <div style={textStyle}>
+              <Title size="H6">Wireless Mouse</Title>
+              <Label>In stock</Label>
+            </div>
+            <Button icon="edit" design="Transparent" accessibleName="Edit wireless mouse" tooltip="Edit" />
+            <Button icon="delete" design="Transparent" accessibleName="Delete wireless mouse" tooltip="Delete" />
+          </div>
+        </ListItemCustom>
+        <ListItemCustom accessibleName="27-inch monitor">
+          <div style={rowStyle}>
+            <div style={textStyle}>
+              <Title size="H6">27-inch Monitor</Title>
+              <Label>Low stock</Label>
+            </div>
+            <Button icon="edit" design="Transparent" accessibleName="Edit 27-inch monitor" tooltip="Edit" />
+            <Button icon="delete" design="Transparent" accessibleName="Delete 27-inch monitor" tooltip="Delete" />
+          </div>
+        </ListItemCustom>
+      </List>
+
+      <br />
+
+      <List
+        headerText="Delete mode - per-item delete button is Tab-reachable in edit mode"
+        selectionMode="Delete"
+      >
+        <ListItemStandard>Draft: Q3 report</ListItemStandard>
+        <ListItemStandard>Draft: Onboarding checklist</ListItemStandard>
+        <ListItemStandard>Draft: Release notes</ListItemStandard>
+      </List>
+    </>
+  );
+}
+
+export default App;


### PR DESCRIPTION
Document the SAP Fiori "Intentional Edit Pattern" keyboard interactions (F2 / F7 / Tab / Arrow Up/Down) that were shipped in two prior changes but were not reflected in the JSDoc or on the docs website. The gap led users to report the intended behavior as a bug (see #13891): interactive elements inside `ui5-li-custom` appear unreachable because plain Tab intentionally leaves the list.

- Extend the "Keyboard Handling" JSDoc block on `ui5-list` with a new "Edit Mode" subsection covering F2, F7, edit-mode Tab flow across items, and column-wise Arrow Up/Down navigation.
- Add a "Keyboard Handling" JSDoc section to `ui5-li-custom` that spells out how to reach its interactive slotted content and cross-references `ui5-list` for the full behavior.
- Add a "Keyboard Handling" section and a runnable sample (`KeyboardHandling`) to the docs website's List page, including a `selectionMode="Delete"` example that demonstrates the delete button being Tab-reachable in edit mode.

Follow-up of #12700 (F7 + Arrow Up/Down cross-item navigation) and #13411 (edit mode via F2/F7 with Tab flow across items).

Fixes #13891 
Related https://github.com/UI5/webcomponents/issues/2964
