### PR TITLE
fix(ui5-link): adjust focus outline in HC themes

### DIFF
--- a/packages/main/src/themes/Link.css
+++ b/packages/main/src/themes/Link.css
@@ -78,7 +78,7 @@
 }
 
 :host .ui5-link-root {
-	outline-offset: -0.0625rem;
+	outline-offset: var(--_ui5_link_outline_offset);
 	border-radius: var(--_ui5_link_focus_border-radius);
 }
 

--- a/packages/main/src/themes/base/Link-parameters.css
+++ b/packages/main/src/themes/base/Link-parameters.css
@@ -6,6 +6,7 @@
 	--_ui5_link_active_text_decoration: underline;
 	--_ui5_link_outline: 0.0625rem dotted var(--sapContent_FocusColor);
 	--_ui5_link_focus_border-radius: 0;
+	--_ui5_link_outline_offset: -0.0625rem;
 	--_ui5_link_focus_background_color: transparent;
 	--_ui5_link_focus_color: var(--sapLinkColor);
 	--_ui5_link_focus_text_decoration: underline;

--- a/packages/main/src/themes/sap_fiori_3_hcb/Link-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3_hcb/Link-parameters.css
@@ -7,6 +7,7 @@
 	--_ui5_link_focus_text_decoration: none;
 	--_ui5_link_focused_hover_text_decoration: none;
 	--_ui5_link_outline: 0.125rem dotted var(--sapContent_FocusColor);
+	--_ui5_link_outline_offset: 0;
 	--_ui5_link_subtle_text_decoration: underline;
 	--_ui5_link_subtle_text_decoration_hover: none;
 }

--- a/packages/main/src/themes/sap_fiori_3_hcw/Link-parameters.css
+++ b/packages/main/src/themes/sap_fiori_3_hcw/Link-parameters.css
@@ -7,6 +7,7 @@
 	--_ui5_link_focus_text_decoration: none;
 	--_ui5_link_focused_hover_text_decoration: none;
 	--_ui5_link_outline: 0.125rem dotted var(--sapContent_FocusColor);
+	--_ui5_link_outline_offset: 0;
 	--_ui5_link_subtle_text_decoration: underline;
 	--_ui5_link_subtle_text_decoration_hover: none;
 }

--- a/packages/main/src/themes/sap_horizon_hcb/Link-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcb/Link-parameters.css
@@ -8,5 +8,6 @@
 	--_ui5_link_subtle_text_decoration: underline;
 	--_ui5_link_subtle_text_decoration_hover: none;
 	--_ui5_link_outline: 0.125rem dotted var(--sapContent_FocusColor);
+	--_ui5_link_outline_offset: 0;
 	--_ui5_link_large_interactive_area_height: 1.5rem;
 }

--- a/packages/main/src/themes/sap_horizon_hcw/Link-parameters.css
+++ b/packages/main/src/themes/sap_horizon_hcw/Link-parameters.css
@@ -8,5 +8,6 @@
 	--_ui5_link_subtle_text_decoration: underline;
 	--_ui5_link_subtle_text_decoration_hover: none;
 	--_ui5_link_outline: 0.125rem dotted var(--sapContent_FocusColor);
+	--_ui5_link_outline_offset: 0;
 	--_ui5_link_large_interactive_area_height: 1.5rem;
 }


### PR DESCRIPTION
Until now, the outline of the border of focused `ui5-link` was -1px in High Contrast themes (Fiori 3 and Horizon) which caused focus border to go over the `ui5-link` text.

This PR adjusts the offset to 0 and the border doesn't overlap the `ui5-link` text.

<img width="310" height="87" alt="linkHC" src="https://github.com/user-attachments/assets/ff082895-19d8-48de-89d8-cf52fb678738" />

