### PR TITLE
ci(release): build cypress-ct deps from root

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -457,9 +457,10 @@ jobs:
       - name: Install Dependencies
         run: yarn --immutable
 
+      # Build from root so workspace deps (e.g. @ui5/webcomponents-base)
+      # produce their dist/ that packages/cypress-ct-ui5-webc compiles against.
       - name: Build
-        run: yarn build
-        working-directory: packages/cypress-ct-ui5-webc
+        run: yarn ci:releasebuild
 
       - name: Publish
         run: npm publish --provenance --access public


### PR DESCRIPTION
## Problem

The `cypress-ct-release` job added in #13917 fails at the Build step:

```
error TS2307: Cannot find module '@ui5/webcomponents-base/dist/thirdparty/preact/preact.module.js'
```

`packages/cypress-ct-ui5-webc` compiles against `@ui5/webcomponents-base/dist`, which only exists after a workspace build. The job ran `yarn build` **inside the package folder**, so `tsc` had no base `dist/` to resolve against.

## Fix

Build from **root** with `yarn ci:releasebuild` (same as the stable/rc jobs) so `@ui5/webcomponents-base` produces its `dist/` first. The publish step stays in the package folder; cypress-ct's own `prepublishOnly` (`yarn build`) then runs its `tsc` during `npm publish`, and the base import resolves.

Follow-up to #13917.