### PR TITLE
chore(ui5-user-settings-dialog): import F6Navigation in website samples

### DIFF
--- a/packages/fiori/cypress/specs/UserSettingsDialog.cy.tsx
+++ b/packages/fiori/cypress/specs/UserSettingsDialog.cy.tsx
@@ -1511,22 +1511,14 @@ describe("F6 Navigation", () => {
             .should("have.attr", "data-sap-ui-fastnavgroup", "true");
     });
 
-    it("F6 navigation when dialog opened programmatically", () => {
-        cy.mount(<>
-            <Button id="open-btn">Open Settings</Button>
-            <UserSettingsDialog id="settings-dialog">
-                <UserSettingsItem text="Setting" selected>
-                    <UserSettingsView>
-                        <Button id="content-btn">Content</Button>
-                    </UserSettingsView>
-                </UserSettingsItem>
-            </UserSettingsDialog>
-        </>);
-
-        cy.get("#open-btn").realClick();
-        cy.get("[ui5-user-settings-dialog]").then($el => {
-            ($el[0] as any).open = true;
-        });
+    it("F6 navigation", () => {
+        cy.mount(<UserSettingsDialog open>
+            <UserSettingsItem text="Setting" selected>
+                <UserSettingsView>
+                    <Button id="content-btn">Content</Button>
+                </UserSettingsView>
+            </UserSettingsItem>
+        </UserSettingsDialog>);
 
         // Initial focus: side panel (first list item)
         cy.get("[ui5-user-settings-dialog]").shadow()
@@ -1537,14 +1529,30 @@ describe("F6 Navigation", () => {
         cy.realPress("F6");
         cy.get("#content-btn").should("be.focused");
 
-        // F6: content → footer
+        // F6: content → footer (Close button)
         cy.realPress("F6");
         cy.get("[ui5-user-settings-dialog]").shadow()
             .find("[ui5-toolbar-button]")
             .should("be.focused");
 
-        // F6: footer → side (wraps)
+        // F6: footer → side (wraps, focus stays inside dialog)
         cy.realPress("F6");
+        cy.get("[ui5-user-settings-dialog]").shadow()
+            .find("[ui5-li]").first()
+            .should("be.focused");
+
+        // Shift+F6: side → footer (wraps backward)
+        cy.realPress(["Shift", "F6"]);
+        cy.get("[ui5-user-settings-dialog]").shadow()
+            .find("[ui5-toolbar-button]")
+            .should("be.focused");
+
+        // Shift+F6: footer → content
+        cy.realPress(["Shift", "F6"]);
+        cy.get("#content-btn").should("be.focused");
+
+        // Shift+F6: content → side (back to starting point)
+        cy.realPress(["Shift", "F6"]);
         cy.get("[ui5-user-settings-dialog]").shadow()
             .find("[ui5-li]").first()
             .should("be.focused");

--- a/packages/fiori/cypress/specs/UserSettingsDialog.cy.tsx
+++ b/packages/fiori/cypress/specs/UserSettingsDialog.cy.tsx
@@ -1511,14 +1511,22 @@ describe("F6 Navigation", () => {
             .should("have.attr", "data-sap-ui-fastnavgroup", "true");
     });
 
-    it("F6 navigation", () => {
-        cy.mount(<UserSettingsDialog open>
-            <UserSettingsItem text="Setting" selected>
-                <UserSettingsView>
-                    <Button id="content-btn">Content</Button>
-                </UserSettingsView>
-            </UserSettingsItem>
-        </UserSettingsDialog>);
+    it("F6 navigation when dialog opened programmatically", () => {
+        cy.mount(<>
+            <Button id="open-btn">Open Settings</Button>
+            <UserSettingsDialog id="settings-dialog">
+                <UserSettingsItem text="Setting" selected>
+                    <UserSettingsView>
+                        <Button id="content-btn">Content</Button>
+                    </UserSettingsView>
+                </UserSettingsItem>
+            </UserSettingsDialog>
+        </>);
+
+        cy.get("#open-btn").realClick();
+        cy.get("[ui5-user-settings-dialog]").then($el => {
+            ($el[0] as any).open = true;
+        });
 
         // Initial focus: side panel (first list item)
         cy.get("[ui5-user-settings-dialog]").shadow()
@@ -1529,30 +1537,14 @@ describe("F6 Navigation", () => {
         cy.realPress("F6");
         cy.get("#content-btn").should("be.focused");
 
-        // F6: content → footer (Close button)
+        // F6: content → footer
         cy.realPress("F6");
         cy.get("[ui5-user-settings-dialog]").shadow()
             .find("[ui5-toolbar-button]")
             .should("be.focused");
 
-        // F6: footer → side (wraps, focus stays inside dialog)
+        // F6: footer → side (wraps)
         cy.realPress("F6");
-        cy.get("[ui5-user-settings-dialog]").shadow()
-            .find("[ui5-li]").first()
-            .should("be.focused");
-
-        // Shift+F6: side → footer (wraps backward)
-        cy.realPress(["Shift", "F6"]);
-        cy.get("[ui5-user-settings-dialog]").shadow()
-            .find("[ui5-toolbar-button]")
-            .should("be.focused");
-
-        // Shift+F6: footer → content
-        cy.realPress(["Shift", "F6"]);
-        cy.get("#content-btn").should("be.focused");
-
-        // Shift+F6: content → side (back to starting point)
-        cy.realPress(["Shift", "F6"]);
         cy.get("[ui5-user-settings-dialog]").shadow()
             .find("[ui5-li]").first()
             .should("be.focused");

--- a/packages/website/docs/_samples/fiori/UserSettingsDialog/Basic/main.js
+++ b/packages/website/docs/_samples/fiori/UserSettingsDialog/Basic/main.js
@@ -1,3 +1,4 @@
+import "@ui5/webcomponents-base/dist/features/F6Navigation.js";
 import "@ui5/webcomponents-fiori/dist/UserSettingsAccountView.js";
 import "@ui5/webcomponents-fiori/dist/UserSettingsAppearanceView.js";
 import "@ui5/webcomponents-fiori/dist/UserSettingsAppearanceViewItem.js";

--- a/packages/website/docs/_samples/fiori/UserSettingsDialog/Basic/sample.tsx
+++ b/packages/website/docs/_samples/fiori/UserSettingsDialog/Basic/sample.tsx
@@ -1,3 +1,4 @@
+import "@ui5/webcomponents-base/dist/features/F6Navigation.js";
 import createReactComponent from "@ui5/webcomponents-base/dist/createReactComponent.js";
 import { type UI5CustomEvent } from "@ui5/webcomponents-base";
 import { useRef, useCallback } from "react";

--- a/packages/website/docs/_samples/fiori/UserSettingsDialog/SaveMode/main.js
+++ b/packages/website/docs/_samples/fiori/UserSettingsDialog/SaveMode/main.js
@@ -1,3 +1,4 @@
+import "@ui5/webcomponents-base/dist/features/F6Navigation.js";
 import "@ui5/webcomponents-fiori/dist/UserSettingsAccountView.js";
 import "@ui5/webcomponents-fiori/dist/UserSettingsAppearanceView.js";
 import "@ui5/webcomponents-fiori/dist/UserSettingsAppearanceViewItem.js";

--- a/packages/website/docs/_samples/fiori/UserSettingsDialog/SaveMode/sample.tsx
+++ b/packages/website/docs/_samples/fiori/UserSettingsDialog/SaveMode/sample.tsx
@@ -1,3 +1,4 @@
+import "@ui5/webcomponents-base/dist/features/F6Navigation.js";
 import createReactComponent from "@ui5/webcomponents-base/dist/createReactComponent.js";
 import { type UI5CustomEvent } from "@ui5/webcomponents-base";
 import { useRef, useCallback } from "react";


### PR DESCRIPTION
Import `F6Navigation.js` in the `Basic` and `SaveMode` website samples for `UserSettingsDialog` so F6 group skipping works in the playground and website