### PR TITLE
fix(ui5-cb-item-group): expose 'title' CSS shadow part via exportparts

### DIFF
--- a/packages/fiori/src/SearchItemGroup.ts
+++ b/packages/fiori/src/SearchItemGroup.ts
@@ -13,6 +13,8 @@ import WrappingType from "@ui5/webcomponents/dist/types/WrappingType.js";
  * @public
  * @since 2.9.0
  * @experimental
+ * @csspart header - Used to style the header item of the group
+ * @csspart title - Used to style the title of the group header
  */
 @customElement({
 	tag: "ui5-search-item-group",

--- a/packages/fiori/src/UserSettingsAppearanceViewGroup.ts
+++ b/packages/fiori/src/UserSettingsAppearanceViewGroup.ts
@@ -20,6 +20,8 @@ import type { DefaultSlot } from "@ui5/webcomponents-base/dist/UI5Element.js";
  * @extends ListItemGroup
  * @public
  * @since 2.17.0
+ * @csspart header - Used to style the header item of the group
+ * @csspart title - Used to style the title of the group header
  */
 @customElement({
 	tag: "ui5-user-settings-appearance-view-group",

--- a/packages/main/src/ComboBoxItemGroup.ts
+++ b/packages/main/src/ComboBoxItemGroup.ts
@@ -17,6 +17,8 @@ import ComboBoxItemGroupTemplate from "./ComboBoxItemGroupTemplate.js";
  * @public
  * @implements {IComboBoxItem}
  * @since 1.0.0-rc.15
+ * @csspart header - Used to style the header item of the group
+ * @csspart title - Used to style the title of the group header
  */
 @customElement({
 	tag: "ui5-cb-item-group",

--- a/packages/main/src/ListBoxItemGroupTemplate.tsx
+++ b/packages/main/src/ListBoxItemGroupTemplate.tsx
@@ -15,7 +15,7 @@ export default function ListItemGroupTemplate(this: ListItemGroup, hooks?: { ite
 			onDragLeave={this._ondragleave}
 		>
 			{this.hasHeader &&
-				<ListItemGroupHeader focused={this.focused} part="header" accessibleRole="Group" wrappingType={this.getGroupHeaderWrapping()} >
+				<ListItemGroupHeader focused={this.focused} part="header" exportparts="title" accessibleRole="Group" wrappingType={this.getGroupHeaderWrapping()} >
 					{ this.hasFormattedHeader ? <slot name="header"></slot> : this.headerText }
 				</ListItemGroupHeader>
 			}

--- a/packages/main/src/MultiComboBoxItemGroup.ts
+++ b/packages/main/src/MultiComboBoxItemGroup.ts
@@ -17,6 +17,8 @@ import ComboBoxItemGroup from "./ComboBoxItemGroup.js";
  * @public
  * @implements {IMultiComboBoxItem}
  * @since 2.0.0
+ * @csspart header - Used to style the header item of the group
+ * @csspart title - Used to style the title of the group header
  */
 @customElement({
 	tag: "ui5-mcb-item-group",

--- a/packages/main/src/SuggestionItemGroup.ts
+++ b/packages/main/src/SuggestionItemGroup.ts
@@ -13,6 +13,8 @@ import type { DefaultSlot } from "@ui5/webcomponents-base/dist/UI5Element.js";
  * @extends ListItemGroup
  * @public
  * @since 2.0.0
+ * @csspart header - Used to style the header item of the group
+ * @csspart title - Used to style the title of the group header
  */
 @customElement({
 	tag: "ui5-suggestion-item-group",


### PR DESCRIPTION
Add `exportparts="title"` to the `ListItemGroupHeader` element in `ListBoxItemGroupTemplate` so that `::part(title)` can reach across two shadow boundaries on `ui5-cb-item-group`, `ui5-mcb-item-group`, `ui5-suggestion-item-group`, and `ui5-search-item-group`.

Also add missing `@csspart` header and `@csspart` title JSDoc to `ComboBoxItemGroup`, `MultiComboBoxItemGroup`, `SuggestionItemGroup`, `SearchItemGroup`, and `UserSettingsAppearanceViewGroup` so the parts are documented in the generated API reference for each component.

Fixes #13936 
