### PR TITLE
fix(ui5-user-settings-dialog): remove unsupported aria-orientation attribute

### DIFF
--- a/packages/fiori/cypress/specs/UserSettingsDialog.cy.tsx
+++ b/packages/fiori/cypress/specs/UserSettingsDialog.cy.tsx
@@ -1412,6 +1412,18 @@ describe("F6 Navigation", () => {
             .should("have.attr", "data-sap-ui-fastnavgroup", "true");
     });
 
+    it("tests side panel does not have unsupported aria-orientation attribute", () => {
+        cy.mount(<UserSettingsDialog open>
+            <UserSettingsItem text="Setting">
+                <UserSettingsView>
+                </UserSettingsView>
+            </UserSettingsItem>
+        </UserSettingsDialog>);
+        cy.get("[ui5-user-settings-dialog]").shadow()
+            .find(".ui5-user-settings-side")
+            .should("not.have.attr", "aria-orientation");
+    });
+
     it("tests footer toolbar has fastnavgroup attribute", () => {
         cy.mount(<UserSettingsDialog open>
             <UserSettingsItem text="Setting">

--- a/packages/fiori/src/UserSettingsDialogTemplate.tsx
+++ b/packages/fiori/src/UserSettingsDialogTemplate.tsx
@@ -25,7 +25,7 @@ export default function UserSettingsDialogTemplate(this: UserSettingsDialog) {
 			initialFocus={`setting-${this._selectedSetting?._id}`}
 		>
 			<div class="ui5-user-settings-root">
-				<div class="ui5-user-settings-side" data-sap-ui-fastnavgroup="true" aria-orientation="vertical" aria-roledescription={this.ariaRoleDescList}>
+				<div class="ui5-user-settings-side" data-sap-ui-fastnavgroup="true" aria-roledescription={this.ariaRoleDescList}>
 					<div class="ui5-user-settings-side-header">
 						{this.headerText &&
 							<Title level="H1" size="H5">{this.headerText}</Title>


### PR DESCRIPTION
This change removed the unsupported aria-orientation="vertical" from the .ui5-user-settings-side div. That attribute is only valid on elements with roles like scrollbar, slider, separator, or composite widgets (listbox, menu, tablist, etc.); a plain div with no role doesn't support it.
