### PR TITLE
fix(framework): ensure animation mode work

### DIFF
--- a/packages/base/cypress/specs/AnimationMode.cy.tsx
+++ b/packages/base/cypress/specs/AnimationMode.cy.tsx
@@ -1,0 +1,41 @@
+import { setAnimationMode } from "../../src/config/AnimationMode.js";
+import { duration } from "../../src/animations/animate.js";
+import { getComponentStyles } from "../../src/theming/componentStyles.js";
+import Generic from "../../test/test-elements/Generic.js";
+
+describe("AnimationMode - duration", () => {
+	it("is 0 when animation mode is none", () => {
+		cy.wrap({ setAnimationMode }).invoke("setAnimationMode", "none");
+
+		cy.wrap({ duration }).invoke("duration").should("equal", 0);
+	});
+
+	it("is 400 when animation mode is full", () => {
+		cy.wrap({ setAnimationMode }).invoke("setAnimationMode", "full");
+
+		cy.wrap({ duration }).invoke("duration").should("equal", 400);
+	});
+});
+
+describe("AnimationMode - CommonStyles", () => {
+	it("common styles sheet exists in the shadow root of a component", () => {
+		cy.mount(<Generic />);
+
+		cy.get("[ui5-test-generic]").shadow().should($shadow => {
+			const shadowRoot = $shadow[0].getRootNode() as ShadowRoot;
+			const componentStylesSheet = getComponentStyles();
+			expect(shadowRoot.adoptedStyleSheets).to.include(componentStylesSheet);
+			expect(componentStylesSheet.cssRules).not.be.empty;
+		});
+	});
+
+	it("common styles sheet contains the animation-mode rule", () => {
+		cy.mount(<Generic />);
+
+		cy.wrap(null).should(() => {
+			const sheet = getComponentStyles();
+			const rules = Array.from(sheet.cssRules).map(r => r.cssText);
+			expect(rules.some(r => r.includes("--_ui5-animation-mode"))).to.be.true;
+		})
+	});
+});

--- a/packages/base/cypress/specs/ConfigurationChange.cy.tsx
+++ b/packages/base/cypress/specs/ConfigurationChange.cy.tsx
@@ -2,6 +2,7 @@ import "../../test/test-elements/Accessor.js";
 import { setTheme, getTheme } from "../../src/config/Theme.js";
 import { setThemeRoot, getThemeRoot } from "../../src/config/ThemeRoot.js";
 import { setNoConflict, getNoConflict } from "../../src/config/NoConflict.js";
+import { setAnimationMode, getAnimationMode } from "../../src/config/AnimationMode.js";
 
 describe("Some configuration options can be changed at runtime", () => {
 	it("Tests that theme can be changed", () => {
@@ -236,5 +237,26 @@ describe("ThemeRoot validation at runtime", () => {
 						.and("include", "https://any-wildcard-domain.com/themes/UI5/Base/baseLib/");
 				});
 		});
+	});
+});
+
+describe("AnimationMode CSS variable", () => {
+	const getCSSVar = () => {
+		return cy.window().then(win => {
+			return win.getComputedStyle(win.document.documentElement).getPropertyValue("--_ui5-animation-mode").trim();
+		});
+	};
+
+	it("sets the CSS variable on getAnimationMode", () => {
+		cy.wrap({ getAnimationMode }).invoke("getAnimationMode");
+		getCSSVar().should("not.be.empty");
+	});
+
+	it("updates the CSS variable when setAnimationMode is called", () => {
+		cy.wrap({ setAnimationMode }).invoke("setAnimationMode", "none");
+		getCSSVar().should("equal", "none");
+
+		cy.wrap({ setAnimationMode }).invoke("setAnimationMode", "full");
+		getCSSVar().should("equal", "full");
 	});
 });

--- a/packages/base/cypress/specs/ConfigurationScript.cy.tsx
+++ b/packages/base/cypress/specs/ConfigurationScript.cy.tsx
@@ -105,6 +105,11 @@ describe("Configuration script", () => {
 		cy.wrap({ getAnimationMode })
 			.invoke("getAnimationMode")
 			.should("equal", configurationObject.animationMode);
+
+		cy.window().should(win => {
+			const value = win.getComputedStyle(win.document.documentElement).getPropertyValue("--_ui5-animation-mode").trim();
+			expect(value).to.equal(configurationObject.animationMode);
+		});
 	});
 
 	it("getEnableDefaultTooltips", () => {

--- a/packages/base/cypress/specs/ConfigurationURL.cy.tsx
+++ b/packages/base/cypress/specs/ConfigurationURL.cy.tsx
@@ -50,6 +50,11 @@ describe("Some settings can be set via SAP UI URL params", () => {
 		cy.wrap({ getAnimationMode })
 			.invoke("getAnimationMode")
 			.should("equal", AnimationMode.Basic);
+
+		cy.window().should(win => {
+			const value = win.getComputedStyle(win.document.documentElement).getPropertyValue("--_ui5-animation-mode").trim();
+			expect(value).to.equal(AnimationMode.Basic);
+		});
 	});
 });
 
@@ -573,5 +578,10 @@ describe("URL parameters are ignored when ignoreUrlParams is set", () => {
 		cy.wrap({ getAnimationMode })
 			.invoke("getAnimationMode")
 			.should("equal", AnimationMode.Basic);
+
+		cy.window().should(win => {
+			const value = win.getComputedStyle(win.document.documentElement).getPropertyValue("--_ui5-animation-mode").trim();
+			expect(value).to.equal(AnimationMode.Basic);
+		});
 	});
 });

--- a/packages/base/src/animations/animate.ts
+++ b/packages/base/src/animations/animate.ts
@@ -1,3 +1,4 @@
+import { getAnimationMode } from "../config/AnimationMode.js";
 import AnimationQueue from "./AnimationQueue.js";
 
 type AnimateOptions = {
@@ -57,7 +58,8 @@ const animate = (options: AnimateOptions) => {
 		stop: () => stop,
 	};
 };
-const duration = 400;
+
+const duration = getAnimationMode() === "none" ? 0 : 400;
 
 export { duration };
 export type { AnimateOptions };

--- a/packages/base/src/animations/animate.ts
+++ b/packages/base/src/animations/animate.ts
@@ -59,7 +59,9 @@ const animate = (options: AnimateOptions) => {
 	};
 };
 
-const duration = getAnimationMode() === "none" ? 0 : 400;
+const duration = () => {
+	return getAnimationMode() === "none" ? 0 : 400;
+};
 
 export { duration };
 export type { AnimateOptions };

--- a/packages/base/src/animations/scroll.ts
+++ b/packages/base/src/animations/scroll.ts
@@ -9,7 +9,7 @@ const scroll = (element: HTMLElement, dx: number, dy: number) => {
 			scrollLeft = element.scrollLeft;
 			scrollTop = element.scrollTop;
 		},
-		duration,
+		duration: duration(),
 		element,
 		advance: progress => {
 			element.scrollLeft = scrollLeft + (progress * dx); // easing - linear

--- a/packages/base/src/animations/slideDown.ts
+++ b/packages/base/src/animations/slideDown.ts
@@ -42,7 +42,7 @@ const slideDown = (element: HTMLElement) => {
 			element.style.marginBottom = "0";
 			element.style.height = "0";
 		},
-		duration,
+		duration: duration(),
 		element,
 		advance: progress => {
 			// WORKAROUND

--- a/packages/base/src/animations/slideUp.ts
+++ b/packages/base/src/animations/slideUp.ts
@@ -38,7 +38,7 @@ const slideUp = (element: HTMLElement) => {
 
 			el.style.overflow = "hidden";
 		},
-		duration,
+		duration: duration(),
 		element,
 		advance: progress => {
 			element.style.paddingTop = `${paddingTop - (paddingTop * progress)}px`;

--- a/packages/base/src/config/AnimationMode.ts
+++ b/packages/base/src/config/AnimationMode.ts
@@ -1,8 +1,13 @@
 import { getAnimationMode as getConfiguredAnimationMode } from "../InitialConfiguration.js";
 import AnimationMode from "../types/AnimationMode.js";
 import { attachConfigurationReset } from "./ConfigurationReset.js";
+import { createOrUpdateStyle } from "../ManagedStyles.js";
 
 let curAnimationMode: `${AnimationMode}` | undefined;
+
+const applyAnimationMode = (animationMode: `${AnimationMode}`) => {
+	createOrUpdateStyle(`:root { --_ui5-animation-mode: ${animationMode}; }`, "data-ui5-animation-mode");
+};
 
 attachConfigurationReset(() => {
 	curAnimationMode = undefined;
@@ -16,6 +21,7 @@ attachConfigurationReset(() => {
 const getAnimationMode = (): `${AnimationMode}` => {
 	if (curAnimationMode === undefined) {
 		curAnimationMode = getConfiguredAnimationMode();
+		applyAnimationMode(curAnimationMode);
 	}
 
 	return curAnimationMode;
@@ -30,6 +36,7 @@ const setAnimationMode = (animationMode: `${AnimationMode}`) => {
 	const options: string[] = Object.values(AnimationMode);
 	if (options.includes(animationMode)) {
 		curAnimationMode = animationMode;
+		applyAnimationMode(curAnimationMode);
 	}
 };
 

--- a/packages/base/src/css/CommonStyles.css
+++ b/packages/base/src/css/CommonStyles.css
@@ -1,0 +1,6 @@
+@container style(--_ui5-animation-mode: none) {
+	* {
+		transition: none !important;
+		animation: none !important;
+	}
+}

--- a/packages/base/src/css/CommonStyles.css
+++ b/packages/base/src/css/CommonStyles.css
@@ -1,6 +1,6 @@
 @container style(--_ui5-animation-mode: none) {
 	* {
-		transition: none !important;
-		animation: none !important;
+		transition-duration: 0s !important;
+		animation-duration: 0s !important;
 	}
 }

--- a/packages/base/src/theming/componentStyles.ts
+++ b/packages/base/src/theming/componentStyles.ts
@@ -1,4 +1,9 @@
+import CommonStylesCss from "../generated/css/CommonStyles.css.js";
+
 const packageMap = new Map<string, string>();
+
+packageMap.set("ui5-common-component-styles", CommonStylesCss);
+
 let componentsStyleSheet: CSSStyleSheet;
 
 const getComponentStyles = () => {

--- a/packages/base/src/theming/componentStyles.ts
+++ b/packages/base/src/theming/componentStyles.ts
@@ -9,6 +9,7 @@ let componentsStyleSheet: CSSStyleSheet;
 const getComponentStyles = () => {
 	if (!componentsStyleSheet) {
 		componentsStyleSheet = new CSSStyleSheet();
+		componentsStyleSheet.replaceSync(Array.from(packageMap.values()).join("\n"));
 	}
 
 	return componentsStyleSheet;

--- a/packages/compat/cypress/specs/Table.cy.tsx
+++ b/packages/compat/cypress/specs/Table.cy.tsx
@@ -509,7 +509,6 @@ describe("Table general interaction", () => {
 		cy.get("@popinChange")
 			.should(stub => {
 				expect(stub).to.have.been.calledTwice;
-				debugger
 				// @ts-ignore
 				expect(stub.args.slice(-1)[0][0].detail.poppedColumns.length).to.equal(2);
 			})


### PR DESCRIPTION
- **Set `--_ui5-animation-mode` CSS variable on configuration** — `AnimationMode.ts` now calls `createOrUpdateStyle`
  (via `document.adoptedStyleSheets`) to keep `--_ui5-animation-mode` in sync with the configured animation mode, both
  on initial read and on every `setAnimationMode` call. Uses adopted stylesheets so the variable is not visible as an
  inline style in DevTools.
- **Add `CommonStyles.css` with animation suppression** — a new `@container style(--_ui5-animation-mode: none)` block
   sets `transition-duration` and `animation-duration` to `0s` on every element inside a component's shadow root when
  animation mode is `none`, ensuring animations complete instantly while preserving their end state.

- **Apply `CommonStyles` eagerly** — `getComponentStyles()` now populates the stylesheet immediately from the
  pre-loaded `packageMap` instead of waiting for `applyTheme` to call `updateComponentStyles`, so the animation
  suppression rule is active from the very first render.

- **Convert `duration` to a function** — `animate.ts` exports `duration` as `() => number` instead of a static
  constant, so it reflects the current animation mode at call time. Updated all consumers (`scroll.ts`, `slideDown.ts`,
   `slideUp.ts`).

## Test plan

  - [ ] `ConfigurationChange.cy.tsx` — verify `--_ui5-animation-mode` is set on `:root` and updates correctly via
  `setAnimationMode`
  - [ ] `ConfigurationScript.cy.tsx` — verify CSS variable matches the value from the config script
  - [ ] `ConfigurationURL.cy.tsx` — verify CSS variable matches the value from URL params and that script config takes
  precedence over URL
  - [ ] `AnimationMode.cy.tsx` — verify `duration()` returns `0` when mode is `none` and `400` otherwise; verify
  `CommonStyles` sheet is adopted into shadow roots and contains the `--_ui5-animation-mode` rule