### PR TITLE
docs(ui5-date-picker): document locale-aware relative date input

### DIFF
--- a/packages/main/src/DatePicker.ts
+++ b/packages/main/src/DatePicker.ts
@@ -139,8 +139,8 @@ type Picker = "day" | "month" | "year";
  * - Month: "this month", "last month", "next month"
  * - Year: "this year", "last year", "next year"
  *
- * The recognized expressions are locale-specific — the equivalent terms in the user's language are used (e.g. "heute" in German, "bugün" in Turkish).
- * Week, month, and year expressions resolve to an offset from today (e.g. "next week" = today + 7 days).
+ * The recognized expressions are locale-specific — the equivalent terms in the user's language are used (for example, "heute" in German, "bugün" in Turkish).
+ * Week, month, and year expressions resolve to an offset from today (for example, "next week" = today + 7 days).
  * For the full list of supported fields and patterns, see [CLDR Date Fields](https://unicode.org/reports/tr35/tr35-dates.html#Calendar_Fields).
  *
  * ### Keyboard Handling

--- a/packages/main/src/DatePicker.ts
+++ b/packages/main/src/DatePicker.ts
@@ -129,6 +129,20 @@ type Picker = "day" | "month" | "year";
  * For example, if the valueFormat is "yyyy-MM-dd", the displayFormat is "MMM d, y", and the used locale is English, a valid value string is "2015-07-30", which leads to an output of "Jul 30, 2015".
  * If no placeholder is set to the DatePicker, the used displayFormat is displayed as a placeholder. If another placeholder is needed, it must be set.
  *
+ * ### Relative date input
+ *
+ * The input field also accepts locale-aware relative date expressions sourced from the Unicode CLDR.
+ * The following expressions are supported in English:
+ *
+ * - Day: "today", "yesterday", "tomorrow"
+ * - Week: "this week", "last week", "next week"
+ * - Month: "this month", "last month", "next month"
+ * - Year: "this year", "last year", "next year"
+ *
+ * The recognized expressions are locale-specific — the equivalent terms in the user's language are used (e.g. "heute" in German, "bugün" in Turkish).
+ * Week, month, and year expressions resolve to an offset from today (e.g. "next week" = today + 7 days).
+ * For the full list of supported fields and patterns, see [CLDR Date Fields](https://unicode.org/reports/tr35/tr35-dates.html#Calendar_Fields).
+ *
  * ### Keyboard Handling
  * The `ui5-date-picker` provides advanced keyboard handling.
  * If the `ui5-date-picker` is focused,


### PR DESCRIPTION
Add a "Relative date input" section to the component overview explaining that the input field accepts CLDR-based relative expressions such as "today", "yesterday", "next week", and "last month". Notes that supported terms are locale-specific and that week/month/year expressions resolve as offsets from today, with a link to the CLDR Date Fields spec.

Related to: BGSOFUIBALKAN-11043