### PR TITLE
fix(ui5-wizard): announce active step with aria-current="step"

### DIFF
--- a/packages/fiori/cypress/specs/Wizard.cy.tsx
+++ b/packages/fiori/cypress/specs/Wizard.cy.tsx
@@ -98,8 +98,14 @@ describe("Wizard general interaction", () => {
         cy.get("@step1InHeaderRoot")
             .should("have.attr", "aria-label", "Step 1 Product type Active");
 
+        cy.get("@step1InHeaderRoot")
+            .should("have.attr", "aria-current", "step");
+
         cy.get("@step2InHeaderRoot")
             .should("have.attr", "aria-label", "Step 2 Product Information Inactive");
+
+        cy.get("@step2InHeaderRoot")
+            .should("not.have.attr", "aria-current");
 
         cy.get("@wizContentItem")
             .should("have.attr", "role", "region");

--- a/packages/fiori/src/WizardTab.ts
+++ b/packages/fiori/src/WizardTab.ts
@@ -184,7 +184,7 @@ class WizardTab extends UI5Element implements ITabbable {
 			"ariaSetsize": this._wizardTabAccInfo && this._wizardTabAccInfo.ariaSetsize,
 			"ariaPosinset": this._wizardTabAccInfo && this._wizardTabAccInfo.ariaPosinset,
 			"ariaLabel": this._wizardTabAccInfo && this._wizardTabAccInfo.ariaLabel,
-			"ariaCurrent": this.selected ? "true" : undefined,
+			"ariaCurrent": this.selected ? "step" : undefined,
 		};
 	}
 }


### PR DESCRIPTION
## Description

The active wizard step rendered `aria-current="true"` instead of the semantically correct `aria-current="step"`. As a result, JAWS announced "current" rather than "current step" for the active step in the wizard navigation header, failing WCAG 4.1.2.

Per WAI-ARIA, `aria-current="step"` is the appropriate token for the current step within a multi-step process such as a wizard.

## Changes

- `packages/fiori/src/WizardTab.ts` — set `ariaCurrent` to `"step"` (instead of `"true"`) for the selected step. `"step"` is already a valid value of the existing `AriaCurrent` type, so no type changes were needed.
- `packages/fiori/cypress/specs/Wizard.cy.tsx` — added assertions to the "ARIA Attributes" test: the active step must expose `aria-current="step"`, and inactive steps must not have `aria-current`.

Fixes #14007