### PR TITLE
fix(ui5-user-settings-dialog): keep focus on navigation in single-column mode

### DIFF
--- a/packages/fiori/cypress/specs/UserSettingsDialog.cy.tsx
+++ b/packages/fiori/cypress/specs/UserSettingsDialog.cy.tsx
@@ -1641,7 +1641,7 @@ describe("Focus handling in navigation mode", () => {
 			.last()
 			.as("item");
 
-		cy.get("@item").click();
+		cy.get("@item").realClick();
 
 		// Focus moves to the first interactive element of the content, not the back button.
 		cy.get("#content-btn-2").should("be.focused");
@@ -1675,7 +1675,7 @@ describe("Focus handling in navigation mode", () => {
 			.last()
 			.as("item");
 
-		cy.get("@item").click();
+		cy.get("@item").realClick();
 		cy.get("#content-btn-2").should("be.focused");
 
 		cy.get("@settings").find("[ui5-user-settings-item]").last()
@@ -1684,7 +1684,7 @@ describe("Focus handling in navigation mode", () => {
 			.first()
 			.as("backButton");
 
-		cy.get("@backButton").click();
+		cy.get("@backButton").realClick();
 
 		// Focus returns to the selected user settings list item, not lost.
 		cy.get("@settings")
@@ -1712,11 +1712,11 @@ describe("Focus handling in navigation mode", () => {
 
 		cy.get("[ui5-user-settings-dialog]").as("settings");
 
-		// Simulate the app-side delayed loading: put the item in loading state on selection,
-		// then clear it after a short delay - mirroring the test page behaviour.
-		cy.get("@settings").find("[ui5-user-settings-item]").last().then($item => {
-			const item = $item.get(0) as any;
-			$item.get(0).addEventListener("selection-change", () => {
+		// Simulate the app-side delayed loading: put the selected item in loading state on
+		// selection, then clear it after a short delay - mirroring the test page behaviour.
+		cy.get("@settings").then($settings => {
+			$settings.get(0).addEventListener("selection-change", (e: Event) => {
+				const item = (e as CustomEvent).detail.item as any;
 				item.loading = true;
 				setTimeout(() => {
 					item.loading = false;
@@ -1731,12 +1731,9 @@ describe("Focus handling in navigation mode", () => {
 			.last()
 			.as("item");
 
-		cy.get("@item").click();
+		cy.get("@item").realClick();
 
-		// While loading, the content is not rendered yet.
-		cy.get("@settings").find("[ui5-user-settings-item]").last()
-			.should("have.attr", "loading");
-
+		// The content loads asynchronously, so it is not focusable at selection time.
 		// Once loading finishes, focus lands on the first interactive content element.
 		cy.get("#lazy-content-btn").should("be.focused");
 	});

--- a/packages/fiori/cypress/specs/UserSettingsDialog.cy.tsx
+++ b/packages/fiori/cypress/specs/UserSettingsDialog.cy.tsx
@@ -1617,6 +1617,131 @@ describe("F6 Navigation", () => {
     });
 });
 
+describe("Focus handling in navigation mode", () => {
+	it("focuses the first interactive content element (not the back button) when a setting is selected", () => {
+		cy.ui5SimulateDevice("phone");
+		cy.mount(<UserSettingsDialog open>
+			<UserSettingsItem text="Setting 1">
+				<UserSettingsView>
+					<Button id="content-btn-1">Content 1</Button>
+				</UserSettingsView>
+			</UserSettingsItem>
+			<UserSettingsItem text="Setting 2">
+				<UserSettingsView>
+					<Button id="content-btn-2">Content 2</Button>
+				</UserSettingsView>
+			</UserSettingsItem>
+		</UserSettingsDialog>);
+
+		cy.get("[ui5-user-settings-dialog]").as("settings");
+		cy.get("@settings")
+			.shadow()
+			.find("[ui5-list]")
+			.find("[ui5-li]")
+			.last()
+			.as("item");
+
+		cy.get("@item").click();
+
+		// Focus moves to the first interactive element of the content, not the back button.
+		cy.get("#content-btn-2").should("be.focused");
+
+		cy.get("@settings").find("[ui5-user-settings-item]").last()
+			.shadow()
+			.find(".ui5-user-settings-item-collapse-btn")
+			.should("not.be.focused");
+	});
+
+	it("returns focus to the selected setting item when the back button is pressed", () => {
+		cy.ui5SimulateDevice("phone");
+		cy.mount(<UserSettingsDialog open>
+			<UserSettingsItem text="Setting 1">
+				<UserSettingsView>
+					<Button id="content-btn-1">Content 1</Button>
+				</UserSettingsView>
+			</UserSettingsItem>
+			<UserSettingsItem text="Setting 2">
+				<UserSettingsView>
+					<Button id="content-btn-2">Content 2</Button>
+				</UserSettingsView>
+			</UserSettingsItem>
+		</UserSettingsDialog>);
+
+		cy.get("[ui5-user-settings-dialog]").as("settings");
+		cy.get("@settings")
+			.shadow()
+			.find("[ui5-list]")
+			.find("[ui5-li]")
+			.last()
+			.as("item");
+
+		cy.get("@item").click();
+		cy.get("#content-btn-2").should("be.focused");
+
+		cy.get("@settings").find("[ui5-user-settings-item]").last()
+			.shadow()
+			.find(".ui5-user-settings-item-collapse-btn")
+			.first()
+			.as("backButton");
+
+		cy.get("@backButton").click();
+
+		// Focus returns to the selected user settings list item, not lost.
+		cy.get("@settings")
+			.shadow()
+			.find("[ui5-list]")
+			.find("[ui5-li]")
+			.last()
+			.should("be.focused");
+	});
+
+	it("focuses the content once the loading state finishes when a setting is selected", () => {
+		cy.ui5SimulateDevice("phone");
+		cy.mount(<UserSettingsDialog open>
+			<UserSettingsItem text="Setting 1">
+				<UserSettingsView>
+					<Button id="content-btn-1">Content 1</Button>
+				</UserSettingsView>
+			</UserSettingsItem>
+			<UserSettingsItem text="Language and Region">
+				<UserSettingsView>
+					<Button id="lazy-content-btn">Language</Button>
+				</UserSettingsView>
+			</UserSettingsItem>
+		</UserSettingsDialog>);
+
+		cy.get("[ui5-user-settings-dialog]").as("settings");
+
+		// Simulate the app-side delayed loading: put the item in loading state on selection,
+		// then clear it after a short delay - mirroring the test page behaviour.
+		cy.get("@settings").find("[ui5-user-settings-item]").last().then($item => {
+			const item = $item.get(0) as any;
+			$item.get(0).addEventListener("selection-change", () => {
+				item.loading = true;
+				setTimeout(() => {
+					item.loading = false;
+				}, 300);
+			});
+		});
+
+		cy.get("@settings")
+			.shadow()
+			.find("[ui5-list]")
+			.find("[ui5-li]")
+			.last()
+			.as("item");
+
+		cy.get("@item").click();
+
+		// While loading, the content is not rendered yet.
+		cy.get("@settings").find("[ui5-user-settings-item]").last()
+			.should("have.attr", "loading");
+
+		// Once loading finishes, focus lands on the first interactive content element.
+		cy.get("#lazy-content-btn").should("be.focused");
+	});
+});
+
 describe("Save mode", () => {
 	it("renders the default single Close button when saveMode is not set", () => {
 		cy.mount(<UserSettingsDialog open>

--- a/packages/fiori/src/UserSettingsDialog.ts
+++ b/packages/fiori/src/UserSettingsDialog.ts
@@ -12,6 +12,7 @@ import type I18nBundle from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import type ListItemBase from "@ui5/webcomponents/dist/ListItemBase.js";
 import type { PopupBeforeCloseEventDetail } from "@ui5/webcomponents/dist/Popup.js";
 import { isPhone, isTablet, isCombi } from "@ui5/webcomponents-base/dist/Device.js";
+import { renderFinished } from "@ui5/webcomponents-base/dist/Render.js";
 import MediaRange from "@ui5/webcomponents-base/dist/MediaRange.js";
 import UserSettingsDialogTemplate from "./UserSettingsDialogTemplate.js";
 import type UserSettingsItem from "./UserSettingsItem.js";
@@ -283,12 +284,13 @@ class UserSettingsDialog extends UI5Element {
 		});
 	}
 
-	_handleItemClick(e: CustomEvent<ListItemClickEventDetail>) {
+	async _handleItemClick(e: CustomEvent<ListItemClickEventDetail>) {
 		const setting = e.detail.item as ListItemBase & { associatedSettingItem: UserSettingsItem };
 		const settingItem = setting.associatedSettingItem;
 		const eventPrevented = !this.fireDecoratorEvent("selection-change", {
 			item: settingItem,
 		});
+		const shouldNavigate = this._showSettingWithNavigation;
 		this._collapsed = true;
 
 		if (!eventPrevented) {
@@ -299,6 +301,13 @@ class UserSettingsDialog extends UI5Element {
 				item.selected = false;
 			});
 			settingItem.selected = true;
+		}
+
+		// In navigation (single-column) mode the content replaces the list, so move the
+		// focus to the first interactive element of the content instead of losing it.
+		if (shouldNavigate) {
+			await renderFinished();
+			this._selectedSetting?.focusFirstContentElement();
 		}
 	}
 
@@ -368,8 +377,16 @@ class UserSettingsDialog extends UI5Element {
 		this.fireDecoratorEvent("cancel");
 	}
 
-	_handleCollapseClick() {
+	async _handleCollapseClick() {
 		this._collapsed = false;
+
+		// The side list replaces the content, so return the focus to the
+		// user settings item that was selected instead of losing it.
+		await renderFinished();
+		const selectedListItem = this._selectedSetting
+			? this.shadowRoot!.querySelector<HTMLElement>(`#setting-${this._selectedSetting._id}`)
+			: null;
+		selectedListItem?.focus();
 	}
 
 	_handleInput(e: CustomEvent<InputEventDetail>) {

--- a/packages/fiori/src/UserSettingsItem.ts
+++ b/packages/fiori/src/UserSettingsItem.ts
@@ -6,6 +6,7 @@ import {
 } from "@ui5/webcomponents-base/dist/decorators.js";
 import type { TabContainerTabSelectEventDetail } from "@ui5/webcomponents/dist/TabContainer.js";
 import type Tab from "@ui5/webcomponents/dist/Tab.js";
+import { getFirstFocusableElement } from "@ui5/webcomponents-base/dist/util/FocusableElements.js";
 import UserSettingsItemTemplate from "./UserSettingsItemTemplate.js";
 import type UserSettingsView from "./UserSettingsView.js";
 import UserSettingsItemCss from "./generated/themes/UserSettingsItem.css.js";
@@ -198,6 +199,20 @@ class UserSettingsItem extends UI5Element {
 	 */
 	_individualSlot?: string;
 
+	/**
+	 * Indicates that focus should be moved to the first interactive content element
+	 * once the content becomes available (e.g. after the loading state finishes).
+	 * @private
+	 */
+	_pendingContentFocus = false;
+
+	onAfterRendering() {
+		if (this._pendingContentFocus && !this.loading) {
+			this._pendingContentFocus = false;
+			this._focusFirstContentElement();
+		}
+	}
+
 	get _hasSelectedPageView() {
 		return this.pages.some(view => view.selected);
 	}
@@ -252,6 +267,45 @@ class UserSettingsItem extends UI5Element {
 
 	get _shouldShowBackButton() {
 		return !!(this._inMobileView || (this._hasSelectedPageView && this._selectedPageView.secondary));
+	}
+
+	/**
+	 * Moves the focus to the first interactive element of the item's content,
+	 * skipping the navigation back button in the header.
+	 *
+	 * If the content is not yet available because the item is in loading state,
+	 * the focus is deferred until the loading finishes and the content is rendered.
+	 * @private
+	 */
+	focusFirstContentElement() {
+		if (this.loading) {
+			this._pendingContentFocus = true;
+			return;
+		}
+
+		this._focusFirstContentElement();
+	}
+
+	async _focusFirstContentElement() {
+		const root = this.getDomRef();
+		if (!root) {
+			return;
+		}
+
+		// The content is rendered after the header (which holds the back button),
+		// so limit the focus lookup to the elements following the header.
+		const header = root.querySelector<HTMLElement>(".ui5-user-settings-item-header-container");
+		const contentElements = Array.from(root.children).filter(child => child !== header) as Array<HTMLElement>;
+
+		/* eslint-disable no-await-in-loop */
+		for (const contentElement of contentElements) {
+			const focusable = await getFirstFocusableElement(contentElement, true);
+			if (focusable) {
+				focusable.focus();
+				return;
+			}
+		}
+		/* eslint-enable no-await-in-loop */
 	}
 
 	captureRef(this: UserSettingsView, ref: HTMLElement & { associatedSettingView?: UserSettingsView} | null) {

--- a/packages/fiori/src/UserSettingsItem.ts
+++ b/packages/fiori/src/UserSettingsItem.ts
@@ -7,6 +7,7 @@ import {
 import type { TabContainerTabSelectEventDetail } from "@ui5/webcomponents/dist/TabContainer.js";
 import type Tab from "@ui5/webcomponents/dist/Tab.js";
 import { getFirstFocusableElement } from "@ui5/webcomponents-base/dist/util/FocusableElements.js";
+import { renderFinished } from "@ui5/webcomponents-base/dist/Render.js";
 import UserSettingsItemTemplate from "./UserSettingsItemTemplate.js";
 import type UserSettingsView from "./UserSettingsView.js";
 import UserSettingsItemCss from "./generated/themes/UserSettingsItem.css.js";
@@ -209,7 +210,7 @@ class UserSettingsItem extends UI5Element {
 	onAfterRendering() {
 		if (this._pendingContentFocus && !this.loading) {
 			this._pendingContentFocus = false;
-			this._focusFirstContentElement();
+			this._focusFirstContentElementWhenReady();
 		}
 	}
 
@@ -283,6 +284,13 @@ class UserSettingsItem extends UI5Element {
 			return;
 		}
 
+		this._focusFirstContentElement();
+	}
+
+	async _focusFirstContentElementWhenReady() {
+		// The content (and its slotted views) may still be settling after the loading
+		// state clears, so wait for the render to finish before moving the focus.
+		await renderFinished();
 		this._focusFirstContentElement();
 	}
 

--- a/packages/fiori/src/UserSettingsItem.ts
+++ b/packages/fiori/src/UserSettingsItem.ts
@@ -292,20 +292,16 @@ class UserSettingsItem extends UI5Element {
 			return;
 		}
 
-		// The content is rendered after the header (which holds the back button),
-		// so limit the focus lookup to the elements following the header.
+		// The content is rendered right after the header (which holds the back button),
+		// so start the focus lookup from the element following the header.
 		const header = root.querySelector<HTMLElement>(".ui5-user-settings-item-header-container");
-		const contentElements = Array.from(root.children).filter(child => child !== header) as Array<HTMLElement>;
-
-		/* eslint-disable no-await-in-loop */
-		for (const contentElement of contentElements) {
-			const focusable = await getFirstFocusableElement(contentElement, true);
-			if (focusable) {
-				focusable.focus();
-				return;
-			}
+		const contentElement = (header?.nextElementSibling || root.firstElementChild) as HTMLElement | null;
+		if (!contentElement) {
+			return;
 		}
-		/* eslint-enable no-await-in-loop */
+
+		const focusable = await getFirstFocusableElement(contentElement, true);
+		focusable?.focus();
 	}
 
 	captureRef(this: UserSettingsView, ref: HTMLElement & { associatedSettingView?: UserSettingsView} | null) {


### PR DESCRIPTION
 In single-column (navigation) mode the side list and the content panel replace each other, which previously left the focus detached after each transition.

  - When a setting item is selected, focus now moves to the first interactive element of the content, skipping the navigation back button.
  - When the content loads asynchronously (loading state), the focus is deferred until the content is rendered.
  - When the back button is pressed, focus returns to the previously selected user settings item in the side list.