### PR TITLE
fix(ui5-input): use element root node for form lookup

### DIFF
--- a/packages/base/src/features/InputElementsFormSupport.ts
+++ b/packages/base/src/features/InputElementsFormSupport.ts
@@ -17,7 +17,8 @@ const getAssociatedForm = (element: UI5Element): HTMLFormElement | null => {
 	const formAttribute = element.getAttribute("form");
 
 	if (formAttribute) {
-		const form = document.getElementById(formAttribute);
+		const rootNode = element.getRootNode() as Document | ShadowRoot;
+		const form = rootNode.getElementById?.(formAttribute) || document.getElementById(formAttribute);
 		return form instanceof HTMLFormElement ? form : null;
 	}
 


### PR DESCRIPTION
## Description
The `getAssociatedForm` function in `InputElementsFormSupport.ts` was using `document.getElementById` directly, which fails when the web component is inside a shadow DOM or a different document context (e.g., iframes, micro-frontends).

## Fix
Now uses `element.getRootNode()` to get the proper document context where the web component lives, with a fallback to `document.getElementById` for compatibility.

This follows the same pattern used elsewhere in the codebase (e.g., `Popup.ts`, `AccessibilityTextsHelper.ts`, `Label.ts`).

## Related
Follow-up to #13321