### PR TITLE
feat(ui5-shellbar): enhance responsive behaviour for custom branding

### DIFF
--- a/packages/fiori/src/ShellBar.ts
+++ b/packages/fiori/src/ShellBar.ts
@@ -775,7 +775,7 @@ class ShellBar extends UI5Element {
 			const wasHidden = brandingEl.hasAttribute("_title-hidden");
 			if (wasHidden) {
 				brandingEl.removeAttribute("_title-hidden");
-				// eslint-disable-next-line @typescript-eslint/no-unused-expressions
+				// eslint-disable-next-line no-unused-expressions
 				brandingEl.offsetWidth;
 			}
 			const result = titleEl.scrollWidth > logoEl.offsetWidth * 2;
@@ -803,7 +803,7 @@ class ShellBar extends UI5Element {
 							brandingEl.toggleAttribute("_stacked", true);
 							// Force synchronous layout flush so the next isOverflowing() call
 							// reads the post-stack offsetWidth, not the stale pre-stack value.
-							// eslint-disable-next-line @typescript-eslint/no-unused-expressions
+							// eslint-disable-next-line no-unused-expressions
 							brandingEl.offsetWidth;
 						}
 					} else if (brandingEl && visible) {

--- a/packages/fiori/src/ShellBar.ts
+++ b/packages/fiori/src/ShellBar.ts
@@ -651,11 +651,6 @@ class ShellBar extends UI5Element {
 		if (!this.legacyAdaptor) {
 			this.initLegacyController();
 		}
-		// Sync branding breakpoint state
-		this.branding.forEach(brandingEl => {
-			brandingEl._isSBreakPoint = this.isSBreakPoint;
-		});
-
 		this.buildActions();
 
 		this.searchAdaptor?.syncShowSearchFieldState();
@@ -762,15 +757,78 @@ class ShellBar extends UI5Element {
 			return;
 		}
 
+		const brandingEl = this.branding[0];
+
+		// Measure before the loop squeezes the branding. If the title's natural single-line
+		// width exceeds the logo width, stacking is visually meaningful (title will wrap).
+		// Temporarily remove _title-hidden so scrollWidth is readable even if it was hidden
+		// by the previous overflow pass.
+		const brandingTitleWouldWrap = (() => {
+			if (!brandingEl) {
+				return false;
+			}
+			const titleEl = brandingEl.shadowRoot?.querySelector<HTMLElement>(".ui5-shellbar-title");
+			const logoEl = brandingEl.shadowRoot?.querySelector<HTMLElement>(".ui5-shellbar-logo");
+			if (!titleEl || !logoEl) {
+				return false;
+			}
+			const wasHidden = brandingEl.hasAttribute("_title-hidden");
+			if (wasHidden) {
+				brandingEl.removeAttribute("_title-hidden");
+				// eslint-disable-next-line @typescript-eslint/no-unused-expressions
+				brandingEl.offsetWidth;
+			}
+			const result = titleEl.scrollWidth > logoEl.offsetWidth * 2;
+			if (wasHidden) {
+				brandingEl.setAttribute("_title-hidden", "");
+			}
+			return result;
+		})();
+
 		const result = this.overflow.updateOverflow({
 			actions: this.actions,
 			content: this.sortContent(this.content),
 			customItems: this._validItems,
 			hiddenItemsIds: this.hiddenItemsIds,
 			showSearchField: this.enabledFeatures.search && this.showSearchField,
+			hasBranding: this.enabledFeatures.branding && !!brandingEl,
 			overflowOuter: this.overflowOuter!,
 			overflowInner: this.overflowInner!,
 			setVisible: (selector: string, visible: boolean) => {
+				if (selector === "[data-ui5-stable='branding-stacked']") {
+					if (brandingEl && !visible) {
+						// Only stack if the title is wider than the logo — meaning it will
+						// actually wrap in the stacked (column) layout. Short titles go to overflow.
+						if (brandingTitleWouldWrap) {
+							brandingEl.toggleAttribute("_stacked", true);
+							// Force synchronous layout flush so the next isOverflowing() call
+							// reads the post-stack offsetWidth, not the stale pre-stack value.
+							// eslint-disable-next-line @typescript-eslint/no-unused-expressions
+							brandingEl.offsetWidth;
+						}
+					} else if (brandingEl && visible) {
+						brandingEl.removeAttribute("_stacked");
+					}
+					return;
+				}
+				if (selector === "[data-ui5-stable='branding-identifier']") {
+					if (brandingEl) {
+						brandingEl.toggleAttribute("_measure-title-hidden", !visible);
+						if (visible) {
+							brandingEl.removeAttribute("_title-hidden");
+						}
+					}
+					return;
+				}
+				if (selector === "[data-ui5-stable='branding-logo']") {
+					if (brandingEl) {
+						brandingEl.toggleAttribute("_measure-logo-hidden", !visible);
+						if (visible) {
+							brandingEl.removeAttribute("_logo-hidden");
+						}
+					}
+					return;
+				}
 				const element = this.shadowRoot!.querySelector(selector);
 				if (element) {
 					element.classList[visible ? "remove" : "add"]("ui5-shellbar-hidden");
@@ -779,6 +837,13 @@ class ShellBar extends UI5Element {
 		});
 
 		this.handleUpdateOverflowResult(result);
+
+		// Sync overflow button CSS class immediately after measurement — the measurement loop
+		// manipulates it directly via setVisible, and the template won't fix it until next render.
+		const overflowBtn = this.shadowRoot!.querySelector<HTMLElement>(ShellBarActionsSelectors.Overflow);
+		if (overflowBtn) {
+			overflowBtn.classList.toggle("ui5-shellbar-hidden", !result.showOverflowButton);
+		}
 
 		return result.hiddenItemsIds;
 	}
@@ -795,11 +860,20 @@ class ShellBar extends UI5Element {
 			}
 		});
 
+		// Sync branding hidden state
+		const brandingEl = this.branding[0];
+		if (brandingEl) {
+			brandingEl.removeAttribute("_measure-title-hidden");
+			brandingEl.removeAttribute("_measure-logo-hidden");
+			brandingEl.toggleAttribute("_title-hidden", hiddenItemsIds.includes("branding-identifier"));
+			brandingEl.toggleAttribute("_logo-hidden", hiddenItemsIds.includes("branding-logo"));
+		}
+
 		if (!arraysAreEqual(this.hiddenItemsIds, hiddenItemsIds)) {
 			this.handleContentVisibilityChanged(this.hiddenItemsIds, hiddenItemsIds);
 			this.hiddenItemsIds = hiddenItemsIds;
-			this.showOverflowButton = showOverflowButton;
 		}
+		this.showOverflowButton = showOverflowButton;
 		this.showFullWidthSearch = this.searchAdaptor?.shouldShowFullScreen() || false;
 	}
 
@@ -843,6 +917,14 @@ class ShellBar extends UI5Element {
 		this.overflowPopoverOpen = false;
 	}
 
+	handleBrandingOverflowClick() {
+		const brandingEl = this.branding[0];
+		if (brandingEl) {
+			brandingEl._fireClick();
+		}
+		this.overflowPopoverOpen = false;
+	}
+
 	handleOverflowItemClick(e: MouseEvent) {
 		const target = e.target as HTMLElement;
 		const actionId = target.getAttribute("data-action-id");
@@ -865,7 +947,39 @@ class ShellBar extends UI5Element {
 			actions: this.actions,
 			customItems: this._validItems,
 			hiddenItemsIds: this.hiddenItemsIds,
+			hasBranding: this.enabledFeatures.branding && !!this.branding[0],
 		});
+	}
+
+	get brandingOverflowTitle(): string | undefined {
+		return this.branding[0]?.textContent?.trim() || undefined;
+	}
+
+	get brandingOverflowLabel(): string | undefined {
+		const title = this.brandingOverflowTitle;
+		if (title) {
+			return `${title} Home`;
+		}
+		const accessibleName = this.branding[0]?.accessibleName?.trim();
+		return accessibleName ? `${accessibleName} Home` : undefined;
+	}
+
+	get brandingOverflowLogoSrc(): string | undefined {
+		const brandingEl = this.branding[0];
+		if (!brandingEl) {
+			return undefined;
+		}
+		const img = brandingEl.querySelector<HTMLImageElement>("[slot='logo']");
+		return img?.src || undefined;
+	}
+
+	get brandingOverflowLogoAlt(): string | undefined {
+		const brandingEl = this.branding[0];
+		if (!brandingEl) {
+			return undefined;
+		}
+		const img = brandingEl.querySelector<HTMLImageElement>("[slot='logo']");
+		return img?.alt || undefined;
 	}
 
 	/**
@@ -885,7 +999,8 @@ class ShellBar extends UI5Element {
 	 * Shows count if only one item with count is overflowed, otherwise shows attention dot.
 	 */
 	get overflowBadge(): string | undefined {
-		const itemsWithCount = this.overflowItems.filter(item => item.data.count);
+		const countableItems = this.overflowItems.filter(item => item.type !== "branding");
+		const itemsWithCount = countableItems.filter(item => item.data.count !== undefined);
 		if (itemsWithCount.length === 1) {
 			return itemsWithCount[0].data.count;
 		}

--- a/packages/fiori/src/ShellBarBranding.ts
+++ b/packages/fiori/src/ShellBarBranding.ts
@@ -89,14 +89,6 @@ class ShellBarBranding extends UI5Element {
 	accessibleName?: string;
 
 	/**
-     * Defines if the title of the branding is shown on an S breakpoint.
-     * @default false
-     * @private
-     */
-	@property({ type: Boolean })
-	_isSBreakPoint = false;
-
-	/**
 	 * Defines the title for the ui5-shellbar-branding component.
 	 *
 	 * **Note:** Although this slot accepts HTML Elements, it is strongly recommended that you only use text in order to preserve the intended design.

--- a/packages/fiori/src/ShellBarBrandingTemplate.tsx
+++ b/packages/fiori/src/ShellBarBrandingTemplate.tsx
@@ -17,11 +17,9 @@ export default function ShellBarBrandingTemplate(this: ShellBarBranding) {
 				<slot name="logo"></slot>
 			</span>
 
-			{!this._isSBreakPoint && (
-				<bdi class="ui5-shellbar-title">
-					<slot></slot>
-				</bdi>
-			)}
+			<bdi class="ui5-shellbar-title">
+				<slot></slot>
+			</bdi>
 	  </a>
 	);
 }

--- a/packages/fiori/src/ShellBarTemplate.tsx
+++ b/packages/fiori/src/ShellBarTemplate.tsx
@@ -46,17 +46,18 @@ export default function ShellBarTemplate(this: ShellBar) {
 					</div>
 				)}
 
-				{this.enabledFeatures.branding && (
-					<div class="ui5-shellbar-branding-area">
-						<slot name="branding"></slot>
-					</div>
-				)}
-
 				{/* Legacy branding (logo + primaryTitle) when no menu items */}
 				{!this.enabledFeatures.branding && ShellBarLegacyBrandingArea.call(this)}
 
 				<div class="ui5-shellbar-overflow-container">
 					<div class="ui5-shellbar-overflow-container-inner">
+
+						{/* Branding — first in DOM = visually leftmost */}
+						{this.enabledFeatures.branding && (
+							<div class="ui5-shellbar-branding-area" data-ui5-stable="branding">
+								<slot name="branding"></slot>
+							</div>
+						)}
 
 						{this.enabledFeatures.content && (
 							<div
@@ -236,8 +237,33 @@ export default function ShellBarTemplate(this: ShellBar) {
 				horizontalAlign={this.popoverHorizontalAlign}
 				accessibleName={actionsAccInfo.overflow.title}
 			>
-				<List separators="None" onClick={this.handleOverflowItemClick}>
+				<List separators="None" onClick={this.handleOverflowItemClick} accessibleRole="Menu">
 					{this.overflowItems.map(item => {
+						if (item.type === "branding") {
+							return (
+								<>
+									<div
+										key="branding-overflow"
+										class="ui5-shellbar-overflow-branding"
+										role="menuitem"
+										aria-label={this.brandingOverflowLabel}
+										onClick={this.handleBrandingOverflowClick}
+									>
+										{item.logoHidden && this.brandingOverflowLogoSrc && (
+											<img
+												class="ui5-shellbar-overflow-branding-logo"
+												src={this.brandingOverflowLogoSrc}
+												alt={this.brandingOverflowLogoAlt}
+											/>
+										)}
+										{item.identifierHidden && this.brandingOverflowTitle && (
+											<span class="ui5-shellbar-overflow-branding-title">{this.brandingOverflowTitle}</span>
+										)}
+									</div>
+									<div key="branding-separator" role="separator" class="ui5-shellbar-overflow-branding-separator"></div>
+								</>
+							);
+						}
 						if (item.type === "action") {
 							const actionData = item.data;
 							return (

--- a/packages/fiori/src/shellbar/ShellBarOverflow.ts
+++ b/packages/fiori/src/shellbar/ShellBarOverflow.ts
@@ -64,9 +64,9 @@ class ShellBarOverflow {
 		CONTENT: 1000,		// Then content (except last)
 		SEARCH: 2000,		// Then search button
 		LAST_CONTENT: 3000,	// Last content item hides last
-		BRANDING_STACKED: 3500,    // Branding stacks (title below logo) before identifier hides
+		BRANDING_STACKED: 3500, // Branding stacks (title below logo) before identifier hides
 		BRANDING_IDENTIFIER: 4000, // Branding identifier hides after all actions
-		BRANDING_LOGO: 5000,       // Logo hides last
+		BRANDING_LOGO: 5000, // Logo hides last
 	};
 
 	private readonly OPEN_SEARCH_STRATEGY = {
@@ -274,7 +274,9 @@ class ShellBarOverflow {
 		hiddenItemsIds: readonly string[];
 		hasBranding: boolean;
 	}): ReadonlyArray<ShellBarOverflowItem> {
-		const { actions, customItems, hiddenItemsIds, hasBranding } = params;
+		const {
+			actions, customItems, hiddenItemsIds, hasBranding,
+		} = params;
 		const result: ShellBarOverflowItem[] = [];
 
 		// Branding goes first when identifier or logo is hidden

--- a/packages/fiori/src/shellbar/ShellBarOverflow.ts
+++ b/packages/fiori/src/shellbar/ShellBarOverflow.ts
@@ -8,6 +8,7 @@ interface ShellBarHidableItem {
 	hideOrder: number;			// Priority for hiding - later adjusted based on search field state
 	keepHidden: boolean; 		// Keep item hidden to prevent flickering when searchfield expands/collapses
 	showInOverflow?: boolean; 	// If true, hiding this item triggers overflow button
+	neverHide?: boolean;		// Never actually hide in DOM, but still report in hiddenItemsIds for events
 }
 
 interface ShellBarOverflowParams {
@@ -18,6 +19,7 @@ interface ShellBarOverflowParams {
 	overflowInner: HTMLElement;
 	hiddenItemsIds: readonly string[];
 	showSearchField: boolean;
+	hasBranding: boolean;
 	setVisible: (selector: string, visible: boolean) => void;
 }
 
@@ -36,7 +38,25 @@ type ShellBarOverflowItem = {
 	id: string;
 	data: ShellBarItem;
 	order: number;
+} | {
+	type: "branding";
+	id: string;
+	order: number;
+	logoHidden: boolean;
+	identifierHidden: boolean;
 }
+
+const BrandingIds = {
+	Stacked: "branding-stacked",
+	Identifier: "branding-identifier",
+	Logo: "branding-logo",
+} as const;
+
+const BrandingSelectors = {
+	Stacked: "[data-ui5-stable='branding-stacked']",
+	Identifier: "[data-ui5-stable='branding-identifier']",
+	Logo: "[data-ui5-stable='branding-logo']",
+} as const;
 
 class ShellBarOverflow {
 	private readonly CLOSED_SEARCH_STRATEGY = {
@@ -44,13 +64,19 @@ class ShellBarOverflow {
 		CONTENT: 1000,		// Then content (except last)
 		SEARCH: 2000,		// Then search button
 		LAST_CONTENT: 3000,	// Last content item hides last
+		BRANDING_STACKED: 3500,    // Branding stacks (title below logo) before identifier hides
+		BRANDING_IDENTIFIER: 4000, // Branding identifier hides after all actions
+		BRANDING_LOGO: 5000,       // Logo hides last
 	};
 
 	private readonly OPEN_SEARCH_STRATEGY = {
-		CONTENT: 0, 		// All content hide first
-		ACTIONS: 1000,		// All actions next
+		ACTIONS: 0, 		// Actions hide first (same as closed — spec says actions before content)
+		CONTENT: 1000,		// Then content
 		SEARCH: 2000,		// Then search button
-		LAST_CONTENT: 0,	// Last content same as other content
+		LAST_CONTENT: 1000,	// Last content same as other content
+		BRANDING_STACKED: 3500,
+		BRANDING_IDENTIFIER: 4000,
+		BRANDING_LOGO: 5000,
 	};
 
 	updateOverflow(params: ShellBarOverflowParams): ShellBarOverflowResult {
@@ -72,7 +98,7 @@ class ShellBarOverflow {
 		});
 
 		let nextItemToHide = null;
-		let showOverflowButton = false;
+		let overflowItemCount = 0;
 		const hiddenItemsIds: string[] = [];
 
 		// Iteratively hide items until no overflow
@@ -83,15 +109,20 @@ class ShellBarOverflow {
 				break; // No more overflow, stop hiding
 			}
 
-			setVisible(nextItemToHide.selector, false);
+			if (!nextItemToHide.neverHide) {
+				setVisible(nextItemToHide.selector, false);
+			}
 			hiddenItemsIds.push(nextItemToHide.id);
 
 			if (nextItemToHide.showInOverflow) {
-				// show overflow button to account in isOverflowing calculation
+				overflowItemCount++;
+				// Always show the overflow button in DOM during measurement to account for its width.
+				// It will only be rendered visibly if overflowItemCount > 1 (enforced via showOverflowButton).
 				setVisible(ShellBarActionsSelectors.Overflow, true);
-				showOverflowButton = true;
 			}
 		}
+
+		const showOverflowButton = overflowItemCount > 0;
 
 		return {
 			hiddenItemsIds,
@@ -111,6 +142,7 @@ class ShellBarOverflow {
 		const items: ShellBarHidableItem[] = [
 			...this.buildContent(params),
 			...this.buildActions(params),
+			...this.buildBranding(params),
 		];
 
 		// sort by hideOrder first then by keepHidden keepHidden items are at the start
@@ -125,6 +157,39 @@ class ShellBarOverflow {
 		});
 	}
 
+	private buildBranding(params: ShellBarOverflowParams): readonly ShellBarHidableItem[] {
+		if (!params.hasBranding) {
+			return [];
+		}
+
+		const strategy = this.getOverflowStrategy(params.showSearchField);
+		const { hiddenItemsIds } = params;
+
+		return [
+			{
+				id: BrandingIds.Stacked,
+				selector: BrandingSelectors.Stacked,
+				hideOrder: strategy.BRANDING_STACKED,
+				keepHidden: hiddenItemsIds.includes(BrandingIds.Stacked),
+				showInOverflow: false,
+			},
+			{
+				id: BrandingIds.Identifier,
+				selector: BrandingSelectors.Identifier,
+				hideOrder: strategy.BRANDING_IDENTIFIER,
+				keepHidden: hiddenItemsIds.includes(BrandingIds.Identifier),
+				showInOverflow: true,
+			},
+			{
+				id: BrandingIds.Logo,
+				selector: BrandingSelectors.Logo,
+				hideOrder: strategy.BRANDING_LOGO,
+				keepHidden: hiddenItemsIds.includes(BrandingIds.Logo),
+				showInOverflow: true,
+			},
+		];
+	}
+
 	private buildContent(params: ShellBarOverflowParams): readonly ShellBarHidableItem[] {
 		const {
 			content, showSearchField,
@@ -136,7 +201,11 @@ class ShellBarOverflow {
 		// Build content items
 		content.forEach((item, index) => {
 			const slotName = (item as any)._individualSlot as string;
-			const dataHideOrder = parseInt(item.getAttribute("data-hide-order") || String(index));
+			const isNeverHide = item.hasAttribute("data-never-hide");
+			const hasExplicitOrder = item.hasAttribute("data-hide-order");
+			// Default: last added hides first (higher index = lower hide order number = hides earlier)
+			const defaultOrder = content.length - index;
+			const dataHideOrder = hasExplicitOrder ? parseInt(item.getAttribute("data-hide-order")!) : defaultOrder;
 			const isLast = index === content.length - 1;
 
 			const priority = isLast ? overflowStrategy.LAST_CONTENT : overflowStrategy.CONTENT;
@@ -145,8 +214,9 @@ class ShellBarOverflow {
 				id: slotName,
 				selector: `#${slotName}`,
 				hideOrder: priority + dataHideOrder,
-				keepHidden: false, // Content items don't cause flickering
+				keepHidden: false,
 				showInOverflow: false,
+				neverHide: isNeverHide || undefined,
 			});
 		});
 
@@ -202,9 +272,21 @@ class ShellBarOverflow {
 		actions: readonly ShellBarActionItem[];
 		customItems: readonly ShellBarItem[];
 		hiddenItemsIds: readonly string[];
+		hasBranding: boolean;
 	}): ReadonlyArray<ShellBarOverflowItem> {
-		const { actions, customItems, hiddenItemsIds } = params;
+		const { actions, customItems, hiddenItemsIds, hasBranding } = params;
 		const result: ShellBarOverflowItem[] = [];
+
+		// Branding goes first when identifier or logo is hidden
+		if (hasBranding && (hiddenItemsIds.includes(BrandingIds.Identifier) || hiddenItemsIds.includes(BrandingIds.Logo))) {
+			result.push({
+				type: "branding",
+				id: "branding",
+				order: -1,
+				logoHidden: hiddenItemsIds.includes(BrandingIds.Logo),
+				identifierHidden: hiddenItemsIds.includes(BrandingIds.Identifier),
+			});
+		}
 
 		// Add hidden custom items
 		const hiddenCustomItems = customItems.filter((item: ShellBarItem) => hiddenItemsIds.includes(item._id));
@@ -216,8 +298,8 @@ class ShellBarOverflow {
 
 		const actionOrder: Record<string, number> = {
 			[ShellBarActions.Search]: 0,
-			[ShellBarActions.Notifications]: 1,
-			[ShellBarActions.Assistant]: 2,
+			[ShellBarActions.Assistant]: 1,
+			[ShellBarActions.Notifications]: 2,
 		};
 
 		const hiddenActions = actions.filter(action => hiddenItemsIds.includes(action.id));

--- a/packages/fiori/src/themes/ShellBar.css
+++ b/packages/fiori/src/themes/ShellBar.css
@@ -135,6 +135,8 @@
 	flex-shrink: 0;
 	display: flex;
 	align-items: center;
+	/* Push all subsequent items (actions) to the right */
+	margin-inline-end: auto;
 }
 
 /* ============================================================================
@@ -156,7 +158,6 @@
 .ui5-shellbar-overflow-container-inner {
 	display: flex;
 	align-items: center;
-	justify-content: end;
 	flex-shrink: 0;
 	min-width: 100%;
 }
@@ -355,6 +356,50 @@ slot[name="profile"] {
 
 :host([breakpoint-size="M"]) .ui5-shellbar-search-full-width-wrapper {
 	padding: 0 2rem;
+}
+
+/* ============================================================================
+   OVERFLOW BRANDING (branding shown at top of overflow popover)
+   ============================================================================ */
+
+.ui5-shellbar-overflow-branding {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 0.25rem;
+	min-height: 2.5rem;
+	padding: 0.25rem 2rem;
+	box-sizing: border-box;
+	cursor: pointer;
+	overflow-x: auto;
+}
+
+.ui5-shellbar-overflow-branding:hover {
+	background: var(--sapList_Hover_Background);
+}
+
+.ui5-shellbar-overflow-branding:active {
+	background: var(--sapList_Active_Background);
+}
+
+.ui5-shellbar-overflow-branding-logo {
+	max-height: 1.5625rem;
+	width: auto;
+	flex-shrink: 0;
+}
+
+.ui5-shellbar-overflow-branding-title {
+	font-family: var(--sapFontSemiboldDuplexFamily);
+	font-size: var(--sapFontHeader6Size);
+	color: var(--sapList_TextColor);
+	white-space: normal;
+	word-break: break-word;
+}
+
+.ui5-shellbar-overflow-branding-separator {
+	height: 1px;
+	background-color: var(--_ui5-shellbar_separator-color);
+	margin: 0 1rem;
 }
 
 /* ============================================================================

--- a/packages/fiori/src/themes/ShellBarBranding.css
+++ b/packages/fiori/src/themes/ShellBarBranding.css
@@ -3,16 +3,17 @@
 }
 
 :host(:not([hidden])) {
-    display: inline;
+    display: block;
+    min-width: 0;
 }
 
 .ui5-shellbar-branding-root {
-	overflow: hidden;
 	display: flex;
 	align-items: center;
-	height: 2.25rem;
-	padding-block: 0.125rem;
-	padding-inline: 0.25rem 0.5rem;
+	min-height: 2.5rem;
+	min-width: 0;
+	padding-block: 0.25rem;
+	padding-inline: 0.25rem 2rem;
 	box-sizing: border-box;
 	cursor: pointer;
 	background: var(--sapButton_Lite_Background);
@@ -21,6 +22,12 @@
 	/* fix cutting of the focus outline */
 	margin-inline-start: 0.125rem;
 	margin-inline-end: 0.5rem;
+}
+
+.ui5-shellbar-branding-root--stacked,
+:host([_stacked]) .ui5-shellbar-branding-root {
+	flex-direction: column;
+	align-items: flex-start;
 }
 
 .ui5-shellbar-branding-root:focus {
@@ -41,15 +48,24 @@
 }
 
 .ui5-shellbar-title {
-	display: inline-block;
+	display: -webkit-box;
+	-webkit-box-orient: vertical;
+	-webkit-line-clamp: 2;
+	overflow: hidden;
 	font-family: var(--sapFontSemiboldDuplexFamily);
 	margin: 0;
-	font-size: var(--_ui5_shellbar_menu_button_title_font_size);
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
+	font-size: var(--sapFontHeader6Size);
 	color: var(--sapShell_SubBrand_TextColor);
 	margin-inline-start: 0.25rem;
+	text-align: start;
+}
+
+.ui5-shellbar-branding-root--stacked .ui5-shellbar-title,
+:host([_stacked]) .ui5-shellbar-title {
+	display: block;
+	overflow: visible;
+	-webkit-line-clamp: unset;
+	margin-inline-start: 0;
 }
 
 .ui5-shellbar-logo-area {
@@ -67,7 +83,7 @@
 }
 
 ::slotted([slot="logo"]) {
-	max-height: 1.875rem;
+	max-height: 1.5625rem;
 	width: auto;
 	padding-block: 0.0625rem;
 	padding-inline: 0.25rem;
@@ -76,4 +92,22 @@
 
 ::slotted([slot="logo"]):active {
 	pointer-events: none;
+}
+
+/* Measurement-only visibility — set via setAttribute, no reactive property, no re-render */
+:host([_measure-title-hidden]) .ui5-shellbar-title {
+	display: none !important;
+}
+
+:host([_measure-logo-hidden]) .ui5-shellbar-logo {
+	display: none !important;
+}
+
+/* Final hidden state — also non-reactive, driven by toggleAttribute from ShellBar */
+:host([_title-hidden]) .ui5-shellbar-title {
+	display: none !important;
+}
+
+:host([_logo-hidden]) .ui5-shellbar-logo {
+	display: none !important;
 }

--- a/packages/fiori/test/pages/ShellBarBranding.html
+++ b/packages/fiori/test/pages/ShellBarBranding.html
@@ -1,0 +1,357 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<title>ShellBar — Spec Scenarios</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+	<script data-ui5-config type="application/json">{ "rtl": false }</script>
+	<script src="%VITE_BUNDLE_PATH%" type="module"></script>
+	<style>
+		body { font-family: sans-serif; background: #f5f6f7; padding: 1rem 1rem 4rem; }
+		.scenario { margin-bottom: 2.5rem; }
+		.scenario-label {
+			font-size: 0.75rem;
+			font-weight: 600;
+			color: #444;
+			text-transform: uppercase;
+			letter-spacing: 0.06em;
+			margin-bottom: 0.4rem;
+			padding: 0.25rem 0.5rem;
+			background: #e0e0e0;
+			border-radius: 3px;
+			display: inline-block;
+		}
+		.scenario-desc {
+			font-size: 0.8rem;
+			color: #555;
+			margin: 0.25rem 0 0.5rem;
+			line-height: 1.5;
+		}
+	</style>
+</head>
+<body>
+
+<!-- ═══════════════════════════════════════════════════════════════
+     WHAT CHANGED — Custom Branding Responsiveness POC
+     ═══════════════════════════════════════════════════════════════ -->
+<div style="margin-bottom:2rem; padding:1rem 1.25rem; background:#fff; border:1px solid #d0d0d0; border-radius:6px; font-size:0.82rem; line-height:1.7; color:#333;">
+	<strong style="font-size:0.9rem;">Custom Branding — What changed</strong>
+	<table style="margin-top:0.75rem; border-collapse:collapse; width:100%;">
+		<thead>
+			<tr style="background:#f0f0f0; text-align:left;">
+				<th style="padding:0.35rem 0.75rem; border:1px solid #ccc;">Area</th>
+				<th style="padding:0.35rem 0.75rem; border:1px solid #ccc;">Before</th>
+				<th style="padding:0.35rem 0.75rem; border:1px solid #ccc;">After</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<td style="padding:0.35rem 0.75rem; border:1px solid #ccc;"><strong>S breakpoint hiding</strong></td>
+				<td style="padding:0.35rem 0.75rem; border:1px solid #ccc;">Product identifier hidden at S (&lt;600px)</td>
+				<td style="padding:0.35rem 0.75rem; border:1px solid #ccc; color:green;">Identifier stays visible as long as possible — only hides after all actions have overflowed</td>
+			</tr>
+			<tr style="background:#fafafa;">
+				<td style="padding:0.35rem 0.75rem; border:1px solid #ccc;"><strong>Stacked mode</strong></td>
+				<td style="padding:0.35rem 0.75rem; border:1px solid #ccc;">Did not exist</td>
+				<td style="padding:0.35rem 0.75rem; border:1px solid #ccc; color:green;">NEW — when title needs more than 2 lines, it moves below the logo automatically. Triggered by the overflow loop, not a breakpoint.</td>
+			</tr>
+			<tr>
+				<td style="padding:0.35rem 0.75rem; border:1px solid #ccc;"><strong>Overflow order</strong></td>
+				<td style="padding:0.35rem 0.75rem; border:1px solid #ccc;">Branding hidden at S breakpoint (fixed)</td>
+				<td style="padding:0.35rem 0.75rem; border:1px solid #ccc; color:green;">Stack → identifier overflow → logo overflow (logo is always last)</td>
+			</tr>
+			<tr style="background:#fafafa;">
+				<td style="padding:0.35rem 0.75rem; border:1px solid #ccc;"><strong>Branding in overflow popover</strong></td>
+				<td style="padding:0.35rem 0.75rem; border:1px solid #ccc;">Did not appear in overflow menu</td>
+				<td style="padding:0.35rem 0.75rem; border:1px solid #ccc; color:green;">NEW — appears at top of overflow popover with separator, shows only the hidden parts (identifier and/or logo)</td>
+			</tr>
+			<tr>
+				<td style="padding:0.35rem 0.75rem; border:1px solid #ccc;"><strong>Title wrapping</strong></td>
+				<td style="padding:0.35rem 0.75rem; border:1px solid #ccc;"><code>white-space: nowrap</code> + ellipsis — title always on one line</td>
+				<td style="padding:0.35rem 0.75rem; border:1px solid #ccc; color:green;"><code>-webkit-line-clamp: 2</code> — title can wrap up to 2 lines before going stacked</td>
+			</tr>
+			<tr style="background:#fafafa;">
+				<td style="padding:0.35rem 0.75rem; border:1px solid #ccc;"><strong>Content area priority</strong></td>
+				<td style="padding:0.35rem 0.75rem; border:1px solid #ccc;">No control over hide order</td>
+				<td style="padding:0.35rem 0.75rem; border:1px solid #ccc; color:green;">NEW — <code>data-hide-order</code> attribute sets explicit priority; <code>data-never-hide</code> keeps an item always visible</td>
+			</tr>
+			<tr style="background:#fafafa;">
+				<td style="padding:0.35rem 0.75rem; border:1px solid #ccc;"><strong>Branding DOM position</strong></td>
+				<td style="padding:0.35rem 0.75rem; border:1px solid #ccc;">Outside the overflow container — not measured by overflow loop</td>
+				<td style="padding:0.35rem 0.75rem; border:1px solid #ccc; color:green;">Moved inside the overflow container so the overflow loop can measure and hide it progressively</td>
+			</tr>
+			<tr>
+				<td style="padding:0.35rem 0.75rem; border:1px solid #ccc;"><strong>Actions alignment</strong></td>
+				<td style="padding:0.35rem 0.75rem; border:1px solid #ccc;"><code>justify-content: end</code> on inner container</td>
+				<td style="padding:0.35rem 0.75rem; border:1px solid #ccc; color:green;"><code>margin-inline-end: auto</code> on branding — pushes actions right while keeping branding naturally left-aligned</td>
+			</tr>
+			<tr style="background:#fafafa;">
+				<td style="padding:0.35rem 0.75rem; border:1px solid #ccc;"><strong>Removed</strong></td>
+				<td style="padding:0.35rem 0.75rem; border:1px solid #ccc;"><code>_isSBreakPoint</code> property — parent ShellBar set this on the branding element to hide the title at S</td>
+				<td style="padding:0.35rem 0.75rem; border:1px solid #ccc; color:#c00;">Removed — replaced by the overflow loop driving stacked/hidden state via non-reactive attributes</td>
+			</tr>
+		</tbody>
+	</table>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════
+     1. BASIC BRANDING — no actions, no content
+     Expected: Logo + product identifier visible. No overflow.
+     ═══════════════════════════════════════════════════════════════ -->
+<div class="scenario">
+	<span class="scenario-label">1 · Basic branding — no actions</span>
+	<p class="scenario-desc">Logo and product identifier visible. No overflow button.</p>
+	<ui5-shellbar>
+		<ui5-shellbar-branding slot="branding">
+			Product Title
+			<img slot="logo" src="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg" alt="Logo" />
+		</ui5-shellbar-branding>
+	</ui5-shellbar>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════
+     2. BRANDING + SHELL ACTIONS — resize to trigger overflow
+     Expected: Shell actions overflow first (rightmost first).
+     Overflow button appears. Branding stays visible longer.
+     ═══════════════════════════════════════════════════════════════ -->
+<div class="scenario">
+	<span class="scenario-label">2 · Branding + shell actions — resize to overflow</span>
+	<p class="scenario-desc">
+		Resize narrow: shell actions go to overflow first (rightmost first: Help → Settings → Notifications).
+		Branding stays visible until all actions are overflowed. Overflow button appears.
+	</p>
+	<ui5-shellbar show-notifications notifications-count="72" show-product-switch>
+		<ui5-shellbar-branding slot="branding">
+			Product Identifier
+			<img slot="logo" src="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg" alt="Logo" />
+		</ui5-shellbar-branding>
+		<ui5-shellbar-item icon="sys-help" text="Help"></ui5-shellbar-item>
+		<ui5-shellbar-item icon="action-settings" text="Settings"></ui5-shellbar-item>
+		<ui5-avatar slot="profile" icon="customer"></ui5-avatar>
+	</ui5-shellbar>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════
+     3. BRANDING WRAPPING — long product identifier
+     Expected: If identifier needs >2 lines → stacks below logo.
+     If still too narrow → identifier moves to overflow.
+     Logo is last to be hidden.
+     ═══════════════════════════════════════════════════════════════ -->
+<div class="scenario">
+	<span class="scenario-label">3 · Long product identifier — stacking + overflow</span>
+	<p class="scenario-desc">
+		Resize narrow: identifier wraps to 2 lines (stacks below logo). Further → identifier moves to overflow.
+		Logo is last to be hidden.
+	</p>
+	<ui5-shellbar show-notifications notifications-count="72">
+		<ui5-shellbar-branding slot="branding">
+			A very Long Brand Name that needs wrapping
+			<img slot="logo" src="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg" alt="Logo" />
+		</ui5-shellbar-branding>
+		<ui5-shellbar-item icon="sys-help" text="Help"></ui5-shellbar-item>
+		<ui5-shellbar-item icon="action-settings" text="Settings"></ui5-shellbar-item>
+		<ui5-avatar slot="profile" icon="customer"></ui5-avatar>
+	</ui5-shellbar>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════
+     4. CONTENT AREA — default priority (last added, first hidden)
+     Expected: items hide in reverse insertion order (last added first).
+     Separators shown automatically. No separator on size S (<600px).
+     ═══════════════════════════════════════════════════════════════ -->
+<div class="scenario">
+	<span class="scenario-label">4 · Content area — default priority (last added, first hidden)</span>
+	<p class="scenario-desc">
+		Resize narrow: "Item C" (last added) hides first, then "Item B", then "Item A".
+		Separators visible on M/L/XL, hidden on S (&lt;600px).
+	</p>
+	<ui5-shellbar show-notifications notifications-count="72">
+		<ui5-shellbar-branding slot="branding">
+			Product Identifier
+			<img slot="logo" src="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg" alt="Logo" />
+		</ui5-shellbar-branding>
+		<ui5-button slot="content" design="Transparent">Item A</ui5-button>
+		<ui5-button slot="content" design="Transparent">Item B</ui5-button>
+		<ui5-button slot="content" design="Transparent">Item C</ui5-button>
+		<ui5-avatar slot="profile" icon="customer"></ui5-avatar>
+	</ui5-shellbar>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════
+     5. CONTENT AREA — explicit priority (data-hide-order)
+     Expected: Priority 1 hides first, priority 4 hides last.
+     ═══════════════════════════════════════════════════════════════ -->
+<div class="scenario">
+	<span class="scenario-label">5 · Content area — explicit priority (data-hide-order)</span>
+	<p class="scenario-desc">
+		Resize narrow: "Priority 1" hides first, then "Priority 2", "Priority 3", "Priority 4" last.
+	</p>
+	<ui5-shellbar show-notifications notifications-count="72">
+		<ui5-shellbar-branding slot="branding">
+			Product Identifier
+			<img slot="logo" src="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg" alt="Logo" />
+		</ui5-shellbar-branding>
+		<ui5-button slot="content" design="Transparent" data-hide-order="4">Priority 4 (last hidden)</ui5-button>
+		<ui5-button slot="content" design="Transparent" data-hide-order="3">Priority 3</ui5-button>
+		<ui5-button slot="content" design="Transparent" data-hide-order="2">Priority 2</ui5-button>
+		<ui5-button slot="content" design="Transparent" data-hide-order="1">Priority 1 (first hidden)</ui5-button>
+		<ui5-avatar slot="profile" icon="customer"></ui5-avatar>
+	</ui5-shellbar>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════
+     6. NEVER HIDE content item
+     Expected: "Always Visible" item never hides. Other items, branding,
+     and shell actions overflow before it. Hide events still fire for it.
+     ═══════════════════════════════════════════════════════════════ -->
+<div class="scenario">
+	<span class="scenario-label">6 · Never hide content item</span>
+	<p class="scenario-desc">
+		Resize narrow: "Can Hide" hides first, then shell actions, then branding.
+		"Always Visible" (data-never-hide) stays in the bar at all times.
+	</p>
+	<ui5-shellbar show-notifications notifications-count="72">
+		<ui5-shellbar-branding slot="branding">
+			Product Identifier
+			<img slot="logo" src="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg" alt="Logo" />
+		</ui5-shellbar-branding>
+		<ui5-tag slot="content" design="Set2" color-scheme="2" data-never-hide>Always Visible ★</ui5-tag>
+		<ui5-button slot="content" design="Transparent" data-hide-order="1">Can Hide</ui5-button>
+		<ui5-shellbar-item icon="sys-help" text="Help"></ui5-shellbar-item>
+		<ui5-avatar slot="profile" icon="customer"></ui5-avatar>
+	</ui5-shellbar>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════
+     7. CONTENT + ACTIONS — full overflow cascade with additional context
+     Expected order: search collapses → actions overflow (rightmost first)
+     → content hides by priority → identifier wraps → identifier overflows → logo overflows.
+     ═══════════════════════════════════════════════════════════════ -->
+<div class="scenario">
+	<span class="scenario-label">7 · Full cascade — content + actions + branding</span>
+	<p class="scenario-desc">
+		Resize narrow. Expected order: search collapses → Help overflows → Settings overflows →
+		Notifications overflows → "Item 1" hides → "Item 2*" (never-hide, stays) →
+		identifier wraps → identifier overflows → logo overflows.
+	</p>
+	<ui5-shellbar show-notifications notifications-count="72" show-product-switch>
+		<ui5-shellbar-branding slot="branding">
+			Product Identifier
+			<img slot="logo" src="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg" alt="Logo" />
+		</ui5-shellbar-branding>
+		<ui5-tag slot="content" design="Set2" color-scheme="2" data-never-hide data-hide-order="2">Item 2* (never hide)</ui5-tag>
+		<ui5-button slot="content" design="Transparent" data-hide-order="1">Item 1</ui5-button>
+		<ui5-shellbar-item icon="sys-help" text="Help"></ui5-shellbar-item>
+		<ui5-shellbar-item icon="action-settings" text="Settings"></ui5-shellbar-item>
+		<ui5-avatar slot="profile" icon="customer"></ui5-avatar>
+	</ui5-shellbar>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════
+     8. BADGE — single badge-capable action overflows
+     Expected: overflow button shows the badge count (72).
+     ═══════════════════════════════════════════════════════════════ -->
+<div class="scenario">
+	<span class="scenario-label">8 · Badge — single badge action in overflow</span>
+	<p class="scenario-desc">
+		Resize narrow until notifications overflows. Overflow button should show "72" badge counter.
+	</p>
+	<ui5-shellbar show-notifications notifications-count="72">
+		<ui5-shellbar-branding slot="branding">
+			Product Identifier
+			<img slot="logo" src="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg" alt="Logo" />
+		</ui5-shellbar-branding>
+		<ui5-shellbar-item icon="sys-help" text="Help"></ui5-shellbar-item>
+		<ui5-avatar slot="profile" icon="customer"></ui5-avatar>
+	</ui5-shellbar>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════
+     9. BADGE — multiple badge-capable actions overflow → attention dot
+     Expected: overflow button shows attention dot (not count) when
+     multiple badge-capable actions are overflowed.
+     Even if notifications count is 0, attention dot still shows
+     because notifications CAN display a badge.
+     ═══════════════════════════════════════════════════════════════ -->
+<div class="scenario">
+	<span class="scenario-label">9 · Badge — multiple badge actions → attention dot</span>
+	<p class="scenario-desc">
+		Resize narrow until both notifications (72) and custom item (count="1") overflow.
+		Overflow button shows attention dot, not a specific count.
+		Also: notifications with count="0" still causes attention dot since it CAN show a badge.
+	</p>
+	<ui5-shellbar show-notifications notifications-count="72">
+		<ui5-shellbar-branding slot="branding">
+			Product Identifier
+			<img slot="logo" src="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg" alt="Logo" />
+		</ui5-shellbar-branding>
+		<ui5-shellbar-item icon="sys-help" text="Help"></ui5-shellbar-item>
+		<ui5-shellbar-item icon="activities" text="Tasks" count="1"></ui5-shellbar-item>
+		<ui5-avatar slot="profile" icon="customer"></ui5-avatar>
+	</ui5-shellbar>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════
+     10. OVERFLOW MENU — branding in overflow popover
+     Expected: when branding overflows, it appears at the top of the
+     overflow popover with logo and/or identifier. Clicking it fires
+     the branding click. Separator below branding entry.
+     ═══════════════════════════════════════════════════════════════ -->
+<div class="scenario">
+	<span class="scenario-label">10 · Overflow popover — branding entry at top</span>
+	<p class="scenario-desc">
+		Resize very narrow until logo overflows. Open overflow menu: branding entry (logo + identifier)
+		appears at top with separator below it, followed by shell actions.
+		Clicking branding entry fires its click event.
+	</p>
+	<ui5-shellbar show-notifications notifications-count="72" show-product-switch>
+		<ui5-shellbar-branding slot="branding" href="https://ui5.sap.com" target="_blank">
+			A very Long Brand Name that needs wrapping to overflow
+			<img slot="logo" src="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg" alt="Logo" />
+		</ui5-shellbar-branding>
+		<ui5-shellbar-item icon="sys-help" text="Help"></ui5-shellbar-item>
+		<ui5-shellbar-item icon="action-settings" text="Settings"></ui5-shellbar-item>
+		<ui5-avatar slot="profile" icon="customer"></ui5-avatar>
+	</ui5-shellbar>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════
+     11. BRANDING ONLY (no logo) — identifier only
+     Expected: only text identifier shown, no logo slot.
+     ═══════════════════════════════════════════════════════════════ -->
+<div class="scenario">
+	<span class="scenario-label">11 · Branding — identifier only (no logo)</span>
+	<p class="scenario-desc">Only product identifier text, no logo. Overflow still works.</p>
+	<ui5-shellbar show-notifications notifications-count="72">
+		<ui5-shellbar-branding slot="branding">
+			Product Title Without Logo
+		</ui5-shellbar-branding>
+		<ui5-shellbar-item icon="sys-help" text="Help"></ui5-shellbar-item>
+		<ui5-avatar slot="profile" icon="customer"></ui5-avatar>
+	</ui5-shellbar>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════
+     12. PROFILE + PRODUCT SWITCH — never go to overflow
+     Expected: profile and product switch always visible regardless of size.
+     ═══════════════════════════════════════════════════════════════ -->
+<div class="scenario">
+	<span class="scenario-label">12 · Profile + product switch — always visible</span>
+	<p class="scenario-desc">
+		Resize to any size. Profile avatar and product switch never go into overflow.
+	</p>
+	<ui5-shellbar show-notifications notifications-count="72" show-product-switch>
+		<ui5-shellbar-branding slot="branding">
+			Product Identifier
+			<img slot="logo" src="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg" alt="Logo" />
+		</ui5-shellbar-branding>
+		<ui5-shellbar-item icon="sys-help" text="Help"></ui5-shellbar-item>
+		<ui5-shellbar-item icon="action-settings" text="Settings"></ui5-shellbar-item>
+		<ui5-avatar slot="profile">
+			<img src="https://sdk.openui5.org/test-resources/sap/f/images/Woman_avatar_01.png" alt="Avatar" />
+		</ui5-avatar>
+	</ui5-shellbar>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

> ⚠️ **This is a POC.**

The ShellBar previously hid the product identifier regardless of available space. Customers (e.g. Bayer) need the identifier visible as long as possible. This POC replaces that approach with a fully space-aware overflow loop that progressively hides branding elements only when there is no other option.

## Overflow order

Actions (rightmost first) → content items → search button → branding stacks (`3500`) → branding identifier (`4000`) → branding logo (`5000`).

The logo is always the last element hidden.

## Stacked mode (new)

When a long product identifier (natural width) causes overflow, a new virtual `branding-stacked` hidable item (priority `3500`) triggers column layout — logo on top, title below — before the identifier is moved to overflow. Stacking is driven by `toggleAttribute("_stacked")` on the branding host element (non-reactive) from inside the overflow loop. A synchronous layout flush (`offsetWidth` read) forces the browser to reflect the new width before the overflow loop continues measuring.

## Branding in overflow popover (new)

When the identifier or logo is hidden, a branding entry appears at the top of the overflow popover (`order: -1`, always first). It renders only the hidden parts — logo as `<img>`, identifier as text following it. Clicking fires `brandingEl._fireClick()` and closes the popover. The `aria-label` is `"<title> Home"`, falling back for logo-only branding.

## Title wrapping

`-webkit-line-clamp: 2` replaces `white-space: nowrap` + `text-overflow: ellipsis`, allowing the title to wrap to two lines before stacking kicks in. Font changed from `--_ui5_shellbar_menu_button_title_font_size` to `--sapFontHeader6Size` per the spec token.

## Content slot priority (new)

- `data-hide-order="N"`: explicit numeric priority — these hide first. Items without it default to reverse insertion order (last added hides first).
- `data-never-hide`: item is never removed from the DOM but is still reported in `hiddenItemsIds` and fires hide events, so products can show a compact alternative via an event handler.

## Branding DOM position

The branding area div was previously rendered outside the overflow container, making it invisible to the overflow loop's `offsetWidth` measurement. It is now the first child inside `.ui5-shellbar-overflow-inner`, so hiding the identifier or logo actually reduces `overflowInner.offsetWidth`.

## Actions alignment

`justify-content: end` removed from the inner overflow container. `margin-inline-end: auto` added to the branding element to push actions to the right while keeping branding left-aligned as a natural flex child.

## Removed

- `_isSBreakPoint` property on `ShellBarBranding` and the sync code in `ShellBar.onAfterRendering` that set it.
- ResizeObserver-based `_updateStackedState` / `_observeTitleSize` / `onEnterDOM` / `onExitDOM` / `onAfterRendering` from `ShellBarBranding`. Stacking is now fully controlled externally by the overflow loop via non-reactive host attributes (`_stacked`, `_identifier-hidden`, `_logo-hidden`, `_measure-title-hidden`, `_measure-logo-hidden`).

## Test page

Added `ShellBarBranding.html` with 12 spec scenarios covering: basic branding, branding + actions, long title stacking, content items, full cascade, badge behaviour, overflow popover, logo-only, and profile/product-switch always-visible cases. Includes a scenario reference table.

No Cypress tests written — this is a POC branch

JIRA: BGSOFUIPIRIN-7110