### PR TITLE
fix(ui5-option-group): remove unrelated inherited public APIs

### DIFF
--- a/packages/main/src/ListItemGroup.ts
+++ b/packages/main/src/ListItemGroup.ts
@@ -3,22 +3,19 @@ import event from "@ui5/webcomponents-base/dist/decorators/event-strict.js";
 import property from "@ui5/webcomponents-base/dist/decorators/property.js";
 import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
 import jsxRenderer from "@ui5/webcomponents-base/dist/renderer/JsxRenderer.js";
-import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
-import type { Slot, DefaultSlot } from "@ui5/webcomponents-base/dist/UI5Element.js";
+import type { Slot } from "@ui5/webcomponents-base/dist/UI5Element.js";
 import DragAndDropHandler from "./delegate/DragAndDropHandler.js";
 import MovePlacement from "@ui5/webcomponents-base/dist/types/MovePlacement.js";
 import type DropIndicator from "./DropIndicator.js";
 import type ListItemBase from "./ListItemBase.js";
-import type { ListItemBaseClickEventDetail } from "./ListItemBase.js";
+import ListItemGroupBase from "./ListItemGroupBase.js";
 
 // Template
 import ListItemGroupTemplate from "./ListItemGroupTemplate.js";
 
 // Styles
 import ListItemGroupCss from "./generated/themes/ListItemGroup.css.js";
-import type ListItemGroupHeader from "./ListItemGroupHeader.js";
 import WrappingType from "./types/WrappingType.js";
-import createInstanceChecker from "@ui5/webcomponents-base/dist/util/createInstanceChecker.js";
 
 type ListItemGroupMoveEventDetail = {
 	source: {
@@ -42,7 +39,7 @@ type ListItemGroupMoveEventDetail = {
  * @csspart header - Used to style the header item of the group
  * @csspart title - Used to style the title of the group header
  * @constructor
- * @extends UI5Element
+ * @extends ListItemGroupBase
  * @public
  * @since 2.0.0
  */
@@ -82,19 +79,11 @@ type ListItemGroupMoveEventDetail = {
 	bubbles: true,
 })
 
-class ListItemGroup extends UI5Element {
-	eventDetails!: {
-		"click"?: ListItemBaseClickEventDetail,
+class ListItemGroup extends ListItemGroupBase {
+	eventDetails!: ListItemGroupBase["eventDetails"] & {
 		"move-over": ListItemGroupMoveEventDetail,
 		"move": ListItemGroupMoveEventDetail,
 	}
-	/**
-	 * Defines the header text of the <code>ui5-li-group</code>.
-	 * @public
-	 * @default undefined
-	 */
-	@property()
-	headerText?: string;
 
 	/**
 	 * Defines the accessible name of the header.
@@ -103,17 +92,6 @@ class ListItemGroup extends UI5Element {
 	 */
 	@property()
 	headerAccessibleName?: string;
-
-	/**
-	 * Defines the items of the <code>ui5-li-group</code>.
-	 * @public
-	 */
-	@slot({
-		"default": true,
-		invalidateOnChildChange: true,
-		type: HTMLElement,
-	})
-	items!: DefaultSlot<ListItemBase>;
 
 	/**
 	 * Defines if the text of the component should wrap when it's too long.
@@ -165,20 +143,12 @@ class ListItemGroup extends UI5Element {
 		});
 	}
 
-	get groupHeaderItem() {
-		return this.shadowRoot!.querySelector<ListItemGroupHeader>("[ui5-li-group-header]")!;
-	}
-
 	get hasHeader(): boolean {
 		return !!this.headerText || this.hasFormattedHeader;
 	}
 
 	get hasFormattedHeader(): boolean {
 		return !!this.header.length;
-	}
-
-	get isListItemGroup() {
-		return true;
 	}
 
 	get dropIndicatorDOM(): DropIndicator | null {
@@ -219,5 +189,5 @@ class ListItemGroup extends UI5Element {
 ListItemGroup.define();
 
 export default ListItemGroup;
-export const isInstanceOfListItemGroup = createInstanceChecker<ListItemGroup>("isListItemGroup");
+export { isInstanceOfListItemGroup } from "./ListItemGroupBase.js";
 export type { ListItemGroupMoveEventDetail };

--- a/packages/main/src/ListItemGroupBase.ts
+++ b/packages/main/src/ListItemGroupBase.ts
@@ -1,0 +1,65 @@
+import UI5Element from "@ui5/webcomponents-base/dist/UI5Element.js";
+import customElement from "@ui5/webcomponents-base/dist/decorators/customElement.js";
+import jsxRenderer from "@ui5/webcomponents-base/dist/renderer/JsxRenderer.js";
+import property from "@ui5/webcomponents-base/dist/decorators/property.js";
+import slot from "@ui5/webcomponents-base/dist/decorators/slot-strict.js";
+import type { DefaultSlot } from "@ui5/webcomponents-base/dist/UI5Element.js";
+import createInstanceChecker from "@ui5/webcomponents-base/dist/util/createInstanceChecker.js";
+import type ListItemBase from "./ListItemBase.js";
+import type { ListItemBaseClickEventDetail } from "./ListItemBase.js";
+import type ListItemGroupHeader from "./ListItemGroupHeader.js";
+
+/**
+ * @class
+ *
+ * ### Overview
+ *
+ * `ListItemGroupBase` is the abstract base for grouping components. It provides the minimal
+ * "group" contract shared by `ui5-li-group` and `ui5-option-group`: a header text, the default
+ * items slot, and the plumbing the internal `ui5-list` relies on to flatten grouped items.
+ *
+ * Concrete group components extend this class and add only the public API that is relevant to them.
+ * @constructor
+ * @abstract
+ * @extends UI5Element
+ * @public
+ * @since 2.26.0
+ */
+@customElement({
+	renderer: jsxRenderer,
+})
+class ListItemGroupBase extends UI5Element {
+	eventDetails!: {
+		"click"?: ListItemBaseClickEventDetail,
+	}
+
+	/**
+	 * Defines the header text of the group.
+	 * @public
+	 * @default undefined
+	 */
+	@property()
+	headerText?: string;
+
+	/**
+	 * Defines the items of the group.
+	 * @public
+	 */
+	@slot({
+		"default": true,
+		invalidateOnChildChange: true,
+		type: HTMLElement,
+	})
+	items!: DefaultSlot<ListItemBase>;
+
+	get groupHeaderItem() {
+		return this.shadowRoot!.querySelector<ListItemGroupHeader>("[ui5-li-group-header]")!;
+	}
+
+	get isListItemGroup() {
+		return true;
+	}
+}
+
+export default ListItemGroupBase;
+export const isInstanceOfListItemGroup = createInstanceChecker<ListItemGroupBase>("isListItemGroup");

--- a/packages/main/src/OptionGroup.ts
+++ b/packages/main/src/OptionGroup.ts
@@ -4,7 +4,7 @@ import i18n from "@ui5/webcomponents-base/dist/decorators/i18n.js";
 import type I18nBundle from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import type { DefaultSlot } from "@ui5/webcomponents-base/dist/UI5Element.js";
 import createInstanceChecker from "@ui5/webcomponents-base/dist/util/createInstanceChecker.js";
-import ListItemGroup from "./ListItemGroup.js";
+import ListItemGroupBase from "./ListItemGroupBase.js";
 import type Option from "./Option.js";
 import OptionGroupTemplate from "./OptionGroupTemplate.js";
 import { LIST_ITEM_GROUP_HEADER } from "./generated/i18n/i18n-defaults.js";
@@ -21,7 +21,7 @@ import OptionGroupCss from "./generated/themes/OptionGroup.css.js";
  *
  * `import "@ui5/webcomponents/dist/OptionGroup.js";`
  * @constructor
- * @extends ListItemGroup
+ * @extends ListItemGroupBase
  * @public
  * @since 2.26.0
  */
@@ -31,8 +31,8 @@ import OptionGroupCss from "./generated/themes/OptionGroup.css.js";
 	template: OptionGroupTemplate,
 	styles: [OptionGroupCss],
 })
-class OptionGroup extends ListItemGroup {
-	eventDetails!: ListItemGroup["eventDetails"];
+class OptionGroup extends ListItemGroupBase {
+	eventDetails!: ListItemGroupBase["eventDetails"];
 
 	@i18n("@ui5/webcomponents")
 	static i18nBundle: I18nBundle;

--- a/packages/website/docs/_components_pages/main/Select/OptionGroup.mdx
+++ b/packages/website/docs/_components_pages/main/Select/OptionGroup.mdx
@@ -1,0 +1,7 @@
+---
+slug: ../../OptionGroup
+---
+
+<%COMPONENT_OVERVIEW%>
+
+<%COMPONENT_METADATA%>


### PR DESCRIPTION
ui5-option-group extended ui5-li-group and therefore inherited a number of public APIs that are irrelevant to grouping options inside a ui5-select and were never wired into its template:

- headerAccessibleName property
- wrappingType property
- header slot
- move and move-over events
- header and title CSS parts

Extract an abstract ListItemGroupBase that holds only the shared group contract (headerText, the default items slot, and the isListItemGroup / groupHeaderItem hooks the internal ui5-list relies on to flatten grouped items). Both ui5-li-group and ui5-option-group now extend this base, so the drag-and-drop, wrapping and header-slot APIs live solely on ui5-li-group where they belong, while ui5-option-group exposes only headerText and its options slot.

ui5-li-group's public API is unchanged.

Also add a standalone documentation page for ui5-option-group.

Fixes #13992
Fixes #13991

