### PR TITLE
fix(ui5-icon): replace size containment with font-size for icon sizing

### DIFF
--- a/packages/main/src/Icon.ts
+++ b/packages/main/src/Icon.ts
@@ -203,6 +203,8 @@ class Icon extends UI5Element implements IIcon {
 	 * When this slot is used, the component renders a `<span>` instead of an `<svg>`.
 	 * Accessibility is fully delegated to the application — set `accessible-name` and `mode` explicitly.
 	 *
+	 * **Note:** To control the glyph size, set `font-size` on the `ui5-icon` host element.
+	 *
 	 * **Example:**
 	 * ```html
 	 * <ui5-icon mode="Image" accessible-name="Home">

--- a/packages/main/src/themes/CheckBox.css
+++ b/packages/main/src/themes/CheckBox.css
@@ -240,6 +240,7 @@
 .ui5-checkbox-icon {
 	width: var(--_ui5_checkbox_icon_size);
 	height: var(--_ui5_checkbox_icon_size);
+	font-size: inherit;
 	color: currentColor;
 	cursor: inherit;
 	position: absolute;

--- a/packages/main/src/themes/Icon.css
+++ b/packages/main/src/themes/Icon.css
@@ -17,10 +17,10 @@
 	display: inline-block;
 	width: 1rem;
 	height: 1rem;
+	font-size: 1rem;
 	color: var(--sapContent_IconColor);
 	fill: currentColor;
 	outline: none;
-	container-type: size;
 }
 
 :host([design="Contrast"]) {
@@ -66,7 +66,7 @@
 	box-sizing: border-box;
 	align-items: center;
 	justify-content: center;
-	font-size: min(100cqw, 100cqh);
+	font-size: inherit;
 	line-height: 1;
 }
 

--- a/packages/main/test/pages/Icon_symbol.html
+++ b/packages/main/test/pages/Icon_symbol.html
@@ -9,7 +9,8 @@
 	<script src="%VITE_BUNDLE_PATH%" type="module"></script>
 
 	<!-- Material Symbols -->
-	<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" />
+	<link rel="stylesheet"
+		href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" />
 
 	<!-- Font Awesome Free -->
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css" />
@@ -44,7 +45,8 @@
 			margin-top: 1rem;
 		}
 
-		th, td {
+		th,
+		td {
 			border: 1px solid var(--sapList_BorderColor, #ccc);
 			padding: 0.5rem 1rem;
 			text-align: center;
@@ -65,6 +67,7 @@
 		ui5-icon {
 			width: 1.5rem;
 			height: 1.5rem;
+			font-size: 1.5rem;
 		}
 	</style>
 	<!-- SAP Icons font (application-hosted) -->
@@ -84,7 +87,8 @@
 
 <body>
 	<h2>Icon - symbol slot</h2>
-	<p>Font-based icons via the <code>symbol</code> slot. The application loads the font; <code>ui5-icon</code> wraps it for sizing, design tokens, and accessibility.</p>
+	<p>Font-based icons via the <code>symbol</code> slot. The application loads the font; <code>ui5-icon</code> wraps it
+		for sizing, design tokens, and accessibility.</p>
 
 	<table>
 		<thead>
@@ -275,59 +279,60 @@
 			</tr>
 			<tr>
 				<td>3rem size</td>
-				<td><ui5-icon name="settings" style="width:3rem;height:3rem"></ui5-icon></td>
+				<td><ui5-icon name="settings" style="width:3rem;height:3rem; font-size: 3rem;"></ui5-icon></td>
 				<td>
-					<ui5-icon style="width:3rem;height:3rem">
+					<ui5-icon style="width:3rem;height:3rem; font-size: 3rem;">
 						<span slot="fontIcon" class="sap-icon-font">&#xe00c;</span>
 					</ui5-icon>
 				</td>
 				<td>
-					<ui5-icon style="width:3rem;height:3rem">
+					<ui5-icon style="width:3rem;height:3rem; font-size: 3rem;">
 						<span slot="fontIcon" class="material-symbols-outlined">settings</span>
 					</ui5-icon>
 				</td>
 				<td>
-					<ui5-icon style="width:3rem;height:3rem">
+					<ui5-icon style="width:3rem;height:3rem; font-size: 3rem;">
 						<i slot="fontIcon" class="fa-solid fa-gear"></i>
 					</ui5-icon>
 				</td>
 				<td>
-					<ui5-icon style="width:3rem;height:3rem">
+					<ui5-icon style="width:3rem;height:3rem; font-size: 3rem;">
 						<i slot="fontIcon" class="bi bi-gear"></i>
 					</ui5-icon>
 				</td>
 				<td>
-					<ui5-icon style="width:3rem;height:3rem">
+					<ui5-icon style="width:3rem;height:3rem; font-size: 3rem;">
 						<i slot="fontIcon" class="ph ph-gear"></i>
 					</ui5-icon>
 				</td>
 			</tr>
 			<tr>
-				<td>5rem×5rem, different font-size per icon<br><small>(tests font-size vs width/height independence)</small></td>
+				<td>5rem×5rem, different font-size per icon<br><small>(tests font-size vs width/height
+						independence)</small></td>
 				<td><ui5-icon name="settings" style="width:5rem;height:5rem; font-size: 2rem;"></ui5-icon></td>
 				<td>
-					<ui5-icon style="width:5rem;height:5rem">
-						<span slot="fontIcon" class="sap-icon-font" style="font-size:2rem">&#xe00c;</span>
+					<ui5-icon style="width:5rem;height:5rem;font-size:2rem">
+						<span slot="fontIcon" class="sap-icon-font">&#xe00c;</span>
 					</ui5-icon>
 				</td>
 				<td>
-					<ui5-icon style="width:5rem;height:5rem">
-						<span slot="fontIcon" class="material-symbols-outlined" style="font-size:2rem">settings</span>
+					<ui5-icon style="width:5rem;height:5rem;font-size:2rem">
+						<span slot="fontIcon" class="material-symbols-outlined">settings</span>
 					</ui5-icon>
 				</td>
 				<td>
-					<ui5-icon style="width:5rem;height:5rem">
-						<i slot="fontIcon" class="fa-solid fa-gear" style="font-size:2rem"></i>
+					<ui5-icon style="width:5rem;height:5rem;font-size:2rem">
+						<i slot="fontIcon" class="fa-solid fa-gear"></i>
 					</ui5-icon>
 				</td>
 				<td>
-					<ui5-icon style="width:5rem;height:5rem">
-						<i slot="fontIcon" class="bi bi-gear" style="font-size:2rem"></i>
+					<ui5-icon style="width:5rem;height:5rem;font-size:2rem">
+						<i slot="fontIcon" class="bi bi-gear"></i>
 					</ui5-icon>
 				</td>
 				<td>
-					<ui5-icon style="width:5rem;height:5rem">
-						<i slot="fontIcon" class="ph ph-gear" style="font-size:2rem"></i>
+					<ui5-icon style="width:5rem;height:5rem;font-size:2rem">
+						<i slot="fontIcon" class="ph ph-gear"></i>
 					</ui5-icon>
 				</td>
 			</tr>


### PR DESCRIPTION
Switch from CSS container queries (container-type: size) to font-size inheritance for sizing the icon glyph. The inner .ui5-icon-root now uses font-size: inherit instead of min(100cqw, 100cqh), and the :host default sets font-size: 1rem to match width/height defaults.

For fontIcon-slot (font-based) icons, glyph size is driven by font-size — setting only width/height is not sufficient. This is documented on the fontIcon slot in Icon.ts.

Fixes: https://github.com/UI5/webcomponents/issues/13973