### PR TITLE
fix(ui5-shellbar-search): add label spacing

### DIFF
--- a/packages/fiori/src/themes/SearchField.css
+++ b/packages/fiori/src/themes/SearchField.css
@@ -294,6 +294,11 @@
 	--_ui5_input_focus_border_radius: var(--_ui5_search_input_border_radius);
 }
 
+.ui5-search-field-select::part(label) {
+	padding: 0 .25rem 0 .5rem;
+}
+
+
 .ui5-search-field-select::part(icon-wrapper) {
 	border-radius: var(--_ui5_search_input_border_radius);
 	height: 100%;


### PR DESCRIPTION
Add 0.25rem (4px) spacing from scope label to the scope dropdown arrow.