### PR TITLE
fix(ui5-avatar): include badge tooltip in aria-label

### DIFF
--- a/packages/main/cypress/specs/Avatar.cy.tsx
+++ b/packages/main/cypress/specs/Avatar.cy.tsx
@@ -27,6 +27,38 @@ describe("Accessibility", () => {
 			.should("have.attr", "aria-label", expectedLabel);
 	});
 
+	it("includes badge tooltip in aria-label", () => {
+		const INITIALS = "JD";
+		const TOOLTIP = "Approved";
+
+		cy.mount(
+			<Avatar id="avatar-badge-tooltip" initials={INITIALS}>
+				<AvatarBadge slot="badge" icon="accept" tooltip={TOOLTIP}></AvatarBadge>
+			</Avatar>
+		);
+
+		cy.get("#avatar-badge-tooltip")
+			.shadow()
+			.find(".ui5-avatar-root")
+			.should("have.attr", "aria-label", `Avatar ${INITIALS} ${TOOLTIP}`);
+	});
+
+	it("appends badge tooltip to accessibleName", () => {
+		const ACCESSIBLE_NAME = "John Doe";
+		const TOOLTIP = "Approved";
+
+		cy.mount(
+			<Avatar id="avatar-accessiblename-badge" accessibleName={ACCESSIBLE_NAME}>
+				<AvatarBadge slot="badge" icon="accept" tooltip={TOOLTIP}></AvatarBadge>
+			</Avatar>
+		);
+
+		cy.get("#avatar-accessiblename-badge")
+			.shadow()
+			.find(".ui5-avatar-root")
+			.should("have.attr", "aria-label", `${ACCESSIBLE_NAME} ${TOOLTIP}`);
+	});
+
 	it("should return correct accessibilityInfo object when avatar is interactive", () => {
 		const INITIALS = "JD";
 		const hasPopup = "menu";

--- a/packages/main/cypress/specs/Avatar.cy.tsx
+++ b/packages/main/cypress/specs/Avatar.cy.tsx
@@ -59,6 +59,33 @@ describe("Accessibility", () => {
 			.should("have.attr", "aria-label", `${ACCESSIBLE_NAME} ${TOOLTIP}`);
 	});
 
+	it("updates aria-label when badge tooltip changes after render", () => {
+		const INITIALS = "JD";
+		const INITIAL_TOOLTIP = "Approved";
+		const UPDATED_TOOLTIP = "Rejected";
+
+		cy.mount(
+			<Avatar id="avatar-badge-tooltip-update" initials={INITIALS}>
+				<AvatarBadge slot="badge" icon="accept" tooltip={INITIAL_TOOLTIP}></AvatarBadge>
+			</Avatar>
+		);
+
+		cy.get("#avatar-badge-tooltip-update")
+			.shadow()
+			.find(".ui5-avatar-root")
+			.should("have.attr", "aria-label", `Avatar ${INITIALS} ${INITIAL_TOOLTIP}`);
+
+		cy.get("#avatar-badge-tooltip-update [slot='badge']")
+			.then($badge => {
+				$badge.attr("tooltip", UPDATED_TOOLTIP);
+			});
+
+		cy.get("#avatar-badge-tooltip-update")
+			.shadow()
+			.find(".ui5-avatar-root")
+			.should("have.attr", "aria-label", `Avatar ${INITIALS} ${UPDATED_TOOLTIP}`);
+	});
+
 	it("should return correct accessibilityInfo object when avatar is interactive", () => {
 		const INITIALS = "JD";
 		const hasPopup = "menu";

--- a/packages/main/src/Avatar.ts
+++ b/packages/main/src/Avatar.ts
@@ -28,6 +28,7 @@ import {
 import AvatarCss from "./generated/themes/Avatar.css.js";
 
 import type Icon from "./Icon.js";
+import type AvatarBadge from "./AvatarBadge.js";
 import AvatarSize from "./types/AvatarSize.js";
 import type AvatarShape from "./types/AvatarShape.js";
 import type AvatarColorScheme from "./types/AvatarColorScheme.js";
@@ -361,14 +362,20 @@ class Avatar extends UI5Element implements ITabbable, IAvatarGroupItem {
 		return null;
 	}
 
+	/**
+	 * Returns the accessible label for the avatar root element.
+	 * Uses `accessibleName` if provided, otherwise falls back to the default
+	 * "Avatar" text appended with `initials` if set.
+	 * The badge's effective tooltip, if present, is always appended at the end
+	 * so screen readers announce the badge state.
+	 */
 	get accessibleNameText() {
-		if (this.accessibleName) {
-			return this.accessibleName;
-		}
-
 		const defaultLabel = Avatar.i18nBundle.getText(AVATAR_TOOLTIP);
+		const baseLabel = this.accessibleName
+			|| (this.initials ? `${defaultLabel} ${this.initials}`.trim() : defaultLabel);
+		const badgeTooltip = (this.badge[0] as AvatarBadge | undefined)?.effectiveTooltip;
 
-		return this.initials ? `${defaultLabel} ${this.initials}`.trim() : defaultLabel;
+		return badgeTooltip ? `${baseLabel} ${badgeTooltip}` : baseLabel;
 	}
 
 	get hasImage() {

--- a/packages/main/src/Avatar.ts
+++ b/packages/main/src/Avatar.ts
@@ -274,7 +274,13 @@ class Avatar extends UI5Element implements ITabbable, IAvatarGroupItem {
 	 * @public
 	 * @since 1.7.0
 	 */
-	@slot()
+	@slot({
+		type: HTMLElement,
+		invalidateOnChildChange: {
+			properties: ["icon", "tooltip", "effectiveTooltip"],
+			slots: false,
+		},
+	})
 	badge!: Slot<HTMLElement>;
 
 	@i18n("@ui5/webcomponents")


### PR DESCRIPTION
SNOW: DINC1004809

The badge's tooltip, is added to the ui5-avatar`s aria-label, so screen readers announce the badge state.