### PR TITLE
feat(ui5-bar): add arrow left/arrow right/home/end navigation

### DIFF
--- a/packages/main/cypress/specs/Bar.cy.tsx
+++ b/packages/main/cypress/specs/Bar.cy.tsx
@@ -1,5 +1,6 @@
 import Bar from "../../src/Bar.js";
 import Button from "../../src/Button.js";
+import Input from "../../src/Input.js";
 
 describe("Bar Accessibility", () => {
 	it("Should use accessibleName property as aria-label", () => {
@@ -63,5 +64,147 @@ describe("Bar Accessibility", () => {
 			.shadow()
 			.find(".ui5-bar-root")
 			.should("have.attr", "aria-label", "External Navigation Label");
+	});
+});
+
+describe("Bar Keyboard Navigation", () => {
+	it("ArrowRight moves focus forward through all three slots", () => {
+		cy.mount(
+			<Bar>
+				<Button id="btn-start" slot="startContent">Start</Button>
+				<Button id="btn-mid">Middle</Button>
+				<Button id="btn-end" slot="endContent">End</Button>
+			</Bar>
+		);
+
+		cy.get("#btn-start").realClick().should("be.focused");
+		cy.realPress("ArrowRight");
+		cy.get("#btn-mid").should("be.focused");
+		cy.realPress("ArrowRight");
+		cy.get("#btn-end").should("be.focused");
+	});
+
+	it("ArrowLeft moves focus backward", () => {
+		cy.mount(
+			<Bar>
+				<Button id="btn-start" slot="startContent">Start</Button>
+				<Button id="btn-mid">Middle</Button>
+				<Button id="btn-end" slot="endContent">End</Button>
+			</Bar>
+		);
+
+		cy.get("#btn-start").realClick().should("be.focused");
+		cy.realPress("ArrowRight");
+		cy.get("#btn-mid").should("be.focused");
+		cy.realPress("ArrowRight");
+		cy.get("#btn-end").should("be.focused");
+		cy.realPress("ArrowLeft");
+		cy.get("#btn-mid").should("be.focused");
+		cy.realPress("ArrowLeft");
+		cy.get("#btn-start").should("be.focused");
+	});
+
+	it("ArrowRight at last item does not move focus", () => {
+		cy.mount(
+			<Bar>
+				<Button id="btn-start" slot="startContent">Start</Button>
+				<Button id="btn-end" slot="endContent">End</Button>
+			</Bar>
+		);
+
+		cy.get("#btn-start").realClick().should("be.focused");
+		cy.realPress("ArrowRight");
+		cy.get("#btn-end").should("be.focused");
+		cy.realPress("ArrowRight");
+		cy.get("#btn-end").should("be.focused");
+	});
+
+	it("ArrowLeft at first item does not move focus", () => {
+		cy.mount(
+			<Bar>
+				<Button id="btn-start" slot="startContent">Start</Button>
+				<Button id="btn-end" slot="endContent">End</Button>
+			</Bar>
+		);
+
+		cy.get("#btn-start").realClick().should("be.focused");
+		cy.realPress("ArrowLeft");
+		cy.get("#btn-start").should("be.focused");
+	});
+
+	it("End key jumps to last focusable item", () => {
+		cy.mount(
+			<Bar>
+				<Button id="btn-start" slot="startContent">Start</Button>
+				<Button id="btn-mid">Middle</Button>
+				<Button id="btn-end" slot="endContent">End</Button>
+			</Bar>
+		);
+
+		cy.get("#btn-start").realClick().should("be.focused");
+		cy.realPress("End");
+		cy.get("#btn-end").should("be.focused");
+	});
+
+	it("Home key jumps to first focusable item", () => {
+		cy.mount(
+			<Bar>
+				<Button id="btn-start" slot="startContent">Start</Button>
+				<Button id="btn-mid">Middle</Button>
+				<Button id="btn-end" slot="endContent">End</Button>
+			</Bar>
+		);
+
+		cy.get("#btn-start").realClick().should("be.focused");
+		cy.realPress("End");
+		cy.get("#btn-end").should("be.focused");
+		cy.realPress("Home");
+		cy.get("#btn-start").should("be.focused");
+	});
+
+	it("ArrowRight inside input with mid-text caret does not move focus", () => {
+		cy.mount(
+			<Bar>
+				<Input id="input-start" slot="startContent" value="hello"></Input>
+				<Button id="btn-end" slot="endContent">End</Button>
+			</Bar>
+		);
+
+		cy.get("#input-start").realClick();
+		// place caret at position 2 (middle of "hello")
+		cy.get("#input-start").shadow().find("input").then($input => {
+			$input[0].setSelectionRange(2, 2);
+		});
+		cy.realPress("ArrowRight");
+		cy.get("#btn-end").should("not.be.focused");
+	});
+
+	it("ArrowRight at end of input text moves focus to next item", () => {
+		cy.mount(
+			<Bar>
+				<Input id="input-start" slot="startContent" value="hello"></Input>
+				<Button id="btn-end" slot="endContent">End</Button>
+			</Bar>
+		);
+
+		cy.get("#input-start").realClick();
+		cy.get("#input-start").shadow().find("input").then($input => {
+			$input[0].setSelectionRange(5, 5); // end of "hello"
+		});
+		cy.realPress("ArrowRight");
+		cy.get("#btn-end").should("be.focused");
+	});
+
+	it("Navigation is disabled when accessibleRole is None", () => {
+		cy.mount(
+			<Bar accessibleRole="None">
+				<Button id="btn-start" slot="startContent">Start</Button>
+				<Button id="btn-end" slot="endContent">End</Button>
+			</Bar>
+		);
+
+		cy.get("#btn-start").realClick().should("be.focused");
+		cy.realPress("ArrowRight");
+		cy.get("#btn-end").should("not.be.focused");
 	});
 });

--- a/packages/main/src/Bar.ts
+++ b/packages/main/src/Bar.ts
@@ -1,4 +1,4 @@
-import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
+import UI5Element, { instanceOfUI5Element } from "@ui5/webcomponents-base/dist/UI5Element.js";
 import type { DefaultSlot, Slot } from "@ui5/webcomponents-base/dist/UI5Element.js";
 import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
 import property from "@ui5/webcomponents-base/dist/decorators/property.js";
@@ -6,6 +6,14 @@ import slot from "@ui5/webcomponents-base/dist/decorators/slot-strict.js";
 import jsxRenderer from "@ui5/webcomponents-base/dist/renderer/JsxRenderer.js";
 import ResizeHandler from "@ui5/webcomponents-base/dist/delegate/ResizeHandler.js";
 import { getEffectiveAriaLabelText } from "@ui5/webcomponents-base/dist/util/AccessibilityTextsHelper.js";
+import isElementHidden from "@ui5/webcomponents-base/dist/util/isElementHidden.js";
+import getActiveElement from "@ui5/webcomponents-base/dist/util/getActiveElement.js";
+import {
+	isLeft,
+	isRight,
+	isHome,
+	isEnd,
+} from "@ui5/webcomponents-base/dist/Keys.js";
 import type BarDesign from "./types/BarDesign.js";
 import type BarAccessibleRole from "./types/BarAccessibleRole.js";
 
@@ -35,6 +43,13 @@ import type { AriaRole } from "@ui5/webcomponents-base/dist/types.js";
  * therefore it might not always be centered in the entire bar.
  *
  * ### Keyboard Handling
+ *
+ * The `ui5-bar` provides advanced keyboard handling among interactive components inside it, no matter in which slot they are placed.
+ *
+ * #### Regular Navigation
+ * - [Left] / [Right] - navigate backward/forward among interactive components
+ * - [Home] / [End] - move to first/last interactive components
+ * - [Tab] / [Shift]+[Tab] - navigate forward/backward among interactive components
  *
  * #### Fast Navigation
  * This component provides a build in fast navigation group which can be used via [F6] / [Shift] + [F6] / [Ctrl] + [Alt/Option] / [Down] or [Ctrl] + [Alt/Option] + [Up].
@@ -128,6 +143,7 @@ class Bar extends UI5Element {
 	endContent!: Slot<HTMLElement>;
 
 	_handleResizeBound: () => void;
+	_onKeyDownBound: (e: KeyboardEvent) => void;
 
 	get accInfo() {
 		return {
@@ -148,6 +164,7 @@ class Bar extends UI5Element {
 		super();
 
 		this._handleResizeBound = this.handleResize.bind(this);
+		this._onKeyDownBound = this._onKeyDown.bind(this);
 	}
 
 	handleResize() {
@@ -166,6 +183,8 @@ class Bar extends UI5Element {
 		this.getDomRef()!.querySelectorAll(".ui5-bar-content-container").forEach(child => {
 			ResizeHandler.register(child as HTMLElement, this._handleResizeBound);
 		}, this);
+
+		this.addEventListener("keydown", this._onKeyDownBound, true);
 	}
 
 	onExitDOM() {
@@ -174,11 +193,151 @@ class Bar extends UI5Element {
 		this.getDomRef()!.querySelectorAll(".ui5-bar-content-container").forEach(child => {
 			ResizeHandler.deregister(child as HTMLElement, this._handleResizeBound);
 		}, this);
+
+		this.removeEventListener("keydown", this._onKeyDownBound, true);
 	 }
 
 	 get effectiveRole() {
 		return this.accessibleRole.toLowerCase() === "toolbar" ? "toolbar" as AriaRole : undefined;
 	 }
+
+	_collectFocusableElements(): Array<HTMLElement> {
+		const slotSelectors = [
+			"slot[name=\"startContent\"]",
+			"slot:not([name])",
+			"slot[name=\"endContent\"]",
+		];
+		const result: Array<HTMLElement> = [];
+
+		slotSelectors.forEach(sel => {
+			const slotEl = this.shadowRoot!.querySelector<HTMLSlotElement>(sel);
+			if (!slotEl) {
+				return;
+			}
+			(slotEl.assignedElements({ flatten: true }) as HTMLElement[]).forEach(el => {
+				result.push(...this._getFocusableFromElement(el));
+			});
+		});
+		return result;
+	}
+
+	_getFocusableFromElement(el: HTMLElement): Array<HTMLElement> {
+		if (isElementHidden(el)) {
+			return [];
+		}
+
+		if (instanceOfUI5Element(el)) {
+			const focusRef = el.getFocusDomRef();
+			if (focusRef && focusRef.tabIndex >= 0 && !isElementHidden(focusRef) && !(focusRef as HTMLInputElement).disabled) {
+				return [focusRef];
+			}
+			return [];
+		}
+
+		if (el.tabIndex >= 0 && !(el as HTMLInputElement).disabled) {
+			return [el];
+		}
+
+		// Non-focusable container: recurse into children
+		const nested: Array<HTMLElement> = [];
+		Array.from(el.children).forEach(child => {
+			nested.push(...this._getFocusableFromElement(child as HTMLElement));
+		});
+		return nested;
+	}
+
+	_hasCaretNavigation(el: EventTarget | null): el is HTMLInputElement | HTMLTextAreaElement {
+		if (!(el instanceof HTMLElement)) {
+			return false;
+		}
+		const tag = el.tagName.toLowerCase();
+		if (tag === "textarea") {
+			return true;
+		}
+		if (tag !== "input") {
+			return false;
+		}
+		const type = (el as HTMLInputElement).type.toLowerCase();
+		return ["text", "search", "url", "tel", "password", ""].includes(type);
+	}
+
+	_onKeyDown(e: KeyboardEvent) {
+		if (this.effectiveRole !== "toolbar") {
+			return;
+		}
+
+		const isForward = this.effectiveDir === "rtl" ? isLeft(e) : isRight(e);
+		const isBackward = this.effectiveDir === "rtl" ? isRight(e) : isLeft(e);
+		const isHomeKey = isHome(e);
+		const isEndKey = isEnd(e);
+
+		if (!isForward && !isBackward && !isHomeKey && !isEndKey) {
+			return;
+		}
+
+		const items = this._collectFocusableElements();
+		if (items.length === 0) {
+			return;
+		}
+
+		const active = getActiveElement() as HTMLElement | null;
+		if (!active) {
+			return;
+		}
+
+		const currentIndex = items.findIndex(item => this._isNodeInsideElement(active, item));
+		if (currentIndex === -1) {
+			return;
+		}
+
+		if (this._hasCaretNavigation(active)) {
+			const input = active as HTMLInputElement;
+			if (isHomeKey || isEndKey) {
+				return;
+			}
+			if (isForward && input.selectionStart !== input.value.length) {
+				return;
+			}
+			if (isBackward && input.selectionStart !== 0) {
+				return;
+			}
+		}
+
+		let nextIndex: number;
+		if (isHomeKey) {
+			nextIndex = 0;
+		} else if (isEndKey) {
+			nextIndex = items.length - 1;
+		} else if (isForward) {
+			nextIndex = Math.min(currentIndex + 1, items.length - 1);
+		} else {
+			nextIndex = Math.max(currentIndex - 1, 0);
+		}
+
+		if (nextIndex === currentIndex) {
+			return;
+		}
+
+		items[nextIndex].focus();
+		e.preventDefault();
+		e.stopPropagation();
+	}
+
+	_isNodeInsideElement(node: Node, element: HTMLElement): boolean {
+		let current: Node | null = node;
+		while (current) {
+			if (current === element) {
+				return true;
+			}
+			const root = current.getRootNode?.();
+			if (root instanceof ShadowRoot) {
+				current = root.host;
+			} else {
+				current = current.parentNode;
+			}
+		}
+		return false;
+	}
 }
 
 Bar.define();

--- a/packages/main/src/Bar.ts
+++ b/packages/main/src/Bar.ts
@@ -14,6 +14,8 @@ import {
 	isHome,
 	isEnd,
 } from "@ui5/webcomponents-base/dist/Keys.js";
+import type { ToolbarArrowNavState } from "./IToolbarArrowNavProvider.js";
+import { isToolbarArrowNavProvider } from "./IToolbarArrowNavProvider.js";
 import type BarDesign from "./types/BarDesign.js";
 import type BarAccessibleRole from "./types/BarAccessibleRole.js";
 
@@ -144,6 +146,10 @@ class Bar extends UI5Element {
 
 	_handleResizeBound: () => void;
 	_onKeyDownBound: (e: KeyboardEvent) => void;
+	_captureActiveElementBound: (e: KeyboardEvent) => void;
+	_activeAtKeyDown: HTMLElement | null = null;
+	_hasArrowNavProvider = false;
+	_arrowNavStateAtKeyDown: ToolbarArrowNavState | undefined = undefined;
 
 	get accInfo() {
 		return {
@@ -165,6 +171,7 @@ class Bar extends UI5Element {
 
 		this._handleResizeBound = this.handleResize.bind(this);
 		this._onKeyDownBound = this._onKeyDown.bind(this);
+		this._captureActiveElementBound = this._captureActiveElement.bind(this);
 	}
 
 	handleResize() {
@@ -184,7 +191,8 @@ class Bar extends UI5Element {
 			ResizeHandler.register(child as HTMLElement, this._handleResizeBound);
 		}, this);
 
-		this.addEventListener("keydown", this._onKeyDownBound, true);
+		this.addEventListener("keydown", this._captureActiveElementBound, true);
+		this.addEventListener("keydown", this._onKeyDownBound);
 	}
 
 	onExitDOM() {
@@ -194,7 +202,8 @@ class Bar extends UI5Element {
 			ResizeHandler.deregister(child as HTMLElement, this._handleResizeBound);
 		}, this);
 
-		this.removeEventListener("keydown", this._onKeyDownBound, true);
+		this.removeEventListener("keydown", this._captureActiveElementBound, true);
+		this.removeEventListener("keydown", this._onKeyDownBound);
 	 }
 
 	 get effectiveRole() {
@@ -202,63 +211,90 @@ class Bar extends UI5Element {
 	 }
 
 	_collectFocusableElements(): Array<HTMLElement> {
+		const contentSlotSelectors = [
+			"slot[name=\"startContent\"]",
+			"slot:not([name])",
+			"slot[name=\"endContent\"]",
+		];
+		const focusableElements: Array<HTMLElement> = [];
+
+		contentSlotSelectors.forEach(slotSelector => {
+			const contentSlot = this.shadowRoot!.querySelector<HTMLSlotElement>(slotSelector);
+			if (!contentSlot) {
+				return;
+			}
+			(contentSlot.assignedElements({ flatten: true }) as HTMLElement[]).forEach(assignedElement => {
+				focusableElements.push(...this._getFocusableFromElement(assignedElement));
+			});
+		});
+		return focusableElements;
+	}
+
+	_getFocusableFromElement(element: HTMLElement): Array<HTMLElement> {
+		if (isElementHidden(element)) {
+			return [];
+		}
+
+		if (instanceOfUI5Element(element)) {
+			const focusDomRef = element.getFocusDomRef();
+			if (focusDomRef && focusDomRef.tabIndex >= 0 && !isElementHidden(focusDomRef) && !(focusDomRef as HTMLInputElement).disabled) {
+				return [focusDomRef];
+			}
+			return [];
+		}
+
+		if (element.tabIndex >= 0 && !(element as HTMLInputElement).disabled) {
+			return [element];
+		}
+
+		// Non-focusable container: recurse into children
+		const childFocusables: Array<HTMLElement> = [];
+		Array.from(element.children).forEach(child => {
+			childFocusables.push(...this._getFocusableFromElement(child as HTMLElement));
+		});
+		return childFocusables;
+	}
+
+	_hasCaretNavigation(element: EventTarget | null): element is HTMLInputElement | HTMLTextAreaElement {
+		if (!(element instanceof HTMLElement)) {
+			return false;
+		}
+		const tagName = element.tagName.toLowerCase();
+		if (tagName === "textarea") {
+			return true;
+		}
+		if (tagName !== "input") {
+			return false;
+		}
+		const inputType = (element as HTMLInputElement).type.toLowerCase();
+		return ["text", "search", "url", "tel", "password", ""].includes(inputType);
+	}
+
+	_findOwnerArrowNavProvider(activeElement: HTMLElement) {
 		const slotSelectors = [
 			"slot[name=\"startContent\"]",
 			"slot:not([name])",
 			"slot[name=\"endContent\"]",
 		];
-		const result: Array<HTMLElement> = [];
-
-		slotSelectors.forEach(sel => {
-			const slotEl = this.shadowRoot!.querySelector<HTMLSlotElement>(sel);
-			if (!slotEl) {
-				return;
+		for (const slotSelector of slotSelectors) {
+			const slotElement = this.shadowRoot!.querySelector<HTMLSlotElement>(slotSelector);
+			if (!slotElement) {
+				continue;
 			}
-			(slotEl.assignedElements({ flatten: true }) as HTMLElement[]).forEach(el => {
-				result.push(...this._getFocusableFromElement(el));
-			});
-		});
-		return result;
+			for (const slottedElement of slotElement.assignedElements({ flatten: true }) as HTMLElement[]) {
+				if (isToolbarArrowNavProvider(slottedElement) && this._isNodeInsideElement(activeElement, slottedElement)) {
+					return slottedElement;
+				}
+			}
+		}
+		return null;
 	}
 
-	_getFocusableFromElement(el: HTMLElement): Array<HTMLElement> {
-		if (isElementHidden(el)) {
-			return [];
-		}
-
-		if (instanceOfUI5Element(el)) {
-			const focusRef = el.getFocusDomRef();
-			if (focusRef && focusRef.tabIndex >= 0 && !isElementHidden(focusRef) && !(focusRef as HTMLInputElement).disabled) {
-				return [focusRef];
-			}
-			return [];
-		}
-
-		if (el.tabIndex >= 0 && !(el as HTMLInputElement).disabled) {
-			return [el];
-		}
-
-		// Non-focusable container: recurse into children
-		const nested: Array<HTMLElement> = [];
-		Array.from(el.children).forEach(child => {
-			nested.push(...this._getFocusableFromElement(child as HTMLElement));
-		});
-		return nested;
-	}
-
-	_hasCaretNavigation(el: EventTarget | null): el is HTMLInputElement | HTMLTextAreaElement {
-		if (!(el instanceof HTMLElement)) {
-			return false;
-		}
-		const tag = el.tagName.toLowerCase();
-		if (tag === "textarea") {
-			return true;
-		}
-		if (tag !== "input") {
-			return false;
-		}
-		const type = (el as HTMLInputElement).type.toLowerCase();
-		return ["text", "search", "url", "tel", "password", ""].includes(type);
+	_captureActiveElement() {
+		this._activeAtKeyDown = getActiveElement() as HTMLElement | null;
+		const provider = this._activeAtKeyDown ? this._findOwnerArrowNavProvider(this._activeAtKeyDown) : null;
+		this._hasArrowNavProvider = provider !== null;
+		this._arrowNavStateAtKeyDown = provider ? provider.getArrowNavState() : undefined;
 	}
 
 	_onKeyDown(e: KeyboardEvent) {
@@ -273,6 +309,27 @@ class Bar extends UI5Element {
 
 		if (!isForward && !isBackward && !isHomeKey && !isEndKey) {
 			return;
+		}
+
+		if (isForward || isBackward) {
+			if (this._hasArrowNavProvider) {
+				const navState = this._arrowNavStateAtKeyDown;
+				if (!navState) {
+					return;
+				}
+				if (isForward && !navState.atRightEnd) {
+					return;
+				}
+				if (isBackward && !navState.atLeftEnd) {
+					return;
+				}
+			} else if (e.defaultPrevented) {
+				// Fallback for composite widgets not implementing IToolbarArrowNavProvider.
+				// Focus stayed on the same element → component was at its boundary.
+				if (getActiveElement() !== this._activeAtKeyDown) {
+					return;
+				}
+			}
 		}
 
 		const items = this._collectFocusableElements();
@@ -295,10 +352,11 @@ class Bar extends UI5Element {
 			if (isHomeKey || isEndKey) {
 				return;
 			}
-			if (isForward && input.selectionStart !== input.value.length) {
+			const selectionStart = input.selectionStart ?? 0;
+			if (isForward && selectionStart !== input.value.length) {
 				return;
 			}
-			if (isBackward && input.selectionStart !== 0) {
+			if (isBackward && selectionStart !== 0) {
 				return;
 			}
 		}
@@ -325,6 +383,7 @@ class Bar extends UI5Element {
 
 	_isNodeInsideElement(node: Node, element: HTMLElement): boolean {
 		let current: Node | null = node;
+
 		while (current) {
 			if (current === element) {
 				return true;
@@ -336,6 +395,7 @@ class Bar extends UI5Element {
 				current = current.parentNode;
 			}
 		}
+
 		return false;
 	}
 }

--- a/packages/main/src/Bar.ts
+++ b/packages/main/src/Bar.ts
@@ -91,9 +91,9 @@ class Bar extends UI5Element {
 	 *
 	 * - By default, accessibleRole is set to "Toolbar", which renders the ARIA role "toolbar".
 	 *
-	 * - Use the default accessibleRole value "Toolbar" only when the component contains two or more active, interactive elements (such as buttons, links, or input fields) within the bar.
+	 * - Use the default accessibleRole value "Toolbar" only when the component contains three or more active, interactive elements (such as buttons, links, or input fields) within the bar.
 	 *
-	 * - If there is only one or no active element, set accessibleRole to "None" to avoid rendering the ARIA role "toolbar", as that role implies a grouping of multiple interactive controls.
+	 * - If there is only one, two or no active element, set accessibleRole to "None" to avoid rendering the ARIA role "toolbar", as that role implies a grouping of multiple interactive controls.
 	 *
 	 * @public
 	 * @default "Toolbar"

--- a/packages/main/src/SegmentedButton.ts
+++ b/packages/main/src/SegmentedButton.ts
@@ -21,6 +21,8 @@ import {
 	isEscape,
 	isSpaceShift,
 } from "@ui5/webcomponents-base/dist/Keys.js";
+import getActiveElement from "@ui5/webcomponents-base/dist/util/getActiveElement.js";
+import type { ToolbarArrowNavState, IToolbarArrowNavProvider } from "./IToolbarArrowNavProvider.js";
 import { LIST_ITEM_SELECTED } from "./generated/i18n/i18n-defaults.js";
 import announce from "@ui5/webcomponents-base/dist/util/InvisibleMessage.js";
 import InvisibleMessageMode from "@ui5/webcomponents-base/dist/types/InvisibleMessageMode.js";
@@ -81,7 +83,7 @@ type SegmentedButtonSelectionChangeEventDetail = {
 	bubbles: true,
 })
 
-class SegmentedButton extends UI5Element {
+class SegmentedButton extends UI5Element implements IToolbarArrowNavProvider {
 	eventDetails!: {
 		"selection-change": SegmentedButtonSelectionChangeEventDetail,
 	}
@@ -215,6 +217,24 @@ class SegmentedButton extends UI5Element {
 
 	getFocusDomRef(): HTMLElement | undefined {
 		return this._itemNavigation._getCurrentItem();
+	}
+
+	getArrowNavState(): ToolbarArrowNavState | undefined {
+		const items = this.navigatableItems;
+		const active = getActiveElement() as HTMLElement | null;
+		if (!active) {
+			return undefined;
+		}
+		const idx = items.findIndex(item =>
+			item === active || item.shadowRoot?.contains(active) || item.contains(active)
+		);
+		if (idx === -1) {
+			return undefined;
+		}
+		return {
+			atLeftEnd: idx === 0,
+			atRightEnd: idx === items.length - 1,
+		};
 	}
 
 	_selectItem(e: MouseEvent | KeyboardEvent) {

--- a/packages/main/test/pages/Bar.html
+++ b/packages/main/test/pages/Bar.html
@@ -81,6 +81,12 @@
 			<ui5-input placeholder="Type here..."></ui5-input>
 			<ui5-button icon="search">Search</ui5-button>
 
+			<ui5-segmented-button>
+				<ui5-segmented-button-item icon="list"></ui5-segmented-button-item>
+				<ui5-segmented-button-item icon="grid"></ui5-segmented-button-item>
+				<ui5-segmented-button-item icon="table-view"></ui5-segmented-button-item>
+			</ui5-segmented-button>
+
 			<ui5-link slot="endContent" href="#">Help</ui5-link>
 			<ui5-button icon="action-settings" design="Transparent" slot="endContent">Settings</ui5-button>
 			<ui5-button design="Positive" slot="endContent">Save</ui5-button>

--- a/packages/main/test/pages/Bar.html
+++ b/packages/main/test/pages/Bar.html
@@ -71,6 +71,20 @@
 			<ui5-button design="Negative" slot="endContent">Decline</ui5-button>
 			<ui5-button design="Transparent" slot="endContent">Cancel</ui5-button>
 		</ui5-bar>
+		<br>
+		<ui5-title level="3">Mixed content (texts, buttons, links, inputs)</ui5-title>
+		<ui5-bar design="Header">
+			<ui5-button icon="nav-back" slot="startContent">Back</ui5-button>
+			<ui5-link slot="startContent" href="#">Home</ui5-link>
+
+			<ui5-label>Search:</ui5-label>
+			<ui5-input placeholder="Type here..."></ui5-input>
+			<ui5-button icon="search">Search</ui5-button>
+
+			<ui5-link slot="endContent" href="#">Help</ui5-link>
+			<ui5-button icon="action-settings" design="Transparent" slot="endContent">Settings</ui5-button>
+			<ui5-button design="Positive" slot="endContent">Save</ui5-button>
+		</ui5-bar>
 	</section>
 
 	<section>


### PR DESCRIPTION
The WAI-ARIA toolbar pattern requires that interactive controls inside a toolbar are navigable with arrow keys. Without this, keyboard users have no standard way to move between actions in the bar other than Tab, which is cumbersome when many controls are present.

This PR introduces arrow key navigation to `ui5-bar`. When the bar has `role="toolbar"` (the default), pressing `ArrowRight` / `ArrowLeft` moves focus between all focusable elements across the bar's three slots (`startContent`, `middle/default`, `endContent`) in DOM order. `Home` and `End` jump directly to the first or last focusable item. Text inputs inside the bar are handled carefully — arrow keys only leave the input when the cursor is already at its edge, so normal text editing still works as expected. `ui5-bar` components with `accessibleRole` different than `Toolbar` are unaffected.