### PR TITLE
fix(ui5-icon): suppress native click propagation for Image mode

### DIFF
--- a/packages/main/cypress/specs/Icon.cy.tsx
+++ b/packages/main/cypress/specs/Icon.cy.tsx
@@ -124,16 +124,42 @@ describe("Icon general interaction", () => {
         cy.get("[ui5-input]").eq(0).should("have.prop", "value", "3");
         cy.get("[ui5-input]").eq(1).should("have.prop", "value", "3");
 
-        // Non-interactive icon: mouse click fires native click but NOT ui5-click
+        // Non-interactive icon: mouse click fires neither native click nor ui5-click
         cy.get("@nonInteractiveIcon").click();
-        cy.get("[ui5-input]").eq(2).should("have.prop", "value", "1");
+        cy.get("[ui5-input]").eq(2).should("have.prop", "value", "0");
         cy.get("[ui5-input]").eq(3).should("have.prop", "value", "0");
 
         cy.get("@interactiveClickStub").should("have.been.calledThrice");
         cy.get("@interactiveUI5ClickStub").should("have.been.calledThrice");
 
-        cy.get("@nonInteractiveClickStub").should("have.been.calledOnce");
+        cy.get("@nonInteractiveClickStub").should("not.have.been.called");
         cy.get("@nonInteractiveUI5ClickStub").should("not.have.been.called");
+    });
+
+    it("Tests mode='Image' does not propagate native click to the host (#13972)", () => {
+        cy.mount(
+            <div style={{ padding: "20px" }}>
+                <Icon
+                    name="add-equipment"
+                    mode="Image"
+                    accessibleName="an alt text"
+                    style={{ display: "inline-block", margin: "10px" }}
+                />
+            </div>
+        );
+
+        cy.get("[ui5-icon][mode='Image']")
+            .as("imageIcon")
+            .then($icon => {
+                $icon.get(0).addEventListener("click", cy.stub().as("imageClickStub"));
+                $icon.get(0).addEventListener("ui5-click", cy.stub().as("imageUI5ClickStub"));
+            });
+
+        // Mouse click on an Image-mode icon must not reach an external click listener
+        cy.get("@imageIcon").realClick();
+
+        cy.get("@imageClickStub").should("not.have.been.called");
+        cy.get("@imageUI5ClickStub").should("not.have.been.called");
     });
 
     it("Tests switch to sap_horizon", () => {

--- a/packages/main/cypress/specs/Icon.cy.tsx
+++ b/packages/main/cypress/specs/Icon.cy.tsx
@@ -124,15 +124,15 @@ describe("Icon general interaction", () => {
         cy.get("[ui5-input]").eq(0).should("have.prop", "value", "3");
         cy.get("[ui5-input]").eq(1).should("have.prop", "value", "3");
 
-        // Non-interactive icon: mouse click fires neither native click nor ui5-click
+        // Non-interactive icon (Decorative): mouse click fires native click but NOT ui5-click
         cy.get("@nonInteractiveIcon").click();
-        cy.get("[ui5-input]").eq(2).should("have.prop", "value", "0");
+        cy.get("[ui5-input]").eq(2).should("have.prop", "value", "1");
         cy.get("[ui5-input]").eq(3).should("have.prop", "value", "0");
 
         cy.get("@interactiveClickStub").should("have.been.calledThrice");
         cy.get("@interactiveUI5ClickStub").should("have.been.calledThrice");
 
-        cy.get("@nonInteractiveClickStub").should("not.have.been.called");
+        cy.get("@nonInteractiveClickStub").should("have.been.calledOnce");
         cy.get("@nonInteractiveUI5ClickStub").should("not.have.been.called");
     });
 

--- a/packages/main/src/Icon.ts
+++ b/packages/main/src/Icon.ts
@@ -249,10 +249,9 @@ class Icon extends UI5Element implements IIcon {
 
 	_onclick(e: MouseEvent) {
 		if (this.mode !== IconMode.Interactive) {
-			// Non-interactive modes (Image/Decorative) must not let the native
-			// browser click escape the shadow root to the host/application,
-			// otherwise the icon is treated as clickable (issue #13972).
-			e.stopPropagation();
+			if (this.mode === IconMode.Image) {
+				e.stopPropagation();
+			}
 			return;
 		}
 

--- a/packages/main/src/Icon.ts
+++ b/packages/main/src/Icon.ts
@@ -249,6 +249,10 @@ class Icon extends UI5Element implements IIcon {
 
 	_onclick(e: MouseEvent) {
 		if (this.mode !== IconMode.Interactive) {
+			// Non-interactive modes (Image/Decorative) must not let the native
+			// browser click escape the shadow root to the host/application,
+			// otherwise the icon is treated as clickable (issue #13972).
+			e.stopPropagation();
 			return;
 		}
 


### PR DESCRIPTION
Non-interactive Image mode already suppressed the `ui5-click` custom event, but the native click still bubbled up to the host, making the icon appear clickable to parent listeners.

Calls `e.stopPropagation()` in `_onclick` for Image mode before returning, aligning runtime behavior with the documented `@event("click")` specification.

Fixes: https://github.com/UI5/webcomponents/issues/13972