### PR TITLE
fix(ui5-list): suppress hidden text announcement for InactiveSelectable items

### DIFF
--- a/packages/main/cypress/specs/List.cy.tsx
+++ b/packages/main/cypress/specs/List.cy.tsx
@@ -3877,7 +3877,7 @@ describe("List - ListItem accessible role inheritance", () => {
 });
 
 describe("List - InactiveSelectable type", () => {
-	it("type='InactiveSelectable' + selectionMode='Multiple' — clicking item toggles checkbox selection", () => {
+	it("type='InactiveSelectable' + selectionMode='Multiple' — clicking item body does NOT toggle selection", () => {
 		cy.mount(
 			<List selectionMode="Multiple">
 				<ListItemStandard id="item1" type="InactiveSelectable">Option A</ListItemStandard>
@@ -3888,21 +3888,25 @@ describe("List - InactiveSelectable type", () => {
 		// Initially not selected
 		cy.get("#item1").should("not.have.attr", "selected");
 
-		// Click item — should become selected (checkbox toggled)
-		cy.get("#item1").click();
-		cy.get("#item1").should("have.attr", "selected");
-
-		// Click again — should become deselected
+		// Click item body — should NOT change selection
 		cy.get("#item1").click();
 		cy.get("#item1").should("not.have.attr", "selected");
 
+		// Clicking checkbox directly toggles selection
+		cy.get("#item1").shadow().find("ui5-checkbox").click();
+		cy.get("#item1").should("have.attr", "selected");
+
+		// Click checkbox again — should become deselected
+		cy.get("#item1").shadow().find("ui5-checkbox").click();
+		cy.get("#item1").should("not.have.attr", "selected");
+
 		// Second item is independent
-		cy.get("#item2").click();
+		cy.get("#item2").shadow().find("ui5-checkbox").click();
 		cy.get("#item2").should("have.attr", "selected");
 		cy.get("#item1").should("not.have.attr", "selected");
 	});
 
-	it("type='InactiveSelectable' + selectionMode='Multiple' — pressing Space toggles selection", () => {
+	it("type='InactiveSelectable' + selectionMode='Multiple' — pressing Space on item body does NOT toggle selection", () => {
 		cy.mount(
 			<List selectionMode="Multiple">
 				<ListItemStandard id="item1" type="InactiveSelectable">Option A</ListItemStandard>
@@ -3911,12 +3915,8 @@ describe("List - InactiveSelectable type", () => {
 
 		cy.get("#item1").should("not.have.attr", "selected");
 
-		// Focus item and press Space
+		// Focus item and press Space — should NOT change selection
 		cy.get("#item1").shadow().find("li").focus();
-		cy.realPress("Space");
-		cy.get("#item1").should("have.attr", "selected");
-
-		// Press Space again — should deselect
 		cy.realPress("Space");
 		cy.get("#item1").should("not.have.attr", "selected");
 	});
@@ -4005,7 +4005,7 @@ describe("List - InactiveSelectable type", () => {
 		cy.get("@selectionChangeStub").should("not.have.been.called");
 	});
 
-	it("type='InactiveSelectable' + selectionMode='Single' — clicking item selects it", () => {
+	it("type='InactiveSelectable' + selectionMode='Single' — clicking item body does NOT select it", () => {
 		cy.mount(
 			<List selectionMode="Single">
 				<ListItemStandard id="item1" type="InactiveSelectable">Option A</ListItemStandard>
@@ -4015,16 +4015,21 @@ describe("List - InactiveSelectable type", () => {
 
 		cy.get("#item1").should("not.have.attr", "selected");
 
+		// Click item body — should NOT select
 		cy.get("#item1").click();
+		cy.get("#item1").should("not.have.attr", "selected");
+
+		// Clicking radio directly selects
+		cy.get("#item1").shadow().find("ui5-radio-button").click();
 		cy.get("#item1").should("have.attr", "selected");
 
-		// Clicking second item moves selection
-		cy.get("#item2").click();
+		// Clicking second item's radio moves selection
+		cy.get("#item2").shadow().find("ui5-radio-button").click();
 		cy.get("#item2").should("have.attr", "selected");
 		cy.get("#item1").should("not.have.attr", "selected");
 	});
 
-	it("type='InactiveSelectable' + selectionMode='Single' — pressing Space selects item", () => {
+	it("type='InactiveSelectable' + selectionMode='Single' — pressing Space on item body does NOT select it", () => {
 		cy.mount(
 			<List selectionMode="Single">
 				<ListItemStandard id="item1" type="InactiveSelectable">Option A</ListItemStandard>
@@ -4036,7 +4041,7 @@ describe("List - InactiveSelectable type", () => {
 		cy.get("#item1").shadow().find("li").focus();
 		cy.realPress("Space");
 
-		cy.get("#item1").should("have.attr", "selected");
+		cy.get("#item1").should("not.have.attr", "selected");
 	});
 
 	it("type='InactiveSelectable' + selectionMode='None' — clicking item does nothing", () => {
@@ -4077,7 +4082,7 @@ describe("List - InactiveSelectable type", () => {
 		cy.get("@selectionChangeStub").should("not.have.been.called");
 	});
 
-	it("type='InactiveSelectable' + selectionMode='Multiple' — selection-change event is fired", () => {
+	it("type='InactiveSelectable' + selectionMode='Multiple' — selection-change event is fired when clicking checkbox", () => {
 		cy.mount(
 			<List selectionMode="Multiple">
 				<ListItemStandard id="item1" type="InactiveSelectable">Option A</ListItemStandard>
@@ -4088,12 +4093,16 @@ describe("List - InactiveSelectable type", () => {
 			$list[0].addEventListener("ui5-selection-change", cy.stub().as("selectionChangeStub"));
 		});
 
+		// Click item body — should NOT fire selection-change
 		cy.get("#item1").click();
+		cy.get("@selectionChangeStub").should("not.have.been.called");
 
+		// Click checkbox — should fire selection-change
+		cy.get("#item1").shadow().find("ui5-checkbox").click();
 		cy.get("@selectionChangeStub").should("have.been.calledOnce");
 	});
 
-	it("type='InactiveSelectable' + selectionMode='SingleStart' — clicking item selects it", () => {
+	it("type='InactiveSelectable' + selectionMode='SingleStart' — clicking item body does NOT select it", () => {
 		cy.mount(
 			<List selectionMode="SingleStart">
 				<ListItemStandard id="item1" type="InactiveSelectable">Option A</ListItemStandard>
@@ -4102,14 +4111,17 @@ describe("List - InactiveSelectable type", () => {
 		);
 
 		cy.get("#item1").click();
+		cy.get("#item1").should("not.have.attr", "selected");
+
+		cy.get("#item1").shadow().find("ui5-radio-button").click();
 		cy.get("#item1").should("have.attr", "selected");
 
-		cy.get("#item2").click();
+		cy.get("#item2").shadow().find("ui5-radio-button").click();
 		cy.get("#item2").should("have.attr", "selected");
 		cy.get("#item1").should("not.have.attr", "selected");
 	});
 
-	it("type='InactiveSelectable' + selectionMode='SingleEnd' — clicking item selects it", () => {
+	it("type='InactiveSelectable' + selectionMode='SingleEnd' — clicking item body does NOT select it", () => {
 		cy.mount(
 			<List selectionMode="SingleEnd">
 				<ListItemStandard id="item1" type="InactiveSelectable">Option A</ListItemStandard>
@@ -4118,14 +4130,17 @@ describe("List - InactiveSelectable type", () => {
 		);
 
 		cy.get("#item1").click();
+		cy.get("#item1").should("not.have.attr", "selected");
+
+		cy.get("#item1").shadow().find("ui5-radio-button").click();
 		cy.get("#item1").should("have.attr", "selected");
 
-		cy.get("#item2").click();
+		cy.get("#item2").shadow().find("ui5-radio-button").click();
 		cy.get("#item2").should("have.attr", "selected");
 		cy.get("#item1").should("not.have.attr", "selected");
 	});
 
-	it("type='InactiveSelectable' + selectionMode='Multiple' — pressing Enter toggles selection", () => {
+	it("type='InactiveSelectable' + selectionMode='Multiple' — pressing Enter on item body does NOT toggle selection", () => {
 		cy.mount(
 			<List selectionMode="Multiple">
 				<ListItemStandard id="item1" type="InactiveSelectable">Option A</ListItemStandard>
@@ -4136,13 +4151,10 @@ describe("List - InactiveSelectable type", () => {
 
 		cy.get("#item1").shadow().find("li").focus();
 		cy.realPress("Enter");
-		cy.get("#item1").should("have.attr", "selected");
-
-		cy.realPress("Enter");
 		cy.get("#item1").should("not.have.attr", "selected");
 	});
 
-	it("type='InactiveSelectable' + selectionMode='Single' — pressing Enter selects item", () => {
+	it("type='InactiveSelectable' + selectionMode='Single' — pressing Enter on item body does NOT select it", () => {
 		cy.mount(
 			<List selectionMode="Single">
 				<ListItemStandard id="item1" type="InactiveSelectable">Option A</ListItemStandard>
@@ -4154,7 +4166,7 @@ describe("List - InactiveSelectable type", () => {
 		cy.get("#item1").shadow().find("li").focus();
 		cy.realPress("Enter");
 
-		cy.get("#item1").should("have.attr", "selected");
+		cy.get("#item1").should("not.have.attr", "selected");
 	});
 
 	it("type='InactiveSelectable' — item-click event is NOT fired on Enter key", () => {
@@ -4223,6 +4235,6 @@ describe("List - InactiveSelectable type", () => {
 		cy.get("#item1").click();
 
 		cy.get("@itemClickStub").should("not.have.been.called");
-		cy.get("@selectionChangeStub").should("have.been.calledOnce");
+		cy.get("@selectionChangeStub").should("not.have.been.called");
 	});
 });

--- a/packages/main/cypress/specs/List.cy.tsx
+++ b/packages/main/cypress/specs/List.cy.tsx
@@ -4013,20 +4013,16 @@ describe("List - InactiveSelectable type", () => {
 			</List>
 		);
 
-		cy.get("#item1").should("not.have.attr", "selected");
+		cy.get("[ui5-list]").then(($list) => {
+			$list[0].addEventListener("ui5-item-click", cy.stub().as("itemClickStub"));
+			$list[0].addEventListener("ui5-selection-change", cy.stub().as("selectionChangeStub"));
+		});
 
-		// Click item body — should NOT select
+		// Single mode renders no radio button — clicking item body does nothing
 		cy.get("#item1").click();
 		cy.get("#item1").should("not.have.attr", "selected");
-
-		// Clicking radio directly selects
-		cy.get("#item1").shadow().find("ui5-radio-button").click();
-		cy.get("#item1").should("have.attr", "selected");
-
-		// Clicking second item's radio moves selection
-		cy.get("#item2").shadow().find("ui5-radio-button").click();
-		cy.get("#item2").should("have.attr", "selected");
-		cy.get("#item1").should("not.have.attr", "selected");
+		cy.get("@itemClickStub").should("not.have.been.called");
+		cy.get("@selectionChangeStub").should("not.have.been.called");
 	});
 
 	it("type='InactiveSelectable' + selectionMode='Single' — pressing Space on item body does NOT select it", () => {
@@ -4113,10 +4109,10 @@ describe("List - InactiveSelectable type", () => {
 		cy.get("#item1").click();
 		cy.get("#item1").should("not.have.attr", "selected");
 
-		cy.get("#item1").shadow().find("ui5-radio-button").click();
+		cy.get("#item1").shadow().find("[id$='-singleSelectionElement']").click();
 		cy.get("#item1").should("have.attr", "selected");
 
-		cy.get("#item2").shadow().find("ui5-radio-button").click();
+		cy.get("#item2").shadow().find("[id$='-singleSelectionElement']").click();
 		cy.get("#item2").should("have.attr", "selected");
 		cy.get("#item1").should("not.have.attr", "selected");
 	});
@@ -4132,10 +4128,10 @@ describe("List - InactiveSelectable type", () => {
 		cy.get("#item1").click();
 		cy.get("#item1").should("not.have.attr", "selected");
 
-		cy.get("#item1").shadow().find("ui5-radio-button").click();
+		cy.get("#item1").shadow().find("[id$='-singleSelectionElement']").click();
 		cy.get("#item1").should("have.attr", "selected");
 
-		cy.get("#item2").shadow().find("ui5-radio-button").click();
+		cy.get("#item2").shadow().find("[id$='-singleSelectionElement']").click();
 		cy.get("#item2").should("have.attr", "selected");
 		cy.get("#item1").should("not.have.attr", "selected");
 	});
@@ -4234,6 +4230,7 @@ describe("List - InactiveSelectable type", () => {
 
 		cy.get("#item1").click();
 
+		cy.get("#item1").should("not.have.attr", "selected");
 		cy.get("@itemClickStub").should("not.have.been.called");
 		cy.get("@selectionChangeStub").should("not.have.been.called");
 	});

--- a/packages/main/src/List.ts
+++ b/packages/main/src/List.ts
@@ -1430,7 +1430,7 @@ class List extends UI5Element {
 		this._itemNavigation.setCurrentItem(target);
 		this.fireDecoratorEvent("item-focused", { item: target });
 
-		if (this.selectionMode === ListSelectionMode.SingleAuto) {
+		if (this.selectionMode === ListSelectionMode.SingleAuto && !(target as ListItem).isInactiveSelectable) {
 			const detail: SelectionRequestEventDetail = {
 				item: target,
 				selectionComponentPressed: false,

--- a/packages/main/src/ListItem.ts
+++ b/packages/main/src/ListItem.ts
@@ -401,13 +401,7 @@ abstract class ListItem extends ListItemBase {
 	}
 
 	fireItemPress(e: Event) {
-		if (this.isInactive) {
-			return;
-		}
-		if (this.isInactiveSelectable) {
-			if (this.modeSingleSelect || this.modeMultiple) {
-				this.fireDecoratorEvent("selection-requested", { item: this, selected: !this.selected, selectionComponentPressed: false });
-			}
+		if (this.isInactive || this.isInactiveSelectable) {
 			return;
 		}
 		super.fireItemPress(e);

--- a/packages/main/src/ListItem.ts
+++ b/packages/main/src/ListItem.ts
@@ -112,8 +112,10 @@ abstract class ListItem extends ListItemBase {
 	 * **Note:** When set to `Active` or `Navigation`, the item will provide visual response upon press and hover,
 	 * while with type `Inactive`, `InactiveSelectable` and `Detail` - will not.
 	 *
-	 * **Note:** `InactiveSelectable` behaves like `Inactive` but allows selection (checkbox/radio) to be toggled
-	 * when the list has a selection mode. The `item-click` event is not fired for this type.
+	 * **Note:** `InactiveSelectable` behaves like `Inactive` but allows selection to be toggled
+	 * via the checkbox (Multi mode) or radio button (Single modes) when the list has a selection mode.
+	 * Clicking the item body or pressing Space/Enter does not trigger selection — only interacting
+	 * with the selection component directly does. The `item-click` event is not fired for this type.
 	 * @default "Active"
 	 * @public
 	*/

--- a/packages/main/src/ListItemStandardTemplate.tsx
+++ b/packages/main/src/ListItemStandardTemplate.tsx
@@ -23,7 +23,7 @@ function listItemContent(this: ListItemStandard) {
 			{renderTitle.call(this)}
 			{renderDescription.call(this)}
 
-			{!this.typeActive && <span class="ui5-hidden-text">{this.type}</span>}
+			{!this.typeActive && !this.isInactiveSelectable && <span class="ui5-hidden-text">{this.type}</span>}
 		</div>
 
 		{!this.description && renderAdditionalText.call(this)}


### PR DESCRIPTION
## Summary

- `InactiveSelectable` list items were causing screen readers to announce the raw string `"InactiveSelectable"` because the hidden text span in `ListItemStandardTemplate.tsx` renders `this.type` verbatim for all non-Active items — fixed by suppressing the span entirely for `InactiveSelectable` items
- Clicking the item body of an `InactiveSelectable` item no longer toggles selection — selection can only be triggered by clicking the checkbox (Multi) or radio button (Single/SingleStart) directly

## Root cause (a11y)

`ListItemStandardTemplate.tsx` line 26:
```tsx
// Before
{!this.typeActive && <span class="ui5-hidden-text">{this.type}</span>}

// After
{!this.typeActive && !this.isInactiveSelectable && <span class="ui5-hidden-text">{this.type}</span>}
```

## Root cause (click behavior)

`ListItem.ts` — `fireItemPress` was firing `selection-requested` when clicking anywhere on the item body. `InactiveSelectable` items should behave like `Inactive` in `fireItemPress` (no-op), leaving selection exclusively to the checkbox/radio `onChange` handlers:

```ts
// Before
fireItemPress(e: Event) {
    if (this.isInactive) { return; }
    if (this.isInactiveSelectable) {
        if (this.modeSingleSelect || this.modeMultiple) {
            this.fireDecoratorEvent("selection-requested", { ... });
        }
        return;
    }
    ...
}

// After
fireItemPress(e: Event) {
    if (this.isInactive || this.isInactiveSelectable) { return; }
    ...
}
```

## Test plan

- [ ] Clicking the **item body** of an `InactiveSelectable` item → no selection change, no `item-click` event
- [ ] Clicking the **checkbox** (Multi mode) on an `InactiveSelectable` item → selection toggles, `selection-change` fires, no `item-click`
- [ ] Clicking the **radio button** (Single/SingleStart mode) on an `InactiveSelectable` item → selection toggles, `selection-change` fires, no `item-click`
- [ ] Screen reader announces nothing extra for `InactiveSelectable` items (no raw enum string)
- [ ] `type="Inactive"` items still have disabled checkbox/no selection (no regression)
- [ ] `type="Active"` items still fire `item-click` as expected (no regression)