### PR TITLE
fix(ui5-time-picker): correct color and font tokens per UXC visual spec

### DIFF
--- a/packages/main/src/themes/TimePickerClock.css
+++ b/packages/main/src/themes/TimePickerClock.css
@@ -121,7 +121,7 @@
 	line-height: 2.75rem;
 	text-align: center;
 	vertical-align: top;
-	font-family: var(--sapFontFamily);
+	font-family: var(--sapFontBoldFamily);
 	font-size: var(--sapFontSize);
 	color: var(--sapTextColor);
 	border: 0.0625rem solid transparent;

--- a/packages/main/src/themes/TimeSelectionClocks.css
+++ b/packages/main/src/themes/TimeSelectionClocks.css
@@ -24,7 +24,7 @@
 	text-align: center;
 	font-family: var(--sapFontFamily);
 	font-size: var(--sapFontSize);
-	color: var(--sapContent_LabelColor);
+	color: var(--sapTextColor);
 }
 
 .ui5-time-picker-tsc-clocks {


### PR DESCRIPTION
- Apply sapTextColor to ui5-time-selection-separator elements (colon separators between hours/minutes/seconds spinbuttons) instead of sapContent_LabelColor
- Apply sapFontBoldFamily to ui5-tp-clock-number elements (clock face digits) instead of sapFontFamily

Fixes: https://github.com/UI5/webcomponents/issues/13956
