### PR TITLE
docs(ui5-switch): add read-only state sample

### DIFF
--- a/packages/website/docs/_samples/main/Switch/ReadOnly/ReadOnly.md
+++ b/packages/website/docs/_samples/main/Switch/ReadOnly/ReadOnly.md
@@ -1,0 +1,5 @@
+import html from '!!raw-loader!./sample.html';
+import js from '!!raw-loader!./main.js';
+import react from '!!raw-loader!./sample.tsx';
+
+<Editor html={html} js={js} react={react} />

--- a/packages/website/docs/_samples/main/Switch/ReadOnly/main.js
+++ b/packages/website/docs/_samples/main/Switch/ReadOnly/main.js
@@ -1,0 +1,1 @@
+import "@ui5/webcomponents/dist/Switch.js";

--- a/packages/website/docs/_samples/main/Switch/ReadOnly/sample.html
+++ b/packages/website/docs/_samples/main/Switch/ReadOnly/sample.html
@@ -1,0 +1,20 @@
+<!-- playground-fold -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sample</title>
+</head>
+<body style="background-color: var(--sapBackgroundColor);">
+<!-- playground-fold-end -->
+
+<ui5-switch readonly></ui5-switch>
+<ui5-switch readonly checked></ui5-switch>
+<ui5-switch readonly design="Textual" text-on="On" text-off="Off"></ui5-switch>
+<ui5-switch readonly checked design="Textual" text-on="On" text-off="Off"></ui5-switch>
+<!-- playground-fold -->
+    <script type="module" src="main.js"></script>
+</body>
+</html>
+<!-- playground-fold-end -->

--- a/packages/website/docs/_samples/main/Switch/ReadOnly/sample.tsx
+++ b/packages/website/docs/_samples/main/Switch/ReadOnly/sample.tsx
@@ -1,0 +1,18 @@
+import createReactComponent from "@ui5/webcomponents-base/dist/createReactComponent.js";
+import SwitchClass from "@ui5/webcomponents/dist/Switch.js";
+
+const Switch = createReactComponent(SwitchClass);
+
+function App() {
+  return (
+    <>
+      <Switch readonly={true} />
+      <Switch readonly={true} checked={true} />
+      <Switch readonly={true} design="Textual" textOn="On" textOff="Off" />
+      <Switch readonly={true} checked={true} design="Textual" textOn="On" textOff="Off" />
+
+    </>
+  );
+}
+
+export default App;


### PR DESCRIPTION
There was no sample for `readonly` state of the `ui5-switch` component. This PR adds such sample.

<img width="740" height="246" alt="image" src="https://github.com/user-attachments/assets/76017fe3-7960-4fc4-95a9-27d7b7570313" />

JIRA: BGSOFUIBALKAN-11098