### PR TITLE
fix(ui5-shellbar): align legacy logo styles with branding

### DIFF
--- a/packages/fiori/src/themes/ShellBarLegacy.css
+++ b/packages/fiori/src/themes/ShellBarLegacy.css
@@ -42,7 +42,9 @@
 }
 
 ::slotted([slot="logo"]) {
-	max-height: 2rem;
+	max-height: 1.875rem;
+	padding-block: 0.0625rem;
+	padding-inline: 0.25rem;
 }
 
 ::slotted([slot="logo"]):active {


### PR DESCRIPTION
The slotted logo rule in ShellBarLegacy.css drifted from ShellBarBranding.css after two upstream changes:

- refactor #13010 split ShellBar.css into features and did not carry the slotted-logo properties into the extracted legacy file.
- feat #13535 aligned ShellBarBranding.css with the Horizon VD spec (30px max-height, 1px padding-block, 4px padding-inline) but ShellBarLegacy.css was not updated.

As a result the logo rendered 2px taller than spec and the visual gap between logo and primary-title was 4px instead of the 8px used by <ui5-shellbar-branding>.

Bring the legacy rule in line with branding:

    ::slotted([slot="logo"]) {
        max-height: 1.875rem;
        padding-block: 0.0625rem;
        padding-inline: 0.25rem;
    }

vertical-align: middle from ShellBarBranding.css is intentionally omitted here: in the legacy shadow tree the logo's immediate parent is display: flex, so vertical-align has no effect on the img.

Fixes #12499 
