### PR TITLE
fix(ui5-combobox): prevent exception when item text is undefined

### DIFF
--- a/packages/main/cypress/specs/ComboBox.cy.tsx
+++ b/packages/main/cypress/specs/ComboBox.cy.tsx
@@ -74,6 +74,29 @@ describe("General Interaction", () => {
 		cy.get("[ui5-cb-item]").eq(2).should("not.have.prop", "_isVisible", true);
 	});
 
+	it("should not crash when an item has no text", () => {
+		cy.mount(
+			<ComboBox>
+				<ComboBoxItem text="One"></ComboBoxItem>
+				<ComboBoxItem></ComboBoxItem>
+				<ComboBoxItem text="Three"></ComboBoxItem>
+			</ComboBox>
+		);
+
+		cy.get("[ui5-combobox]")
+			.as("combobox")
+			.shadow()
+			.find("[ui5-icon]")
+			.realClick();
+
+		cy.get("[ui5-cb-item]").should("have.length", 3);
+
+		cy.get("@combobox").realPress("O");
+		cy.get("[ui5-cb-item]").eq(0).should("have.prop", "_isVisible", true);
+		cy.get("[ui5-cb-item]").eq(1).should("not.have.prop", "_isVisible", true);
+		cy.get("[ui5-cb-item]").eq(2).should("not.have.prop", "_isVisible", true);
+	});
+
 	it("should open the popover when typing a value", () => {
 		cy.mount(
 			<ComboBox>

--- a/packages/main/src/Filters.ts
+++ b/packages/main/src/Filters.ts
@@ -12,7 +12,7 @@ const StartsWithPerTerm = <T>(value: string, items: Array<T>, propName: string) 
 
 		reg.lastIndex = 0;
 
-		return reg.test(text.toLowerCase());
+		return reg.test((text ?? "").toLowerCase());
 	});
 };
 


### PR DESCRIPTION
## Summary

- `StartsWithPerTerm` in `Filters.ts` called `.toLowerCase()` directly on `text`, crashing when a `ComboBoxItem` has no `text` set (i.e. `undefined`)
- Guard with `?? ""` to match the existing null-safe pattern already used by `StartsWith` and `Contains`
- Added a Cypress regression test: a ComboBox with one item missing `text` filters without throwing

## Test plan

- [ ] Open a ComboBox that has an item with no `text` attribute and type to filter — no crash
- [ ] Existing filtration tests continue to pass

Fixes #13971