### PR TITLE
fix(ui5-search-item-show-more, localization): correct property type and suppress overlay logs

### DIFF
--- a/packages/fiori/src/SearchItemShowMore.ts
+++ b/packages/fiori/src/SearchItemShowMore.ts
@@ -68,8 +68,8 @@ If a number is provided, it displays "Show more (N)", where N is that number.
 	 * @public
 	 * @default undefined
 	 */
-	@property()
-	itemsToShowCount ?: number;
+	@property({ type: Number })
+	itemsToShowCount?: number;
 
 	/**
 	 * Defines whether the show more item is selected.

--- a/packages/localization/overlay/sap/base/Log.js
+++ b/packages/localization/overlay/sap/base/Log.js
@@ -1,5 +1,10 @@
 sap.ui.define([], function() {
 	const Log = console;
-	Log.warning = console.warn;
+
+	// Log.fatal = console.error;
+	// Log.warning = console.warn;
+	Log.fatal = function() {};
+	Log.warning = function() {};
+
 	return Log;
 });


### PR DESCRIPTION
- Add `{ type: Number }` to `@property` decorator for itemsToShowCount to fix incorrect property type warning
- Replace Log.fatal/Log.warning with no-op functions in the sap/base/Log overlay to suppress unneeded console output in production