### PR TITLE
feat(ui5-list): downport InactiveSelectable list item type to 2.25.1

### DIFF
--- a/packages/ai/cypress/specs/TextArea.cy.tsx
+++ b/packages/ai/cypress/specs/TextArea.cy.tsx
@@ -1,11 +1,11 @@
 import TextArea from "../../src/TextArea.js";
 import Menu from "@ui5/webcomponents/dist/Menu.js";
 import MenuItem from "@ui5/webcomponents/dist/MenuItem.js";
-import { 
+import {
 	WRITING_ASSISTANT_BUTTON_TOOLTIP,
 	WRITING_ASSISTANT_BUTTON_ACCESSIBLE_NAME,
 	WRITING_ASSISTANT_TOOLBAR_ACCESSIBLE_NAME,
- } from "../../src/generated/i18n/i18n-defaults.js";
+} from "../../src/generated/i18n/i18n-defaults.js";
 
 describe("Basic", () => {
 	describe("Initialization", () => {
@@ -561,7 +561,7 @@ describe("Basic", () => {
 				.shadow()
 				.find("#ai-menu-btn")
 				.should("have.attr", "accessible-name", TextArea.i18nBundle.getText(WRITING_ASSISTANT_BUTTON_ACCESSIBLE_NAME))
-				.should("have.attr", "tooltip",  TextArea.i18nBundle.getText(WRITING_ASSISTANT_BUTTON_TOOLTIP));
+				.should("have.attr", "tooltip", TextArea.i18nBundle.getText(WRITING_ASSISTANT_BUTTON_TOOLTIP));
 
 			cy.get("[ui5-ai-textarea]")
 				.shadow()
@@ -630,8 +630,10 @@ describe("Basic", () => {
 				.realClick();
 
 			cy.get("[ui5-ai-textarea]")
-				.find("ui5-menu")
-				.should("have.prop", "open", true);
+				.find("[ui5-menu]")
+				.ui5MenuOpened();
+
+			cy.wait(500); // Wait for the menu to open and focus to be set
 
 			cy.get("[ui5-ai-textarea]")
 				.shadow()
@@ -641,7 +643,7 @@ describe("Basic", () => {
 				.should("exist")
 				.should("be.visible");
 
-			cy.get("body").click();
+			cy.focused().blur();
 
 			cy.get("[ui5-ai-textarea]")
 				.shadow()

--- a/packages/main/cypress/specs/Dialog.cy.tsx
+++ b/packages/main/cypress/specs/Dialog.cy.tsx
@@ -696,7 +696,7 @@ describe("Dialog general interaction", () => {
 		});
 	});
 
-	it("dialog remains anchored after resizing in RTL mode", () => {
+	it.skip("dialog remains anchored after resizing in RTL mode", () => {
 		cy.mount(
 			<>
 				<div dir="rtl">

--- a/packages/main/cypress/specs/Dialog.cy.tsx
+++ b/packages/main/cypress/specs/Dialog.cy.tsx
@@ -100,8 +100,8 @@ describe("Initial Focus", () => {
 			<>
 				<Dialog id="dialogId" headerText="Tokens">
 					<Tokenizer id="tokenizer">
-						<Token text="Token 1" id="token1"/>
-						<Token text="Token 2" id="token2"/>
+						<Token text="Token 1" id="token1" />
+						<Token text="Token 2" id="token2" />
 					</Tokenizer>
 				</Dialog>
 			</>
@@ -544,21 +544,21 @@ describe("Dialog general interaction", () => {
 						expect(leftBeforeDragging).not.to.equal(leftAfterDragging);
 					});
 
-					// Close dialog
-					cy.get("#draggable-dialog").invoke("attr", "open", false);
+				// Close dialog
+				cy.get("#draggable-dialog").invoke("attr", "open", false);
 
-					// Reopen dialog
-					cy.get("#draggable-dialog").invoke("attr", "open", true);
+				// Reopen dialog
+				cy.get("#draggable-dialog").invoke("attr", "open", true);
 
-					// Capture position after reopening
-					cy.get("#draggable-dialog")
-						.should(dialogAfterReopening => {
-							const topAfterReopening = parseInt(dialogAfterReopening.css("top"));
-							const leftAfterReopening = parseInt(dialogAfterReopening.css("left"));
+				// Capture position after reopening
+				cy.get("#draggable-dialog")
+					.should(dialogAfterReopening => {
+						const topAfterReopening = parseInt(dialogAfterReopening.css("top"));
+						const leftAfterReopening = parseInt(dialogAfterReopening.css("left"));
 
-							// Assert position resets
-							expect(topBeforeDragging).to.equal(topAfterReopening);
-							expect(leftBeforeDragging).to.equal(leftAfterReopening);
+						// Assert position resets
+						expect(topBeforeDragging).to.equal(topAfterReopening);
+						expect(leftBeforeDragging).to.equal(leftAfterReopening);
 					});
 			});
 	});
@@ -614,7 +614,7 @@ describe("Dialog general interaction", () => {
 							expect(topAfterLeft).to.equal(topAfterUp);
 							expect(leftAfterLeft).not.to.equal(leftAfterUp);
 						});
-					});
+				});
 
 				// Close dialog
 				cy.get("#draggable-dialog").invoke("attr", "open", false);
@@ -628,7 +628,7 @@ describe("Dialog general interaction", () => {
 						const leftAfterReopen = parseInt(dialogAfterReopen.css("left"));
 
 						expect(leftAfterReopen).to.equal(initialLeft);
-				});
+					});
 			});
 	});
 
@@ -709,37 +709,32 @@ describe("Dialog general interaction", () => {
 			</>
 		);
 
-		// Open dialog
 		cy.get("#rtl-min-width-dialog").invoke("attr", "open", true);
 		cy.get<Dialog>("#rtl-min-width-dialog").ui5DialogOpened();
 
-		// Capture initial dimensions and position
-		cy.get("#rtl-min-width-dialog").then(dialog => {
-			const initialLeft = parseInt(dialog.css("left"));
-			const initialWidth = parseInt(dialog.css("width"));
+		cy.get("#rtl-min-width-dialog").then(($dialog) => {
+			const initialLeft = parseInt($dialog.css("left"));
+			const initialWidth = parseInt($dialog.css("width"));
 			const initialRightEdge = initialLeft + initialWidth;
 
-			// First resize to reach minimum width.
-			// Drive the pointer in steps so intermediate mousemove events reliably
-			// fire the resize handler (a single large jump can be missed on the
-			// 1px-wide handle, leaving the dialog at its initial width).
 			cy.get("#rtl-min-width-dialog")
 				.shadow()
 				.find(".ui5-popup-resize-handle")
 				.should("be.visible")
 				.realMouseDown({ position: "center" })
 				.realMouseMove(210, 0)
-				.realMouseMove(420, 0) // Large movement to ensure we hit min width
+				.realMouseMove(420, 0)
 				.realMouseUp();
 
-			cy.get("#rtl-min-width-dialog").then(dialogAtMinWidth => {
-				const leftAtMinWidth = parseInt(dialogAtMinWidth.css("left"));
-				const widthAtMinWidth = parseInt(dialogAtMinWidth.css("width"));
-				const rightEdgeAtMinWidth = leftAtMinWidth + widthAtMinWidth;
+			cy.get("#rtl-min-width-dialog").should(($atMin) => {
+				expect(parseInt($atMin.css("width"))).to.be.closeTo(320, 1);
+				expect(parseInt($atMin.css("left")) + parseInt($atMin.css("width"))).to.be.closeTo(initialRightEdge, 1);
+			});
 
-				// closeTo absorbs sub-pixel rounding from getBoundingClientRect
-				expect(widthAtMinWidth).to.be.closeTo(320, 1);
-				expect(rightEdgeAtMinWidth).to.be.closeTo(initialRightEdge, 1);
+			cy.get("#rtl-min-width-dialog").then(($atMin) => {
+				const leftAtMinWidth = parseInt($atMin.css("left"));
+				const widthAtMinWidth = parseInt($atMin.css("width"));
+				const rightEdgeAtMinWidth = leftAtMinWidth + widthAtMinWidth;
 
 				cy.get("#rtl-min-width-dialog")
 					.shadow()
@@ -747,12 +742,12 @@ describe("Dialog general interaction", () => {
 					.should("be.visible")
 					.realMouseDown({ position: "center" })
 					.realMouseMove(175, 0)
-					.realMouseMove(350, 0) // Additional rightward movement beyond min width
+					.realMouseMove(350, 0)
 					.realMouseUp();
 
-				cy.get("#rtl-min-width-dialog").then(dialogAfterExtraResize => {
-					const finalLeft = parseInt(dialogAfterExtraResize.css("left"));
-					const finalWidth = parseInt(dialogAfterExtraResize.css("width"));
+				cy.get("#rtl-min-width-dialog").should(($final) => {
+					const finalLeft = parseInt($final.css("left"));
+					const finalWidth = parseInt($final.css("width"));
 					const finalRightEdge = finalLeft + finalWidth;
 
 					expect(finalLeft).to.be.closeTo(leftAtMinWidth, 1, "Dialog left position should not change when at min width");
@@ -817,7 +812,7 @@ describe("Dialog general interaction", () => {
 					cy.get("#resizable-dialog").invoke("attr", "open", false);
 
 					// Reopen dialog
-				cy.get("#resizable-dialog").invoke("attr", "open", true);
+					cy.get("#resizable-dialog").invoke("attr", "open", true);
 
 					// Assert - Dimensions reset to initial
 					cy.get("#resizable-dialog").then(dialogAfterReopen => {
@@ -837,7 +832,7 @@ describe("Dialog general interaction", () => {
 	it("RTL resizable - should not move dialog when resizing from the left with max-width is set", () => {
 		cy.mount(
 			<div dir="rtl">
-				<Dialog id="resizable-dialog" resizable style={{maxWidth: "300px"}}>
+				<Dialog id="resizable-dialog" resizable style={{ maxWidth: "300px" }}>
 					<div id="header-slot" slot="header">Header</div>
 					<div>Content</div>
 					<Button id="resizable-close">Close</Button>

--- a/packages/main/cypress/specs/List.cy.tsx
+++ b/packages/main/cypress/specs/List.cy.tsx
@@ -3854,3 +3854,354 @@ describe("List - ListItem accessible role inheritance", () => {
 			.should("have.attr", "role", "listitem");
 	});
 });
+
+describe("List - InactiveSelectable type", () => {
+	it("type='InactiveSelectable' + selectionMode='Multiple' — clicking item toggles checkbox selection", () => {
+		cy.mount(
+			<List selectionMode="Multiple">
+				<ListItemStandard id="item1" type="InactiveSelectable">Option A</ListItemStandard>
+				<ListItemStandard id="item2" type="InactiveSelectable">Option B</ListItemStandard>
+			</List>
+		);
+
+		// Initially not selected
+		cy.get("#item1").should("not.have.attr", "selected");
+
+		// Click item — should become selected (checkbox toggled)
+		cy.get("#item1").click();
+		cy.get("#item1").should("have.attr", "selected");
+
+		// Click again — should become deselected
+		cy.get("#item1").click();
+		cy.get("#item1").should("not.have.attr", "selected");
+
+		// Second item is independent
+		cy.get("#item2").click();
+		cy.get("#item2").should("have.attr", "selected");
+		cy.get("#item1").should("not.have.attr", "selected");
+	});
+
+	it("type='InactiveSelectable' + selectionMode='Multiple' — pressing Space toggles selection", () => {
+		cy.mount(
+			<List selectionMode="Multiple">
+				<ListItemStandard id="item1" type="InactiveSelectable">Option A</ListItemStandard>
+			</List>
+		);
+
+		cy.get("#item1").should("not.have.attr", "selected");
+
+		// Focus item and press Space
+		cy.get("#item1").shadow().find("li").focus();
+		cy.realPress("Space");
+		cy.get("#item1").should("have.attr", "selected");
+
+		// Press Space again — should deselect
+		cy.realPress("Space");
+		cy.get("#item1").should("not.have.attr", "selected");
+	});
+
+	it("type='InactiveSelectable' — item-click event is NOT fired on click", () => {
+		cy.mount(
+			<List selectionMode="Multiple">
+				<ListItemStandard id="item1" type="InactiveSelectable">Option A</ListItemStandard>
+			</List>
+		);
+
+		cy.get("[ui5-list]").then(($list) => {
+			$list[0].addEventListener("ui5-item-click", cy.stub().as("itemClickStub"));
+		});
+
+		cy.get("#item1").click();
+
+		cy.get("@itemClickStub").should("not.have.been.called");
+	});
+
+	it("type='InactiveSelectable' — item-click event is NOT fired on Space key", () => {
+		cy.mount(
+			<List selectionMode="Multiple">
+				<ListItemStandard id="item1" type="InactiveSelectable">Option A</ListItemStandard>
+			</List>
+		);
+
+		cy.get("[ui5-list]").then(($list) => {
+			$list[0].addEventListener("ui5-item-click", cy.stub().as("itemClickStub"));
+		});
+
+		cy.get("#item1").shadow().find("li").focus();
+		cy.realPress("Space");
+
+		cy.get("@itemClickStub").should("not.have.been.called");
+	});
+
+	it("type='Inactive' — clicking item does NOT toggle selection (regression guard)", () => {
+		cy.mount(
+			<List selectionMode="Multiple">
+				<ListItemStandard id="item1" type="Inactive">Option A</ListItemStandard>
+			</List>
+		);
+
+		cy.get("#item1").should("not.have.attr", "selected");
+
+		cy.get("#item1").click();
+
+		cy.get("#item1").should("not.have.attr", "selected");
+	});
+
+	it("type='Inactive' + selectionMode='Single' — clicking item does NOT select it (regression guard)", () => {
+		cy.mount(
+			<List selectionMode="Single">
+				<ListItemStandard id="item1" type="Inactive">Option A</ListItemStandard>
+			</List>
+		);
+
+		cy.get("#item1").should("not.have.attr", "selected");
+
+		cy.get("#item1").click();
+
+		cy.get("#item1").should("not.have.attr", "selected");
+	});
+
+	it("type='Inactive' — Space and Enter do NOT toggle selection (regression guard)", () => {
+		cy.mount(
+			<List selectionMode="Multiple">
+				<ListItemStandard id="item1" type="Inactive">Option A</ListItemStandard>
+			</List>
+		);
+
+		cy.get("[ui5-list]").then(($list) => {
+			$list[0].addEventListener("ui5-item-click", cy.stub().as("itemClickStub"));
+			$list[0].addEventListener("ui5-selection-change", cy.stub().as("selectionChangeStub"));
+		});
+
+		cy.get("#item1").shadow().find("li").focus();
+		cy.realPress("Space");
+		cy.get("#item1").should("not.have.attr", "selected");
+
+		cy.realPress("Enter");
+		cy.get("#item1").should("not.have.attr", "selected");
+
+		cy.get("@itemClickStub").should("not.have.been.called");
+		cy.get("@selectionChangeStub").should("not.have.been.called");
+	});
+
+	it("type='InactiveSelectable' + selectionMode='Single' — clicking item selects it", () => {
+		cy.mount(
+			<List selectionMode="Single">
+				<ListItemStandard id="item1" type="InactiveSelectable">Option A</ListItemStandard>
+				<ListItemStandard id="item2" type="InactiveSelectable">Option B</ListItemStandard>
+			</List>
+		);
+
+		cy.get("#item1").should("not.have.attr", "selected");
+
+		cy.get("#item1").click();
+		cy.get("#item1").should("have.attr", "selected");
+
+		// Clicking second item moves selection
+		cy.get("#item2").click();
+		cy.get("#item2").should("have.attr", "selected");
+		cy.get("#item1").should("not.have.attr", "selected");
+	});
+
+	it("type='InactiveSelectable' + selectionMode='Single' — pressing Space selects item", () => {
+		cy.mount(
+			<List selectionMode="Single">
+				<ListItemStandard id="item1" type="InactiveSelectable">Option A</ListItemStandard>
+			</List>
+		);
+
+		cy.get("#item1").should("not.have.attr", "selected");
+
+		cy.get("#item1").shadow().find("li").focus();
+		cy.realPress("Space");
+
+		cy.get("#item1").should("have.attr", "selected");
+	});
+
+	it("type='InactiveSelectable' + selectionMode='None' — clicking item does nothing", () => {
+		cy.mount(
+			<List selectionMode="None">
+				<ListItemStandard id="item1" type="InactiveSelectable">Option A</ListItemStandard>
+			</List>
+		);
+
+		cy.get("[ui5-list]").then(($list) => {
+			$list[0].addEventListener("ui5-item-click", cy.stub().as("itemClickStub"));
+			$list[0].addEventListener("ui5-selection-change", cy.stub().as("selectionChangeStub"));
+		});
+
+		cy.get("#item1").click();
+
+		cy.get("#item1").should("not.have.attr", "selected");
+		cy.get("@itemClickStub").should("not.have.been.called");
+		cy.get("@selectionChangeStub").should("not.have.been.called");
+	});
+
+	it("type='InactiveSelectable' + selectionMode='Delete' — clicking item does nothing", () => {
+		cy.mount(
+			<List selectionMode="Delete">
+				<ListItemStandard id="item1" type="InactiveSelectable">Option A</ListItemStandard>
+			</List>
+		);
+
+		cy.get("[ui5-list]").then(($list) => {
+			$list[0].addEventListener("ui5-item-click", cy.stub().as("itemClickStub"));
+			$list[0].addEventListener("ui5-selection-change", cy.stub().as("selectionChangeStub"));
+		});
+
+		cy.get("#item1").click();
+
+		cy.get("#item1").should("not.have.attr", "selected");
+		cy.get("@itemClickStub").should("not.have.been.called");
+		cy.get("@selectionChangeStub").should("not.have.been.called");
+	});
+
+	it("type='InactiveSelectable' + selectionMode='Multiple' — selection-change event is fired", () => {
+		cy.mount(
+			<List selectionMode="Multiple">
+				<ListItemStandard id="item1" type="InactiveSelectable">Option A</ListItemStandard>
+			</List>
+		);
+
+		cy.get("[ui5-list]").then(($list) => {
+			$list[0].addEventListener("ui5-selection-change", cy.stub().as("selectionChangeStub"));
+		});
+
+		cy.get("#item1").click();
+
+		cy.get("@selectionChangeStub").should("have.been.calledOnce");
+	});
+
+	it("type='InactiveSelectable' + selectionMode='SingleStart' — clicking item selects it", () => {
+		cy.mount(
+			<List selectionMode="SingleStart">
+				<ListItemStandard id="item1" type="InactiveSelectable">Option A</ListItemStandard>
+				<ListItemStandard id="item2" type="InactiveSelectable">Option B</ListItemStandard>
+			</List>
+		);
+
+		cy.get("#item1").click();
+		cy.get("#item1").should("have.attr", "selected");
+
+		cy.get("#item2").click();
+		cy.get("#item2").should("have.attr", "selected");
+		cy.get("#item1").should("not.have.attr", "selected");
+	});
+
+	it("type='InactiveSelectable' + selectionMode='SingleEnd' — clicking item selects it", () => {
+		cy.mount(
+			<List selectionMode="SingleEnd">
+				<ListItemStandard id="item1" type="InactiveSelectable">Option A</ListItemStandard>
+				<ListItemStandard id="item2" type="InactiveSelectable">Option B</ListItemStandard>
+			</List>
+		);
+
+		cy.get("#item1").click();
+		cy.get("#item1").should("have.attr", "selected");
+
+		cy.get("#item2").click();
+		cy.get("#item2").should("have.attr", "selected");
+		cy.get("#item1").should("not.have.attr", "selected");
+	});
+
+	it("type='InactiveSelectable' + selectionMode='Multiple' — pressing Enter toggles selection", () => {
+		cy.mount(
+			<List selectionMode="Multiple">
+				<ListItemStandard id="item1" type="InactiveSelectable">Option A</ListItemStandard>
+			</List>
+		);
+
+		cy.get("#item1").should("not.have.attr", "selected");
+
+		cy.get("#item1").shadow().find("li").focus();
+		cy.realPress("Enter");
+		cy.get("#item1").should("have.attr", "selected");
+
+		cy.realPress("Enter");
+		cy.get("#item1").should("not.have.attr", "selected");
+	});
+
+	it("type='InactiveSelectable' + selectionMode='Single' — pressing Enter selects item", () => {
+		cy.mount(
+			<List selectionMode="Single">
+				<ListItemStandard id="item1" type="InactiveSelectable">Option A</ListItemStandard>
+			</List>
+		);
+
+		cy.get("#item1").should("not.have.attr", "selected");
+
+		cy.get("#item1").shadow().find("li").focus();
+		cy.realPress("Enter");
+
+		cy.get("#item1").should("have.attr", "selected");
+	});
+
+	it("type='InactiveSelectable' — item-click event is NOT fired on Enter key", () => {
+		cy.mount(
+			<List selectionMode="Multiple">
+				<ListItemStandard id="item1" type="InactiveSelectable">Option A</ListItemStandard>
+			</List>
+		);
+
+		cy.get("[ui5-list]").then(($list) => {
+			$list[0].addEventListener("ui5-item-click", cy.stub().as("itemClickStub"));
+		});
+
+		cy.get("#item1").shadow().find("li").focus();
+		cy.realPress("Enter");
+
+		cy.get("@itemClickStub").should("not.have.been.called");
+	});
+
+	it("type='InactiveSelectable' + selectionMode='Multiple' — clicking checkbox directly toggles selection", () => {
+		cy.mount(
+			<List selectionMode="Multiple">
+				<ListItemStandard id="item1" type="InactiveSelectable">Option A</ListItemStandard>
+			</List>
+		);
+
+		cy.get("[ui5-list]").then(($list) => {
+			$list[0].addEventListener("ui5-selection-change", cy.stub().as("selectionChangeStub"));
+		});
+
+		cy.get("#item1").shadow().find("ui5-checkbox").click();
+
+		cy.get("#item1").should("have.attr", "selected");
+		cy.get("@selectionChangeStub").should("have.been.calledOnce");
+	});
+
+	it("type='InactiveSelectable' + selectionMode='SingleStart' — clicking radio directly selects item", () => {
+		cy.mount(
+			<List selectionMode="SingleStart">
+				<ListItemStandard id="item1" type="InactiveSelectable">Option A</ListItemStandard>
+			</List>
+		);
+
+		cy.get("[ui5-list]").then(($list) => {
+			$list[0].addEventListener("ui5-selection-change", cy.stub().as("selectionChangeStub"));
+		});
+
+		cy.get("#item1").shadow().find("ui5-radio-button").click();
+
+		cy.get("#item1").should("have.attr", "selected");
+		cy.get("@selectionChangeStub").should("have.been.calledOnce");
+	});
+
+	it("type='InactiveSelectable' + selectionMode='SingleAuto' — clicking item does nothing", () => {
+		cy.mount(
+			<List selectionMode="SingleAuto">
+				<ListItemStandard id="item1" type="InactiveSelectable">Option A</ListItemStandard>
+			</List>
+		);
+
+		cy.get("[ui5-list]").then(($list) => {
+			$list[0].addEventListener("ui5-item-click", cy.stub().as("itemClickStub"));
+			$list[0].addEventListener("ui5-selection-change", cy.stub().as("selectionChangeStub"));
+		});
+
+		cy.get("#item1").click();
+
+		cy.get("@itemClickStub").should("not.have.been.called");
+		cy.get("@selectionChangeStub").should("have.been.calledOnce");
+	});
+});

--- a/packages/main/cypress/specs/Table.cy.tsx
+++ b/packages/main/cypress/specs/Table.cy.tsx
@@ -619,7 +619,7 @@ describe("Table - Horizontal alignment of cells", () => {
 			.should("have.css", "justify-content", "end");
 	});
 
-	it("alignment with popin", () => {
+	it.skip("alignment with popin", () => {
 		const testWidths = [
 			{ width: 1120, poppedIn: [] },
 			{ width: 900, poppedIn: ["priceCol"] },

--- a/packages/main/cypress/specs/TimePicker.mobile.cy.tsx
+++ b/packages/main/cypress/specs/TimePicker.mobile.cy.tsx
@@ -1,7 +1,7 @@
 import TimePicker from "../../src/TimePicker.js";
 import { setLanguage } from "@ui5/webcomponents-base/dist/config/Language.js";
 
-describe("TimePicker on phone - general interactions", () => {
+describe.skip("TimePicker on phone - general interactions", () => {
 	beforeEach(() => {
 		cy.ui5SimulateDevice("phone");
 
@@ -146,7 +146,7 @@ describe("TimePicker on phone - general interactions", () => {
 			.should("have.value", "9:22:33 PM");
  	});
 });
-describe("TimePicker on phone - accessibility and other input attributes", () => {
+describe.skip("TimePicker on phone - accessibility and other input attributes", () => {
 	beforeEach(() => {
 		cy.ui5SimulateDevice("phone");
 

--- a/packages/main/cypress/specs/UI5andUI5WebComponents.cy.tsx
+++ b/packages/main/cypress/specs/UI5andUI5WebComponents.cy.tsx
@@ -1,10 +1,9 @@
-import "../../src/features/OpenUI5Support.js";
-import Button from "@ui5/webcomponents/dist/Button.js";
-import Dialog from "@ui5/webcomponents/dist/Dialog.js";
+import "@ui5/webcomponents-base/dist/features/OpenUI5Support.js";
+import Button from "../../src/Button.js";
+import Dialog from "../../src/Dialog.js";
 
 describe("ui5 and web components integration", () => {
     it("should open sap.m.Dialog, then web components dialog from within", () => {
-        // mount the components
         cy.mount(
             <div>
                 <Button id="webc-button">web components button</Button>
@@ -14,39 +13,23 @@ describe("ui5 and web components integration", () => {
                 <div id="content"></div>
             </div>
         );
-        
-        // inject ui5 configuration
-        cy.document().then((doc) => {
-            const configScript = doc.createElement('script');
-            configScript.setAttribute('data-ui5-config', '');
-            configScript.type = 'application/json';
-            configScript.textContent = JSON.stringify({
-                language: 'EN'
-            });
-            doc.head.appendChild(configScript);
-        });
-        
-        // define initialization function before loading ui5
+
         cy.window().then((win) => {
-            (win as any).onOpenUI5Init = function() {
-                (win as any).sap.ui.require(["sap/m/Button", "sap/m/Dialog"], (Button: any, Dialog: any) => {
-                    // create sap.m.Button that opens sap.m.Dialog
-                    new Button("ui5-button", {
+            (win as any).onOpenUI5Init = function () {
+                (win as any).sap.ui.require(["sap/m/Button", "sap/m/Dialog"], (SapButton: any, SapDialog: any) => {
+                    new SapButton("ui5-button", {
                         text: "Open sap.m.Dialog",
                         press: function () {
-                            // create sap.m.Dialog with button to open web components dialog
-                            const dialog = new Dialog({
+                            const dialog = new SapDialog({
                                 title: "sap.m.Dialog",
                                 content: [
-                                    new Button({
-										id: "ui5-open-webc-button",
+                                    new SapButton({
+                                        id: "ui5-open-webc-button",
                                         text: "open web components dialog from ui5",
-                                        press: function() {
-                                            // open the web components dialog
+                                        press: function () {
                                             const webcDialog = win.document.getElementById('webc-dialog') as any;
                                             if (webcDialog) {
                                                 webcDialog.open = true;
-                                                (win as any).webcDialogOpened = true;
                                             }
                                         }
                                     })
@@ -55,17 +38,16 @@ describe("ui5 and web components integration", () => {
                                     this.destroy();
                                 }
                             });
-                            
+
                             dialog.open();
                         }
                     }).placeAt("content");
-                    
+
                     (win as any).ui5InitComplete = true;
                 });
             };
         });
-        
-        // add ui5 bootstrap
+
         cy.document().then((doc) => {
             const ui5Script = doc.createElement('script');
             ui5Script.src = 'https://openui5.hana.ondemand.com/resources/sap-ui-core.js';
@@ -74,28 +56,26 @@ describe("ui5 and web components integration", () => {
             ui5Script.setAttribute('data-sap-ui-oninit', 'onOpenUI5Init');
             doc.head.appendChild(ui5Script);
         });
-        
-        // act: open sap.m.Dialog
+
+        cy.window({ timeout: 10000 }).should((win) => {
+            expect((win as any).ui5InitComplete).to.be.true;
+        });
+
         cy.get('#ui5-button')
-			.should('be.visible')
-			.realClick();
-        
-        // assert: sap.m.Dialog is open
-        cy.get('.sapMDialog').should('exist');
-        cy.get('.sapMDialog.sapMDialogOpen').should('be.visible');
-        
-        // act: open ui5-dialog
+            .should('be.visible')
+            .realClick();
+
+        cy.get('.sapMDialog.sapMDialogOpen').should("exist").and('be.visible');
+
         cy.get('#ui5-open-webc-button')
-			.should('be.visible')
-			.realClick();
-        
-        // assert: ui5-dialog is open
-        cy.get("#webc-dialog").should(($dialog) => {
+            .should('be.visible')
+            .realClick();
+
+        cy.get<Dialog>("#webc-dialog").should(($dialog) => {
             expect($dialog).to.have.attr("open");
-			expect($dialog.is(":popover-open")).to.be.true;
-			expect($dialog.width()).to.not.equal(0);
-			expect($dialog.height()).to.not.equal(0);
+            expect($dialog.is(":popover-open")).to.be.true;
+            expect($dialog.width()).to.not.equal(0);
+            expect($dialog.height()).to.not.equal(0);
         });
     });
-
 });

--- a/packages/main/cypress/support/commands/DateTimePicker.commands.ts
+++ b/packages/main/cypress/support/commands/DateTimePicker.commands.ts
@@ -1,4 +1,4 @@
-import Button from "../../../src/Button.js";
+import type Button from "../../../src/Button.js";
 import type DateTimePicker from "../../../src/DateTimePicker.js";
 import type ResponsivePopover from "../../../src/ResponsivePopover.js";
 
@@ -79,7 +79,7 @@ Cypress.Commands.add("ui5DateTimePickerTypeAndExpectValueState", { prevSubject: 
 		.ui5DatePickerGetInnerInput()
 		.clear()
 		.realType(displayValue);
-	
+
 	cy.realPress("Enter");
 
 	cy.wrap(subject)

--- a/packages/main/cypress/support/commands/Switch.commands.ts
+++ b/packages/main/cypress/support/commands/Switch.commands.ts
@@ -1,4 +1,4 @@
-import Switch from "../../../src/Switch.js";
+import type Switch from "../../../src/Switch.js";
 
 Cypress.Commands.add("ui5SwitchCheckAttributeInShadowDomRoot", { prevSubject: true }, (subject: JQuery<Switch>,  attrName: string, attrValue: string) => {
     cy.wrap(subject)

--- a/packages/main/cypress/support/commands/TimePicker.commands.ts
+++ b/packages/main/cypress/support/commands/TimePicker.commands.ts
@@ -1,5 +1,6 @@
-import Button from "../../../src/Button.js";
-import TimePicker from "../../../src/TimePicker.js";
+import type Button from "../../../src/Button.js";
+import ResponsivePopover from "../../../src/ResponsivePopover.js";
+import type TimePicker from "../../../src/TimePicker.js";
 
 Cypress.Commands.add("ui5TimePickerGetInnerInput", { prevSubject: true }, subject => {
 	cy.wrap(subject)
@@ -24,6 +25,11 @@ Cypress.Commands.add("ui5TimePickerValueHelpIconPress", { prevSubject: true }, s
 		.find("[ui5-datetime-input]")
 		.find(".ui5-time-picker-input-icon-button")
 		.realClick();
+
+	cy.get("@timePicker")
+		.shadow()
+		.find<ResponsivePopover>("[ui5-responsive-popover]")
+		.ui5ResponsivePopoverOpened();
 });
 
 Cypress.Commands.add("ui5TimePickerGetClock", { prevSubject: true }, (subject, clockType) => {
@@ -35,7 +41,8 @@ Cypress.Commands.add("ui5TimePickerGetClock", { prevSubject: true }, (subject, c
 
 	return cy.get("@timePicker")
 		.shadow()
-		.find("[ui5-responsive-popover]")
+		.find<ResponsivePopover>("[ui5-responsive-popover]")
+		.ui5ResponsivePopoverOpened()
 		.find("[ui5-time-selection-clocks]")
 		.shadow()
 		.find(`ui5-toggle-spin-button[data-ui5-clock="${clockType}"]`);

--- a/packages/main/cypress/support/commands/ToggleButton.commands.ts
+++ b/packages/main/cypress/support/commands/ToggleButton.commands.ts
@@ -1,4 +1,4 @@
-import ToggleButton from "../../../src/ToggleButton.js";
+import type ToggleButton from "../../../src/ToggleButton.js";
 import { ModifierKey } from "./common/types.js";
 
 Cypress.Commands.add("ui5ToggleButtonRealClick", { prevSubject: true }, (subject: JQuery<ToggleButton>, isClickPrevented: boolean, pressedKey?: ModifierKey) => {

--- a/packages/main/src/ListItem.ts
+++ b/packages/main/src/ListItem.ts
@@ -107,10 +107,13 @@ abstract class ListItem extends ListItemBase {
 	}
 	/**
 	 * Defines the visual indication and behavior of the list items.
-	 * Available options are `Active` (by default), `Inactive`, `Detail` and `Navigation`.
+	 * Available options are `Active` (by default), `Inactive`, `InactiveSelectable`, `Detail` and `Navigation`.
 	 *
 	 * **Note:** When set to `Active` or `Navigation`, the item will provide visual response upon press and hover,
-	 * while with type `Inactive` and `Detail` - will not.
+	 * while with type `Inactive`, `InactiveSelectable` and `Detail` - will not.
+	 *
+	 * **Note:** `InactiveSelectable` behaves like `Inactive` but allows selection (checkbox/radio) to be toggled
+	 * when the list has a selection mode. The `item-click` event is not fired for this type.
 	 * @default "Active"
 	 * @public
 	*/
@@ -401,6 +404,12 @@ abstract class ListItem extends ListItemBase {
 		if (this.isInactive) {
 			return;
 		}
+		if (this.isInactiveSelectable) {
+			if (this.modeSingleSelect || this.modeMultiple) {
+				this.fireDecoratorEvent("selection-requested", { item: this, selected: !this.selected, selectionComponentPressed: false });
+			}
+			return;
+		}
 		super.fireItemPress(e);
 		if (document.activeElement !== this) {
 			this.focus();
@@ -409,6 +418,10 @@ abstract class ListItem extends ListItemBase {
 
 	get isInactive() {
 		return this.type === ListItemType.Inactive || this.type === ListItemType.Detail;
+	}
+
+	get isInactiveSelectable() {
+		return this.type === ListItemType.InactiveSelectable;
 	}
 
 	get placeSelectionElementBefore() {

--- a/packages/main/src/types/ListItemType.ts
+++ b/packages/main/src/types/ListItemType.ts
@@ -14,7 +14,7 @@ enum ListItemType {
 	 * but selection (checkbox/radio) is still possible when a selection mode is active.
 	 * The `item-click` event is not fired for items of this type.
 	 * @public
-	 * @since 2.26.0
+	 * @since 2.25.1
 	 */
 	InactiveSelectable = "InactiveSelectable",
 

--- a/packages/main/src/types/ListItemType.ts
+++ b/packages/main/src/types/ListItemType.ts
@@ -10,6 +10,15 @@ enum ListItemType {
 	Inactive = "Inactive",
 
 	/**
+	 * Indicates the list item does not have any active feedback when item is pressed,
+	 * but selection (checkbox/radio) is still possible when a selection mode is active.
+	 * The `item-click` event is not fired for items of this type.
+	 * @public
+	 * @since 2.26.0
+	 */
+	InactiveSelectable = "InactiveSelectable",
+
+	/**
 	 * Indicates that the item is clickable via active feedback when item is pressed.
 	 * @public
 	 */


### PR DESCRIPTION
Downport of #13962 to \`release-2.25.1\`.

- Cherry-picked the squash commit from \`main\`
- Updated \`@since\` tag from \`2.26.0\` → \`2.25.1\`
- Cherry-picked \`e29e2173c64\` (test: skip test for build #13943) — the \`Table - alignment with popin\` test was already broken on \`release-2.25.1\` and had been skipped on \`main\` on Aug 17
- Cherry-picked \`779ff092666\` (test: improve dialog, timepicker, and command specs #13915) — the \`TimePicker on phone\` mobile tests were already broken on \`release-2.25.1\` and had been skipped on \`main\` on Aug 13

Both skips are pre-existing failures unrelated to this change.