### PR TITLE
fix(ui5-user-menu): replace invalid aria-label of div with accessible name on Bar

### DIFF
--- a/packages/fiori/cypress/specs/UserMenu.cy.tsx
+++ b/packages/fiori/cypress/specs/UserMenu.cy.tsx
@@ -10,6 +10,7 @@ import MessageStrip from "@ui5/webcomponents/dist/MessageStrip.js";
 import {
 	USER_MENU_MANAGE_ACCOUNT_BUTTON_TXT,
 	USER_MENU_OTHER_ACCOUNT_BUTTON_TXT,
+	USER_MENU_CURRENT_INFORMATION_TXT,
 } from "../../src/generated/i18n/i18n-defaults.js";
 
 describe("Initial rendering", () => {
@@ -257,6 +258,9 @@ describe("Initial rendering", () => {
 			.scrollTo("bottom");
 		cy.get("[ui5-user-menu]").shadow().find("[ui5-bar]").as("headerBar");
 		cy.get("@headerBar").find("[ui5-title]").contains("Alain Chevalier 1");
+		cy.get("@headerBar").should("have.attr", "accessible-name", USER_MENU_CURRENT_INFORMATION_TXT.defaultText);
+		cy.get("[ui5-user-menu]").shadow().find(".ui5-user-menu-selected-account").should("not.have.attr", "aria-label");
+
 	});
 });
 

--- a/packages/fiori/src/UserMenuTemplate.tsx
+++ b/packages/fiori/src/UserMenuTemplate.tsx
@@ -40,7 +40,7 @@ export default function UserMenuTemplate(this: UserMenu) {
 				<Bar class={{
 					"ui5-user-menu-fixed-header": true,
 					"ui5-user-menu-rp-scrolled": this._isScrolled || this._titleMovedToHeader
-				}} slot="header">
+				}} slot="header" accessible-name={this._ariaLabelledByAccountInformationText}>
 					{this._titleMovedToHeader &&
 						<Title
 							level="H1"
@@ -104,7 +104,7 @@ export default function UserMenuTemplate(this: UserMenu) {
 function headerContent(this: UserMenu) {
 	return (<>
 		{this._selectedAccount &&
-			<div class="ui5-user-menu-selected-account" aria-label={this._ariaLabelledByAccountInformationText}>
+			<div class="ui5-user-menu-selected-account">
 				<span title={this.showEditButton ? this._editAvatarTooltip : undefined}>
 					<Avatar size="L" onClick={this._isAvatarInteractive ? this._handleAvatarClick : undefined} initials={this._selectedAccount._initials} colorScheme={this._selectedAccount.avatarColorScheme} fallbackIcon={personPlaceholder} class="ui5-user-menu-selected-account-avatar" mode={this._isAvatarInteractive ? "Interactive" : "Image"}>
 						{this._selectedAccount.avatarSrc &&


### PR DESCRIPTION
Replaces the invalid `aria-label` usage on the UserMenu account container with the `accessible-name` API on the fixed header Bar. Adds Cypress coverage for the accessible name and removal of the invalid attribute.