### PR TITLE
fix(ui5-list): add private selectionWhileInactive property

### DIFF
--- a/packages/main/cypress/specs/List.cy.tsx
+++ b/packages/main/cypress/specs/List.cy.tsx
@@ -3876,7 +3876,7 @@ describe("List - ListItem accessible role inheritance", () => {
 	});
 });
 
-describe("List - _selectionWhileInactive", () => {
+describe("List - selectionWhileInactive", () => {
 	it("clicking an Inactive item WITH the flag toggles its selection (Multiple mode)", () => {
 		cy.mount(
 			<List id="list-with-flag" selectionMode="Multiple">
@@ -3885,7 +3885,7 @@ describe("List - _selectionWhileInactive", () => {
 			</List>
 		);
 
-		cy.get("#list-with-flag").invoke("prop", "_selectionWhileInactive", true);
+		cy.get("#list-with-flag").invoke("prop", "selectionWhileInactive", true);
 
 		cy.get("#inactive1").should("not.have.attr", "selected");
 
@@ -3906,7 +3906,7 @@ describe("List - _selectionWhileInactive", () => {
 			</List>
 		);
 
-		cy.get("#list-with-flag-space").invoke("prop", "_selectionWhileInactive", true);
+		cy.get("#list-with-flag-space").invoke("prop", "selectionWhileInactive", true);
 
 		cy.get("#inactive-space").shadow().find("li").focus();
 		cy.get("#inactive-space").should("not.have.attr", "selected");
@@ -3927,7 +3927,7 @@ describe("List - _selectionWhileInactive", () => {
 			</List>
 		);
 
-		cy.get("#list-no-itemclick").invoke("prop", "_selectionWhileInactive", true);
+		cy.get("#list-no-itemclick").invoke("prop", "selectionWhileInactive", true);
 
 		cy.get("#list-no-itemclick").then(($list) => {
 			$list[0].addEventListener("ui5-item-click", cy.stub().as("itemClickStub"));
@@ -3957,7 +3957,7 @@ describe("List - _selectionWhileInactive", () => {
 			</List>
 		);
 
-		cy.get("#list-active-flag").invoke("prop", "_selectionWhileInactive", true);
+		cy.get("#list-active-flag").invoke("prop", "selectionWhileInactive", true);
 
 		cy.get("#list-active-flag").then(($list) => {
 			$list[0].addEventListener("ui5-item-click", cy.stub().as("itemClickStub"));
@@ -3977,7 +3977,7 @@ describe("List - _selectionWhileInactive", () => {
 			</List>
 		);
 
-		cy.get("#list-single-flag").invoke("prop", "_selectionWhileInactive", true);
+		cy.get("#list-single-flag").invoke("prop", "selectionWhileInactive", true);
 
 		cy.get("#inactive-single-1").realClick();
 

--- a/packages/main/cypress/specs/List.cy.tsx
+++ b/packages/main/cypress/specs/List.cy.tsx
@@ -3875,3 +3875,118 @@ describe("List - ListItem accessible role inheritance", () => {
 			.should("have.attr", "role", "listitem");
 	});
 });
+
+describe("List - _selectionWhileInactive", () => {
+	it("clicking an Inactive item WITH the flag toggles its selection (Multiple mode)", () => {
+		cy.mount(
+			<List id="list-with-flag" selectionMode="Multiple">
+				<ListItemStandard id="inactive1" type="Inactive">Inactive Item 1</ListItemStandard>
+				<ListItemStandard id="inactive2" type="Inactive">Inactive Item 2</ListItemStandard>
+			</List>
+		);
+
+		cy.get("#list-with-flag").invoke("prop", "_selectionWhileInactive", true);
+
+		cy.get("#inactive1").should("not.have.attr", "selected");
+
+		cy.get("#inactive1").realClick();
+
+		cy.get("#inactive1").should("have.attr", "selected");
+
+		// Click again toggles off
+		cy.get("#inactive1").realClick();
+
+		cy.get("#inactive1").should("not.have.attr", "selected");
+	});
+
+	it("pressing Space on a focused Inactive item WITH the flag toggles selection", () => {
+		cy.mount(
+			<List id="list-with-flag-space" selectionMode="Multiple">
+				<ListItemStandard id="inactive-space" type="Inactive">Inactive Item</ListItemStandard>
+			</List>
+		);
+
+		cy.get("#list-with-flag-space").invoke("prop", "_selectionWhileInactive", true);
+
+		cy.get("#inactive-space").shadow().find("li").focus();
+		cy.get("#inactive-space").should("not.have.attr", "selected");
+
+		cy.realPress("Space");
+
+		cy.get("#inactive-space").should("have.attr", "selected");
+
+		cy.realPress("Space");
+
+		cy.get("#inactive-space").should("not.have.attr", "selected");
+	});
+
+	it("item-click event is NOT fired for an Inactive item with the flag", () => {
+		cy.mount(
+			<List id="list-no-itemclick" selectionMode="Multiple">
+				<ListItemStandard id="inactive-no-click" type="Inactive">Inactive Item</ListItemStandard>
+			</List>
+		);
+
+		cy.get("#list-no-itemclick").invoke("prop", "_selectionWhileInactive", true);
+
+		cy.get("#list-no-itemclick").then(($list) => {
+			$list[0].addEventListener("ui5-item-click", cy.stub().as("itemClickStub"));
+		});
+
+		cy.get("#inactive-no-click").realClick();
+
+		cy.get("@itemClickStub").should("not.have.been.called");
+	});
+
+	it("clicking an Inactive item WITHOUT the flag does NOT toggle selection (existing behavior)", () => {
+		cy.mount(
+			<List id="list-no-flag" selectionMode="Multiple">
+				<ListItemStandard id="inactive-no-flag" type="Inactive">Inactive Item</ListItemStandard>
+			</List>
+		);
+
+		cy.get("#inactive-no-flag").realClick();
+
+		cy.get("#inactive-no-flag").should("not.have.attr", "selected");
+	});
+
+	it("Active items in a list with the flag still work normally", () => {
+		cy.mount(
+			<List id="list-active-flag" selectionMode="Multiple">
+				<ListItemStandard id="active-item" type="Active">Active Item</ListItemStandard>
+			</List>
+		);
+
+		cy.get("#list-active-flag").invoke("prop", "_selectionWhileInactive", true);
+
+		cy.get("#list-active-flag").then(($list) => {
+			$list[0].addEventListener("ui5-item-click", cy.stub().as("itemClickStub"));
+		});
+
+		cy.get("#active-item").realClick();
+
+		cy.get("@itemClickStub").should("have.been.calledOnce");
+		cy.get("#active-item").should("have.attr", "selected");
+	});
+
+	it("selectionMode Single with the flag — clicking Inactive item selects it", () => {
+		cy.mount(
+			<List id="list-single-flag" selectionMode="Single">
+				<ListItemStandard id="inactive-single-1" type="Inactive">Inactive Item 1</ListItemStandard>
+				<ListItemStandard id="inactive-single-2" type="Inactive">Inactive Item 2</ListItemStandard>
+			</List>
+		);
+
+		cy.get("#list-single-flag").invoke("prop", "_selectionWhileInactive", true);
+
+		cy.get("#inactive-single-1").realClick();
+
+		cy.get("#inactive-single-1").should("have.attr", "selected");
+
+		// Clicking second item selects it and deselects first
+		cy.get("#inactive-single-2").realClick();
+
+		cy.get("#inactive-single-2").should("have.attr", "selected");
+		cy.get("#inactive-single-1").should("not.have.attr", "selected");
+	});
+});

--- a/packages/main/src/List.ts
+++ b/packages/main/src/List.ts
@@ -544,6 +544,15 @@ class List extends UI5Element {
 	_loadMoreActive = false;
 
 	/**
+	 * When set to `true`, allows list items with `type="Inactive"` to retain selection
+	 * (checkbox/radio) while suppressing the active press feedback and item-click event.
+	 * @default false
+	 * @private
+	 */
+	@property({ type: Boolean })
+	_selectionWhileInactive = false;
+
+	/**
 	 * Defines the current media query size.
 	 * @default "S"
 	 * @private
@@ -911,6 +920,7 @@ class List extends UI5Element {
 			if (item.hasConfigurableMode) {
 				(item as ListItem)._selectionMode = this.selectionMode;
 				(item as ListItem)._inheritedAccessibleRole = inheritedItemRole;
+				(item as ListItem)._selectionWhileInactive = this._selectionWhileInactive;
 			}
 			item.hasBorder = showBottomBorder;
 

--- a/packages/main/src/List.ts
+++ b/packages/main/src/List.ts
@@ -550,7 +550,7 @@ class List extends UI5Element {
 	 * @private
 	 */
 	@property({ type: Boolean })
-	_selectionWhileInactive = false;
+	selectionWhileInactive = false;
 
 	/**
 	 * Defines the current media query size.
@@ -920,7 +920,7 @@ class List extends UI5Element {
 			if (item.hasConfigurableMode) {
 				(item as ListItem)._selectionMode = this.selectionMode;
 				(item as ListItem)._inheritedAccessibleRole = inheritedItemRole;
-				(item as ListItem)._selectionWhileInactive = this._selectionWhileInactive;
+				(item as ListItem).selectionWhileInactive = this.selectionWhileInactive;
 			}
 			item.hasBorder = showBottomBorder;
 

--- a/packages/main/src/ListItem.ts
+++ b/packages/main/src/ListItem.ts
@@ -201,6 +201,13 @@ abstract class ListItem extends ListItemBase {
 	_selectionMode: `${ListSelectionMode}` = "None";
 
 	/**
+	 * Propagated from the parent List. When `true`, inactive items can still be selected.
+	 * @private
+	 */
+	@property({ type: Boolean })
+	_selectionWhileInactive = false;
+
+	/**
 	 * Indicates whether the list item is in edit mode.
 	 * When active, Tab cycles through internal focusable elements
 	 * instead of navigating to the next list item.
@@ -368,7 +375,7 @@ abstract class ListItem extends ListItemBase {
 	 * and Multi (ui5-checkbox) selection modes are used.
 	 */
 	onMultiSelectionComponentPress(e: CustomEvent) {
-		if (this.isInactive) {
+		if (this.isInactive && !this._selectionWhileInactive) {
 			return;
 		}
 
@@ -376,7 +383,7 @@ abstract class ListItem extends ListItemBase {
 	}
 
 	onSingleSelectionComponentPress(e: CustomEvent) {
-		if (this.isInactive) {
+		if (this.isInactive && !this._selectionWhileInactive) {
 			return;
 		}
 
@@ -399,6 +406,9 @@ abstract class ListItem extends ListItemBase {
 
 	fireItemPress(e: Event) {
 		if (this.isInactive) {
+			if (this._selectionWhileInactive && this._selectionMode !== ListSelectionMode.None && this._selectionMode !== ListSelectionMode.Delete) {
+				this.fireDecoratorEvent("selection-requested", { item: this, selected: !this.selected, selectionComponentPressed: false });
+			}
 			return;
 		}
 		super.fireItemPress(e);

--- a/packages/main/src/ListItem.ts
+++ b/packages/main/src/ListItem.ts
@@ -205,7 +205,7 @@ abstract class ListItem extends ListItemBase {
 	 * @private
 	 */
 	@property({ type: Boolean })
-	_selectionWhileInactive = false;
+	selectionWhileInactive = false;
 
 	/**
 	 * Indicates whether the list item is in edit mode.
@@ -375,7 +375,7 @@ abstract class ListItem extends ListItemBase {
 	 * and Multi (ui5-checkbox) selection modes are used.
 	 */
 	onMultiSelectionComponentPress(e: CustomEvent) {
-		if (this.isInactive && !this._selectionWhileInactive) {
+		if (this.isInactive && !this.selectionWhileInactive) {
 			return;
 		}
 
@@ -383,7 +383,7 @@ abstract class ListItem extends ListItemBase {
 	}
 
 	onSingleSelectionComponentPress(e: CustomEvent) {
-		if (this.isInactive && !this._selectionWhileInactive) {
+		if (this.isInactive && !this.selectionWhileInactive) {
 			return;
 		}
 
@@ -406,7 +406,7 @@ abstract class ListItem extends ListItemBase {
 
 	fireItemPress(e: Event) {
 		if (this.isInactive) {
-			if (this._selectionWhileInactive && this._selectionMode !== ListSelectionMode.None && this._selectionMode !== ListSelectionMode.Delete) {
+			if (this.selectionWhileInactive && this._selectionMode !== ListSelectionMode.None && this._selectionMode !== ListSelectionMode.Delete) {
 				this.fireDecoratorEvent("selection-requested", { item: this, selected: !this.selected, selectionComponentPressed: false });
 			}
 			return;


### PR DESCRIPTION
## Summary
- Adds a new private `_selectionWhileInactive` boolean property to `ui5-list` (default `false`)
- When set, propagates to all list items via `prepareListItems()`
- On `ui5-li` items with `type="Inactive"`, clicking or using Space/Enter now toggles selection (checkbox/radio) without firing the `item-click` event

## Usage
```html
<ui5-list selection-mode="Multiple" _selection-while-inactive>
  <ui5-li type="Inactive">Item</ui5-li>
</ui5-list>
```

## Test plan
- [ ] Set `type="Inactive"` on list items with a selection mode — verify selection toggles on click/keyboard
- [ ] Verify `item-click` is NOT fired for inactive items
- [ ] Verify normal Active items are unaffected
- [ ] Verify flag=false (default) preserves existing Inactive behavior