### PR TITLE
fix(cypress-ct-ui5-webc): add repository field for npm provenance

### DIFF
--- a/packages/cypress-ct-ui5-webc/package.json
+++ b/packages/cypress-ct-ui5-webc/package.json
@@ -3,6 +3,11 @@
   "version": "0.0.5",
   "description": "Custom framework definition adapter for Cypress Component Testing of UI5 Web Components",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/UI5/webcomponents.git",
+    "directory": "packages/cypress-ct-ui5-webc"
+  },
   "types": "./dist/index.d.ts",
   "exports": {
     "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Problem

Publishing `@ui5/cypress-ct-ui5-webc@0.0.5` failed with a `422 Unprocessable Entity` from the npm registry:

```
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@ui5%2fcypress-ct-ui5-webc
- Error verifying sigstore provenance bundle: Failed to validate repository information:
  package.json: "repository.url" is "", expected to match "https://github.com/UI5/webcomponents" from provenance
```

The package's `package.json` had **no `repository` field**. With provenance enabled, npm compares `repository.url` against the source repo recorded in the provenance statement; an empty value fails the match and the publish is rejected.

## Fix

Add a `repository` block matching the other published packages (`main`, `base`, `fiori`):

```json
"repository": {
  "type": "git",
  "url": "https://github.com/UI5/webcomponents.git",
  "directory": "packages/cypress-ct-ui5-webc"
}
```

## Note

Since `0.0.5` was already tagged/version-bumped but never published, a republish (new patch) will be needed after this merges.