### PR TITLE
fix(ui5-shellbar): prevent search auto-expand on non-desktop resize

### DIFF
--- a/packages/fiori/cypress/specs/ShellBar.mobile.cy.tsx
+++ b/packages/fiori/cypress/specs/ShellBar.mobile.cy.tsx
@@ -1,5 +1,10 @@
 import ShellBar from "../../src/ShellBar.js";
 import ShellBarSearch from "../../src/ShellBarSearch.js";
+import ShellBarSpacer from "../../src/ShellBarSpacer.js";
+import Input from "@ui5/webcomponents/dist/Input.js";
+
+// Safe buffer over the implementation's 100ms throttle (matches the pattern in ShellBar.cy.tsx).
+const RESIZE_THROTTLE_RATE = 300; // ms
 
 describe("Mobile Behaviour", () => {
 	beforeEach(() => {
@@ -38,5 +43,47 @@ describe("Mobile Behaviour", () => {
 		);
 
 		cy.get("#shellbar").should("have.prop", "showSearchField", true);
+	});
+
+	it("Test search does not auto-expand from resize on mobile", () => {
+		// Matches the reproduction layout: spacer-only content gives the spacer
+		// enough width in landscape to cross the 25rem expand threshold.
+		cy.mount(
+			<ShellBar id="shellbar">
+				<ShellBarSpacer slot="content"></ShellBarSpacer>
+				<ShellBarSearch id="search" slot="searchField"></ShellBarSearch>
+			</ShellBar>
+		);
+
+		// Start in portrait — search is collapsed, no full-screen dialog.
+		cy.viewport(440, 956);
+		// Wait for the initial resize cycle to clear the `initialRender` flag.
+		cy.wait(RESIZE_THROTTLE_RATE);
+
+		// Simulate orientation change to landscape (same as rotating the device).
+		cy.viewport(956, 440);
+		cy.wait(RESIZE_THROTTLE_RATE);
+
+		// Search must stay collapsed — no auto-expand from a resize/orientation event on non-desktop.
+		cy.get("#shellbar").should("have.prop", "showSearchField", false);
+		cy.get("#search").should("have.prop", "open", false);
+	});
+
+	it("Test legacy search does not auto-expand from resize on mobile", () => {
+		// Same scenario with a legacy ui5-input in the searchField slot (ShellBarSearchLegacy path).
+		cy.mount(
+			<ShellBar id="shellbar">
+				<ShellBarSpacer slot="content"></ShellBarSpacer>
+				<Input id="search" slot="searchField"></Input>
+			</ShellBar>
+		);
+
+		cy.viewport(440, 956);
+		cy.wait(RESIZE_THROTTLE_RATE);
+
+		cy.viewport(956, 440);
+		cy.wait(RESIZE_THROTTLE_RATE);
+
+		cy.get("#shellbar").should("have.prop", "showSearchField", false);
 	});
 });

--- a/packages/fiori/src/shellbar/ShellBarSearch.ts
+++ b/packages/fiori/src/shellbar/ShellBarSearch.ts
@@ -1,4 +1,4 @@
-import { isPhone } from "@ui5/webcomponents-base/dist/Device.js";
+import { isPhone, isDesktop } from "@ui5/webcomponents-base/dist/Device.js";
 import type { IShellBarSearchField } from "../ShellBar.js";
 import type { IShellBarSearchController } from "./IShellBarSearchController.js";
 
@@ -68,6 +68,7 @@ class ShellBarSearch implements IShellBarSearchController {
 	/**
 	 * Auto-collapse/restore search field based on available space.
 	 * Delegates decision logic to SearchController.
+	 * Note: on non-desktop devices (phone/tablet), auto-expand is suppressed — expansion must come from an explicit user tap.
 	 */
 	autoManageSearchState(hiddenItems: number, availableSpace: number) {
 		if (!this.hasSearchField) {
@@ -88,7 +89,7 @@ class ShellBarSearch implements IShellBarSearchController {
 
 		if (hiddenItems > 0 && !preventCollapse) {
 			this.setSearchState(false);
-		} else if (availableSpace + this.getSearchButtonSize() > searchFieldWidth) {
+		} else if (isDesktop() && availableSpace + this.getSearchButtonSize() > searchFieldWidth) {
 			this.setSearchState(true);
 		}
 

--- a/packages/fiori/src/shellbar/ShellBarSearchLegacy.ts
+++ b/packages/fiori/src/shellbar/ShellBarSearchLegacy.ts
@@ -1,3 +1,4 @@
+import { isDesktop } from "@ui5/webcomponents-base/dist/Device.js";
 import type { IShellBarSearchController } from "./IShellBarSearchController.js";
 
 interface ShellBarSearchLegacyConstructorParams {
@@ -85,7 +86,7 @@ class ShellBarSearchLegacy implements IShellBarSearchController {
 
 		if (hiddenItems > 0 && !preventCollapse) {
 			this.setSearchState(false);
-		} else if (availableSpace + this.getSearchButtonSize() > searchFieldWidth) {
+		} else if (isDesktop() && availableSpace + this.getSearchButtonSize() > searchFieldWidth) {
 			this.setSearchState(true);
 		}
 


### PR DESCRIPTION
On phones and tablets, rotating the device triggers the ShellBar's resize-based auto-expand logic, opening the full-screen search dialog without any user intent.

Guard the expand branch in both ShellBarSearch and ShellBarSearchLegacy with isDesktop() so that auto-expansion from resize events is limited to desktop environments. On non-desktop devices, expansion must come from an explicit user tap on the search icon.

Fixes: auto-open of full-screen search on phone/tablet orientation change
SNOW: CS20260013061846
