### PR TITLE
fix(ui5-date-picker): sync disabled state to inner input immediately on change

### DIFF
--- a/packages/main/src/DatePicker.ts
+++ b/packages/main/src/DatePicker.ts
@@ -77,7 +77,7 @@ import datePickerCss from "./generated/themes/DatePicker.css.js";
 import datePickerPopoverCss from "./generated/themes/DatePickerPopover.css.js";
 import ResponsivePopoverCommonCss from "./generated/themes/ResponsivePopoverCommon.css.js";
 import ValueStateMessageCss from "./generated/themes/ValueStateMessage.css.js";
-import type { Slot } from "@ui5/webcomponents-base/dist/UI5Element.js";
+import type { Slot, ChangeInfo } from "@ui5/webcomponents-base/dist/UI5Element.js";
 
 type ValueStateAnnouncement = Record<Exclude<ValueState, ValueState.None>, string>;
 
@@ -483,6 +483,12 @@ class DatePicker extends DateComponentBase implements IFormInputElement {
 	onResponsivePopoverBeforeOpen() {
 		this._calendar.timestamp = this._calendarTimestamp;
 		this._calendarCurrentPicker = this.firstPicker;
+	}
+
+	onInvalidation(changeInfo: ChangeInfo) {
+		if (changeInfo.type === "property" && changeInfo.name === "disabled" && this._dateTimeInput) {
+			this._dateTimeInput.disabled = !!changeInfo.newValue;
+		}
 	}
 
 	onBeforeRendering() {


### PR DESCRIPTION
**Issue:**

When `disabled`  was toggled via a framework (e.g. React), the host element updated synchronously but the inner  only updated in the next animation frame. This gap allowed the browser's accessibility tree to snapshot a stale disabled state that never cleared, leaving the inner input reported as disabled even after the component was re-enabled.

**Solution:**

Override `onInvalidation` to propagate `disabled` to `_dateTimeInput` immediately when the property changes, before the scheduled re-render fires. This closes the one-frame gap and ensures the accessibility tree always reflects the correct state.

Fixes #14006