### PR TITLE
fix(ui5-timeline): prevent clipped focus outlines

### DIFF
--- a/packages/fiori/src/themes/TimelineGroupItem.css
+++ b/packages/fiori/src/themes/TimelineGroupItem.css
@@ -24,6 +24,7 @@
 	display: flex;
 	justify-content: space-between;
 	gap: 0.125rem;
+	margin-inline-end: calc(-1 * var(--_ui5_TimelineItem_bubble_border_right));
 }
 
 .ui5-tlgi-icon-placeholder {

--- a/packages/fiori/src/themes/TimelineItem.css
+++ b/packages/fiori/src/themes/TimelineItem.css
@@ -164,6 +164,7 @@
 	flex: 1;
 	position: relative;
 	margin-left: .5rem;
+	margin-inline-end: calc(-1 * var(--_ui5_TimelineItem_bubble_border_right));
 	padding: var(--_ui5_TimelineItem_bubble_content_padding);
 	word-break: break-word;
 }
@@ -171,6 +172,14 @@
 :host([layout="Horizontal"]) .ui5-tli-bubble {
 	margin-top: .5rem;
 	margin-left: 0;
+}
+
+:host([layout="Vertical"][first-item-in-timeline]) .ui5-tli-bubble {
+	margin-block-start: calc(-1 * var(--_ui5_TimelineItem_bubble_border_top));
+}
+
+:host([layout="Vertical"][last-item]) .ui5-tli-bubble {
+	margin-block-end: calc(-1 * var(--_ui5_TimelineItem_bubble_border_bottom));
 }
 
 .ui5-tli-bubble:focus {


### PR DESCRIPTION
Previously, when a `ui5-timeline-item` bubble was focused, the focus outline drawn with `::after` was getting cut.
 
In **vertical layout**, the focus outline was clipped at the top and bottom of the first and last items. 

With this change we reserve margin on the bubble for the focus ring offset using the existing theme parameters, apply the same inline-end offset to the group toggle button row.

## Before

<img width="969" height="408" alt="image" src="https://github.com/user-attachments/assets/3ccb7d9b-deb2-4473-aa71-a3eee95adb7f" />

## After

<img width="970" height="330" alt="image" src="https://github.com/user-attachments/assets/30b6d9e2-72c1-4449-b76e-31f0bf7fbb87" />

Fixes:
An issue, reported internally by colleagues.
