### PR TITLE
feat(ui5-user-settings-account-view): add show-edit-button property

### DIFF
--- a/packages/fiori/cypress/specs/UserSettingsDialog.cy.tsx
+++ b/packages/fiori/cypress/specs/UserSettingsDialog.cy.tsx
@@ -799,16 +799,14 @@ describe("User account view", () => {
         cy.get("@settingItem").find("[ui5-user-settings-account-view]").as("settingView");
         cy.get("@settingView").should("exist");
 
-        // _manageAccountButtonText resolves via the guarded i18nBundle getter
         cy.get("@settingView").shadow().find("[ui5-button]")
             .should("contain.text", USER_SETTINGS_ACCOUNT_MANAGE_ACCOUNT_BUTTON_TXT.defaultText);
 
-        // _editAvatarTooltip resolves via the guarded i18nBundle getter and is applied as the badge title
         cy.get("@settingView").shadow().find("[ui5-avatar] [ui5-avatar-badge]")
-            .should("exist");
+            .should("not.exist");
     });
 
-    it("tests avatar default", () => {
+    it("tests avatar default - no edit button", () => {
         cy.mount(<UserSettingsDialog open>
             <UserSettingsItem text="Setting">
                 <UserSettingsAccountView text="Setting1">
@@ -821,20 +819,19 @@ describe("User account view", () => {
             </UserSettingsItem>
         </UserSettingsDialog>);
         cy.get("[ui5-user-settings-dialog]").as("settings");
-        cy.get("@settings").should("exist");
         cy.get("@settings").find("[ui5-user-settings-item]").as("settingItem");
         cy.get("@settingItem").find("[ui5-user-settings-account-view]").as("settingView");
         cy.get("@settingView").shadow().find("[ui5-avatar]").as("avatar");
         cy.get("@avatar").should("exist");
-        cy.get("@avatar").should("have.length", 1);
         cy.get("@avatar").should("have.attr", "fallback-icon", "person-placeholder");
-        cy.get("@avatar").find("[ui5-avatar-badge]").should("exist");
+        cy.get("@avatar").should("have.attr", "mode", "Image");
+        cy.get("@avatar").find("[ui5-avatar-badge]").should("not.exist");
     });
 
-    it("renders ui5-avatar-badge (not ui5-tag) for the edit badge on the account avatar", () => {
+    it("tests show-edit-button - shows avatar badge and interactive mode", () => {
         cy.mount(<UserSettingsDialog open>
             <UserSettingsItem text="Setting">
-                <UserSettingsAccountView text="Setting1">
+                <UserSettingsAccountView text="Setting1" showEditButton={true}>
                     <UserMenuAccount slot="account"
                                      titleText="Alain Chevalier"
                                      subtitleText="alian.chevalier@sap.com">
@@ -844,6 +841,7 @@ describe("User account view", () => {
         </UserSettingsDialog>);
         cy.get("[ui5-user-settings-account-view]").as("settingView");
         cy.get("@settingView").shadow().find("[ui5-avatar]").as("avatar");
+        cy.get("@avatar").should("have.attr", "mode", "Interactive");
         cy.get("@avatar").find("[ui5-avatar-badge]").should("exist");
         cy.get("@avatar").find("[ui5-tag]").should("not.exist");
     });
@@ -899,7 +897,7 @@ describe("User account view", () => {
     it("tests edit-avatar-click event", () => {
         cy.mount(<UserSettingsDialog open>
             <UserSettingsItem text="Setting">
-                <UserSettingsAccountView text="Setting1">
+                <UserSettingsAccountView text="Setting1" showEditButton={true}>
                     <UserMenuAccount slot="account"
                                      titleText="Alain Chevalier 1">
                     </UserMenuAccount>
@@ -923,6 +921,25 @@ describe("User account view", () => {
         cy.get("@avatar").click();
 
         cy.get("@clicked").should("have.been.calledOnce");
+    });
+
+    it("tests edit-avatar-click event is not fired when showEditButton is false", () => {
+        cy.mount(<UserSettingsDialog open>
+            <UserSettingsItem text="Setting">
+                <UserSettingsAccountView text="Setting1">
+                    <UserMenuAccount slot="account"
+                                     titleText="Alain Chevalier 1">
+                    </UserMenuAccount>
+                </UserSettingsAccountView>
+            </UserSettingsItem>
+        </UserSettingsDialog>);
+        cy.get("[ui5-user-settings-dialog]").find("[ui5-user-settings-account-view]").as("settingView");
+        cy.get("@settingView")
+            .then($el => {
+                $el.get(0).addEventListener("edit-accounts-click", cy.stub().as("clicked"));
+            });
+        cy.get("@settingView").shadow().find("[ui5-avatar]").click({ force: true });
+        cy.get("@clicked").should("not.have.been.called");
     });
 
     it("tests manage-account-click event", () => {

--- a/packages/fiori/src/UserSettingsAccountView.ts
+++ b/packages/fiori/src/UserSettingsAccountView.ts
@@ -66,6 +66,16 @@ class UserSettingsAccountView extends UserSettingsView {
 	account!: Slot<UserMenuAccount>;
 
 	/**
+	 * Defines if the User Settings Account View shows the edit button on the avatar.
+	 *
+	 * @default false
+	 * @public
+	 * @since 2.26.0
+	 */
+	@property({ type: Boolean })
+	showEditButton = false;
+
+	/**
 	 * Defines if the User Menu shows the `Manage Account` option.
 	 *
 	 * @default false

--- a/packages/fiori/src/UserSettingsAccountViewTemplate.tsx
+++ b/packages/fiori/src/UserSettingsAccountViewTemplate.tsx
@@ -12,14 +12,19 @@ export default function UserSettingsAccountViewTemplate(this: UserSettingsAccoun
 		<div class="ui5-user-settings-view-container">
 			<div class="ui5-user-settings-view ui5-user-settings-account-view">
 				<div class="ui5-user-settings-account">
-					<Avatar size="XL" onClick={this._handleEditAvatarClick} initials={this._account?._initials}
-					        fallbackIcon={personPlaceholder} class="ui5-user-settings-account-avatar" interactive>
-						{this._account?.avatarSrc &&
-                            <img src={this._account.avatarSrc}/>
+					<span title={this.showEditButton ? this._editAvatarTooltip : undefined}>
+						<Avatar size="XL" onClick={this.showEditButton ? this._handleEditAvatarClick : undefined}
+						        initials={this._account?._initials} fallbackIcon={personPlaceholder}
+						        class="ui5-user-settings-account-avatar"
+						        mode={this.showEditButton ? "Interactive" : "Image"}>
+							{this._account?.avatarSrc &&
+							<img src={this._account.avatarSrc}/>
 						}
-						<AvatarBadge slot="badge" icon={edit}></AvatarBadge>
-
-					</Avatar>
+							{this.showEditButton &&
+								<AvatarBadge slot="badge" icon={edit}></AvatarBadge>
+							}
+						</Avatar>
+					</span>
 					{this._account?.titleText &&
                         <Text id="account-title" class="ui5-user-settings-account-title">{this._account.titleText}</Text>
 					}

--- a/packages/fiori/src/UserSettingsAccountViewTemplate.tsx
+++ b/packages/fiori/src/UserSettingsAccountViewTemplate.tsx
@@ -18,8 +18,8 @@ export default function UserSettingsAccountViewTemplate(this: UserSettingsAccoun
 						        class="ui5-user-settings-account-avatar"
 						        mode={this.showEditButton ? "Interactive" : "Image"}>
 							{this._account?.avatarSrc &&
-							<img src={this._account.avatarSrc}/>
-						}
+								<img src={this._account.avatarSrc}/>
+							}
 							{this.showEditButton &&
 								<AvatarBadge slot="badge" icon={edit}></AvatarBadge>
 							}


### PR DESCRIPTION
Introducing **`show-edit-button`** property into the `<ui5-user-settings-account-view>` web component.
The `show-edit-button` property allows you to show the edit icon on top of the avatar.
The default value of the `show-edit-button` property is `false`.

Fixes: #13893