### PR TITLE
docs(ui5-date-picker): add numeric relative date patterns to documentation

### DIFF
--- a/packages/main/src/DatePicker.ts
+++ b/packages/main/src/DatePicker.ts
@@ -134,10 +134,10 @@ type Picker = "day" | "month" | "year";
  * The input field also accepts locale-aware relative date expressions sourced from the Unicode CLDR.
  * The following expressions are supported in English:
  *
- * - Day: "today", "yesterday", "tomorrow"
- * - Week: "this week", "last week", "next week"
- * - Month: "this month", "last month", "next month"
- * - Year: "this year", "last year", "next year"
+ * - Day: "today", "yesterday", "tomorrow", "in N days", "N days ago"
+ * - Week: "this week", "last week", "next week", "in N weeks", "N weeks ago"
+ * - Month: "this month", "last month", "next month", "in N months", "N months ago"
+ * - Year: "this year", "last year", "next year", "in N years", "N years ago"
  *
  * The recognized expressions are locale-specific — the equivalent terms in the user's language are used (for example, "heute" in German, "bugün" in Turkish).
  * Week, month, and year expressions resolve to an offset from today (for example, "next week" = today + 7 days).


### PR DESCRIPTION
Extend the "Relative date input" section with offset-based expressions ("in N days", "N days ago", etc.) for all four scales (day, week, month, year), matching the patterns documented for sap.m.DatePicker in OpenUI5.

Related to: BGSOFUIBALKAN-11043