### PR TITLE
fix(ui5-search-field): Align hover/active background with design spec

### DIFF
--- a/packages/fiori/src/themes/SearchField.css
+++ b/packages/fiori/src/themes/SearchField.css
@@ -45,6 +45,11 @@
 	background-color: var(--_ui5-search-wrapper-hover-background-color);
 }
 
+:host(:not([collapsed]):focus-within),
+.ui5-shellbar-search-field-wrapper:focus-within {
+	background-color: var(--_ui5-search-wrapper-active-background-color);
+}
+
 :host([focused-inner-input]) .ui5-search-field-root {
 	outline: var(--_ui5_search_wrapper_outline);
 	border-radius: var(--_ui5_search_input_border_radius);

--- a/packages/fiori/src/themes/base/SearchField-parameters.css
+++ b/packages/fiori/src/themes/base/SearchField-parameters.css
@@ -6,7 +6,8 @@
 	--_ui5-search-wrapper-background: var(--sapShell_InteractiveBackground);
 	--_ui5_search_separator_background: var(--sapShell_InteractiveBorderColor);
 	--_ui5-search-wrapper-hover-background: var(--sapField_Hover_BackgroundStyle);
-	--_ui5-search-wrapper-hover-background-color: var(--sapField_Hover_Background);
+	--_ui5-search-wrapper-hover-background-color: none;
+	--_ui5-search-wrapper-active-background-color: none;
 	--_ui5-search-elements-hover-background: none;
 	--_ui5-search-elements-active-background: none;
 	--_ui5_search_input_scope_margin: 0 0.125rem 0 .5rem;

--- a/packages/fiori/src/themes/sap_fiori_3/SearchField-parameters.css
+++ b/packages/fiori/src/themes/sap_fiori_3/SearchField-parameters.css
@@ -7,7 +7,6 @@
 	--_ui5-search-wrapper-background: var(--sapShellColor);
 	--_ui5_search_separator_background: none;
 	--_ui5-search-wrapper-hover-background: none;
-	--_ui5-search-wrapper-hover-background-color: none;
 	--_ui5_search_input_scope_margin: 0;
 	--_ui5-search_input_scope_hover_shadow: none;
 	--_ui5-search_input_scope_active_shadow: none;

--- a/packages/fiori/src/themes/sap_fiori_3_dark/SearchField-parameters.css
+++ b/packages/fiori/src/themes/sap_fiori_3_dark/SearchField-parameters.css
@@ -7,7 +7,6 @@
 	--_ui5-search-wrapper-background: var(--sapShellColor);
 	--_ui5_search_separator_background: none;
 	--_ui5-search-wrapper-hover-background: none;
-	--_ui5-search-wrapper-hover-background-color: none;
 	--_ui5_search_input_scope_margin: 0;
 	--_ui5-search_input_scope_hover_shadow: none;
 	--_ui5-search_input_scope_active_shadow: none;

--- a/packages/fiori/src/themes/sap_fiori_3_hcb/SearchField-parameters.css
+++ b/packages/fiori/src/themes/sap_fiori_3_hcb/SearchField-parameters.css
@@ -7,7 +7,6 @@
 	--_ui5-search-wrapper-background: var(--sapShellColor);
 	--_ui5_search_separator_background: none;
 	--_ui5-search-wrapper-hover-background: none;
-	--_ui5-search-wrapper-hover-background-color: none;
 	--_ui5_search_input_scope_margin: 0;
 	--_ui5-search_input_scope_hover_shadow: none;
 	--_ui5-search_input_scope_active_shadow: none;

--- a/packages/fiori/src/themes/sap_fiori_3_hcw/SearchField-parameters.css
+++ b/packages/fiori/src/themes/sap_fiori_3_hcw/SearchField-parameters.css
@@ -7,7 +7,6 @@
 	--_ui5-search-wrapper-background: var(--sapShellColor);
 	--_ui5_search_separator_background: none;
 	--_ui5-search-wrapper-hover-background: none;
-	--_ui5-search-wrapper-hover-background-color: none;
 	--_ui5_search_input_scope_margin: 0;
 	--_ui5-search_input_scope_hover_shadow: none;
 	--_ui5-search_input_scope_active_shadow: none;

--- a/packages/fiori/src/themes/sap_horizon/SearchField-parameters.css
+++ b/packages/fiori/src/themes/sap_horizon/SearchField-parameters.css
@@ -1,0 +1,6 @@
+@import "../base/SearchField-parameters.css";
+
+:host {
+	--_ui5-search-wrapper-hover-background-color: var(--sapShell_Hover_Background);
+	--_ui5-search-wrapper-active-background-color: var(--sapShell_Active_Background);
+}

--- a/packages/fiori/src/themes/sap_horizon/parameters-bundle.css
+++ b/packages/fiori/src/themes/sap_horizon/parameters-bundle.css
@@ -18,8 +18,7 @@
 @import "./FlexibleColumnLayout-parameters.css";
 @import "./MediaGallery-parameters.css";
 @import "../base/DynamicPage-parameters.css";
-@import "../base/SearchField-parameters.css";
-@import "../base/Search-parameters.css";
+@import "./SearchField-parameters.css";
 @import "../base/Search-parameters.css";
 @import "./DynamicPageTitle-parameters.css";
 @import "../base/DynamicPageHeader-parameters.css";

--- a/packages/fiori/src/themes/sap_horizon_dark/SearchField-parameters.css
+++ b/packages/fiori/src/themes/sap_horizon_dark/SearchField-parameters.css
@@ -1,0 +1,6 @@
+@import "../base/SearchField-parameters.css";
+
+:host {
+	--_ui5-search-wrapper-hover-background-color: var(--sapShell_Hover_Background);
+	--_ui5-search-wrapper-active-background-color: var(--sapShell_Active_Background);
+}

--- a/packages/fiori/src/themes/sap_horizon_dark/parameters-bundle.css
+++ b/packages/fiori/src/themes/sap_horizon_dark/parameters-bundle.css
@@ -8,7 +8,7 @@
 @import "./ProductSwitchItem-parameters.css";
 @import "../base/ShellBar-parameters.css";
 @import "./ShellBar-parameters.css";
-@import "../base/SearchField-parameters.css";
+@import "./SearchField-parameters.css";
 @import "../base/Search-parameters.css";
 @import "./TimelineItem-parameters.css";
 @import "./SideNavigation-parameters.css";

--- a/packages/fiori/src/themes/sap_horizon_hcb/SearchField-parameters.css
+++ b/packages/fiori/src/themes/sap_horizon_hcb/SearchField-parameters.css
@@ -7,7 +7,6 @@
 	--_ui5-search-wrapper-background: none;
 	--_ui5_search_separator_background: none;
 	--_ui5-search-wrapper-hover-background: none;
-	--_ui5-search-wrapper-hover-background-color: none;
 	--_ui5_search_input_scope_margin: 0;
 	--_ui5-search_input_scope_hover_shadow: none;
 	--_ui5-search_input_scope_active_shadow: none;

--- a/packages/fiori/src/themes/sap_horizon_hcw/SearchField-parameters.css
+++ b/packages/fiori/src/themes/sap_horizon_hcw/SearchField-parameters.css
@@ -7,7 +7,6 @@
 	--_ui5-search-wrapper-background: none;
 	--_ui5_search_separator_background: none;
 	--_ui5-search-wrapper-hover-background: none;
-	--_ui5-search-wrapper-hover-background-color: none;
 	--_ui5_search_input_scope_margin: 0;
 	--_ui5-search_input_scope_hover_shadow: none;
 	--_ui5-search_input_scope_active_shadow: none;


### PR DESCRIPTION
  Changes:
  - Set the hover through `sapShell_Hover_Background` and add  `sapShell_Active_Background` for the active state