### PR TITLE
fix(ui5-shellbar): update Joule assistant button icon in website samples

### DIFF
--- a/packages/website/docs/_samples/fiori/FlexibleColumnLayout/Basic/sample.html
+++ b/packages/website/docs/_samples/fiori/FlexibleColumnLayout/Basic/sample.html
@@ -20,7 +20,7 @@
                     Smart Store, New York
                     <img src="https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg" slot="logo" />
                 </ui5-shellbar-branding>
-				<ui5-toggle-button icon="sap-icon://da" slot="assistant"></ui5-toggle-button>
+				<ui5-toggle-button icon="sap-icon://da" design="Transparent" slot="assistant"></ui5-toggle-button>
                 <ui5-shellbar-item icon="disconnected" text="Disconnect"></ui5-shellbar-item>
                 <ui5-shellbar-item icon="incoming-call" text="Incoming Calls"></ui5-shellbar-item>
             </ui5-shellbar>

--- a/packages/website/docs/_samples/fiori/FlexibleColumnLayout/Basic/sample.tsx
+++ b/packages/website/docs/_samples/fiori/FlexibleColumnLayout/Basic/sample.tsx
@@ -269,6 +269,7 @@ function App() {
             </ShellBarBranding>
             <ToggleButton
               icon={toggleIcon}
+              design="Transparent"
               slot="assistant"
               onClick={handleToggleClick}
             />

--- a/packages/website/docs/_samples/fiori/NavigationLayout/Basic/main.js
+++ b/packages/website/docs/_samples/fiori/NavigationLayout/Basic/main.js
@@ -31,6 +31,11 @@ import "@ui5/webcomponents-icons/dist/menu2.js";
 import "@ui5/webcomponents-icons/dist/sys-help.js";
 import "@ui5/webcomponents-icons/dist/customer.js";
 import "@ui5/webcomponents-icons/dist/da.js";
+import "@ui5/webcomponents-icons/dist/da-2.js";
+
+document.getElementById("joule")?.addEventListener("click", (e) => {
+    e.target.icon = e.target.pressed ? "da-2" : "da";
+});
 
 import NavigationLayoutMode from "@ui5/webcomponents-fiori/dist/types/NavigationLayoutMode.js";
 

--- a/packages/website/docs/_samples/fiori/NavigationLayout/Basic/sample.html
+++ b/packages/website/docs/_samples/fiori/NavigationLayout/Basic/sample.html
@@ -21,7 +21,7 @@
             <ui5-shellbar-search slot="searchField" show-clear-icon placeholder="Search Apps, Products"></ui5-shellbar-search>
 
             <ui5-shellbar-item icon="sys-help" text="Help"></ui5-shellbar-item>
-            <ui5-toggle-button icon="sap-icon://da" tooltip="Joule" slot="assistant"></ui5-toggle-button>
+            <ui5-toggle-button id="joule" icon="sap-icon://da" tooltip="Joule" slot="assistant"></ui5-toggle-button>
             <ui5-avatar slot="profile">
                 <img src="../assets/images/avatars/man_avatar_3.png"/>
             </ui5-avatar>

--- a/packages/website/docs/_samples/fiori/NavigationLayout/Basic/sample.html
+++ b/packages/website/docs/_samples/fiori/NavigationLayout/Basic/sample.html
@@ -21,7 +21,7 @@
             <ui5-shellbar-search slot="searchField" show-clear-icon placeholder="Search Apps, Products"></ui5-shellbar-search>
 
             <ui5-shellbar-item icon="sys-help" text="Help"></ui5-shellbar-item>
-            <ui5-toggle-button id="joule" icon="sap-icon://da" tooltip="Joule" slot="assistant"></ui5-toggle-button>
+            <ui5-toggle-button id="joule" icon="sap-icon://da" design="Transparent" tooltip="Joule" slot="assistant"></ui5-toggle-button>
             <ui5-avatar slot="profile">
                 <img src="../assets/images/avatars/man_avatar_3.png"/>
             </ui5-avatar>

--- a/packages/website/docs/_samples/fiori/NavigationLayout/Basic/sample.tsx
+++ b/packages/website/docs/_samples/fiori/NavigationLayout/Basic/sample.tsx
@@ -73,6 +73,10 @@ function App() {
   const [activePage, setActivePage] = useState("home");
   const [jouleIcon, setJouleIcon] = useState("da");
 
+  const handleToggleClick = (e: UI5CustomEvent<ToggleButtonClass, "click">) => {
+    setJouleIcon(e.currentTarget.pressed ? "da-2" : "da");
+  };
+
   const handleStartButtonClick = () => {
     const nl = navLayoutRef.current;
     nl.mode = nl.isSideCollapsed() ? "Expanded" : "Collapsed";
@@ -132,9 +136,10 @@ function App() {
             <ShellBarItem icon="sys-help" text="Help" />
             <ToggleButton
               icon={jouleIcon}
+              design="Transparent"
               tooltip="Joule"
               slot="assistant"
-              onClick={(e) => setJouleIcon((e.target as EventTarget & { pressed: boolean }).pressed ? "da-2" : "da")}
+              onClick={handleToggleClick}
             />
             <Avatar slot="profile">
               <img src="/images/avatars/man_avatar_3.png" alt="Profile" />

--- a/packages/website/docs/_samples/fiori/NavigationLayout/Basic/sample.tsx
+++ b/packages/website/docs/_samples/fiori/NavigationLayout/Basic/sample.tsx
@@ -32,6 +32,7 @@ import "@ui5/webcomponents-icons/dist/menu2.js";
 import "@ui5/webcomponents-icons/dist/sys-help.js";
 import "@ui5/webcomponents-icons/dist/customer.js";
 import "@ui5/webcomponents-icons/dist/da.js";
+import "@ui5/webcomponents-icons/dist/da-2.js";
 
 const NavigationLayout = createReactComponent(NavigationLayoutClass);
 const ShellBar = createReactComponent(ShellBarClass);
@@ -70,6 +71,7 @@ const contentPages = [
 function App() {
   const navLayoutRef = useRef(null);
   const [activePage, setActivePage] = useState("home");
+  const [jouleIcon, setJouleIcon] = useState("da");
 
   const handleStartButtonClick = () => {
     const nl = navLayoutRef.current;
@@ -128,7 +130,12 @@ function App() {
             />
 
             <ShellBarItem icon="sys-help" text="Help" />
-            <ToggleButton icon="da" tooltip="Joule" slot="assistant" />
+            <ToggleButton
+              icon={jouleIcon}
+              tooltip="Joule"
+              slot="assistant"
+              onClick={(e) => setJouleIcon((e.target as EventTarget & { pressed: boolean }).pressed ? "da-2" : "da")}
+            />
             <Avatar slot="profile">
               <img src="/images/avatars/man_avatar_3.png" alt="Profile" />
             </Avatar>

--- a/packages/website/docs/_samples/fiori/ProductSwitch/WithShellBar/sample.html
+++ b/packages/website/docs/_samples/fiori/ProductSwitch/WithShellBar/sample.html
@@ -16,7 +16,7 @@
             Corporate Portal
             <img src="../assets/images/sap-logo-svg.svg" alt="SAP Logo" slot="logo" />
         </ui5-shellbar-branding>
-		<ui5-toggle-button icon="sap-icon://da" slot="assistant"></ui5-toggle-button>
+		<ui5-toggle-button icon="sap-icon://da" design="Transparent" slot="assistant"></ui5-toggle-button>
     </ui5-shellbar>
     <ui5-popover id="productswitch-popover" placement="Bottom">
         <ui5-product-switch>

--- a/packages/website/docs/_samples/fiori/ProductSwitch/WithShellBar/sample.tsx
+++ b/packages/website/docs/_samples/fiori/ProductSwitch/WithShellBar/sample.tsx
@@ -68,6 +68,7 @@ function App() {
         </ShellBarBranding>
         <ToggleButton
           icon={assistantIcon}
+          design="Transparent"
           slot="assistant"
           onClick={handleToggleButtonClick}
         />

--- a/packages/website/docs/_samples/fiori/ShellBar/Advanced/main.js
+++ b/packages/website/docs/_samples/fiori/ShellBar/Advanced/main.js
@@ -17,3 +17,8 @@ import "@ui5/webcomponents-icons/dist/nav-back.js";
 import "@ui5/webcomponents-icons/dist/sys-help.js";
 import "@ui5/webcomponents-icons/dist/customer.js";
 import "@ui5/webcomponents-icons/dist/da.js";
+import "@ui5/webcomponents-icons/dist/da-2.js";
+
+document.getElementById("joule")?.addEventListener("click", (e) => {
+    e.target.icon = e.target.pressed ? "da-2" : "da";
+});

--- a/packages/website/docs/_samples/fiori/ShellBar/Advanced/sample.html
+++ b/packages/website/docs/_samples/fiori/ShellBar/Advanced/sample.html
@@ -30,7 +30,7 @@
             <ui5-shellbar-search slot="searchField" show-clear-icon placeholder="Search Apps, Products"></ui5-shellbar-search>
 
             <ui5-shellbar-item icon="sys-help" text="Help"></ui5-shellbar-item>
-            <ui5-toggle-button id="joule" icon="sap-icon://da" tooltip="Joule" slot="assistant"></ui5-toggle-button>
+            <ui5-toggle-button id="joule" icon="sap-icon://da" design="Transparent" tooltip="Joule" slot="assistant"></ui5-toggle-button>
             <ui5-avatar slot="profile">
                 <img src="../assets/images/avatars/man_avatar_3.png"/>
             </ui5-avatar>

--- a/packages/website/docs/_samples/fiori/ShellBar/Advanced/sample.html
+++ b/packages/website/docs/_samples/fiori/ShellBar/Advanced/sample.html
@@ -30,7 +30,7 @@
             <ui5-shellbar-search slot="searchField" show-clear-icon placeholder="Search Apps, Products"></ui5-shellbar-search>
 
             <ui5-shellbar-item icon="sys-help" text="Help"></ui5-shellbar-item>
-            <ui5-toggle-button icon="sap-icon://da" tooltip="Joule" slot="assistant"></ui5-toggle-button>
+            <ui5-toggle-button id="joule" icon="sap-icon://da" tooltip="Joule" slot="assistant"></ui5-toggle-button>
             <ui5-avatar slot="profile">
                 <img src="../assets/images/avatars/man_avatar_3.png"/>
             </ui5-avatar>

--- a/packages/website/docs/_samples/fiori/ShellBar/Advanced/sample.tsx
+++ b/packages/website/docs/_samples/fiori/ShellBar/Advanced/sample.tsx
@@ -1,3 +1,4 @@
+import { type UI5CustomEvent } from "@ui5/webcomponents-base";
 import { useState } from "react";
 import createReactComponent from "@ui5/webcomponents-base/dist/createReactComponent.js";
 import ShellBarClass from "@ui5/webcomponents-fiori/dist/ShellBar.js";
@@ -35,6 +36,10 @@ const ToggleButton = createReactComponent(ToggleButtonClass);
 function App() {
   const [jouleIcon, setJouleIcon] = useState("da");
 
+  const handleToggleClick = (e: UI5CustomEvent<ToggleButtonClass, "click">) => {
+    setJouleIcon(e.currentTarget.pressed ? "da-2" : "da");
+  };
+
   return (
     <>
       <ShellBar
@@ -71,9 +76,10 @@ function App() {
         <ShellBarItem icon="sys-help" text="Help" />
         <ToggleButton
           icon={jouleIcon}
+          design="Transparent"
           tooltip="Joule"
           slot="assistant"
-          onClick={(e) => setJouleIcon((e.target as EventTarget & { pressed: boolean }).pressed ? "da-2" : "da")}
+          onClick={handleToggleClick}
         />
         <Avatar slot="profile">
           <img src="/images/avatars/man_avatar_3.png" alt="Profile" />

--- a/packages/website/docs/_samples/fiori/ShellBar/Advanced/sample.tsx
+++ b/packages/website/docs/_samples/fiori/ShellBar/Advanced/sample.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import createReactComponent from "@ui5/webcomponents-base/dist/createReactComponent.js";
 import ShellBarClass from "@ui5/webcomponents-fiori/dist/ShellBar.js";
 import ShellBarBrandingClass from "@ui5/webcomponents-fiori/dist/ShellBarBranding.js";
@@ -16,6 +17,7 @@ import "@ui5/webcomponents-icons/dist/nav-back.js";
 import "@ui5/webcomponents-icons/dist/sys-help.js";
 import "@ui5/webcomponents-icons/dist/customer.js";
 import "@ui5/webcomponents-icons/dist/da.js";
+import "@ui5/webcomponents-icons/dist/da-2.js";
 
 const ShellBar = createReactComponent(ShellBarClass);
 const ShellBarBranding = createReactComponent(ShellBarBrandingClass);
@@ -31,6 +33,8 @@ const Text = createReactComponent(TextClass);
 const ToggleButton = createReactComponent(ToggleButtonClass);
 
 function App() {
+  const [jouleIcon, setJouleIcon] = useState("da");
+
   return (
     <>
       <ShellBar
@@ -65,7 +69,12 @@ function App() {
         />
 
         <ShellBarItem icon="sys-help" text="Help" />
-        <ToggleButton icon="da" tooltip="Joule" slot="assistant" />
+        <ToggleButton
+          icon={jouleIcon}
+          tooltip="Joule"
+          slot="assistant"
+          onClick={(e) => setJouleIcon((e.target as EventTarget & { pressed: boolean }).pressed ? "da-2" : "da")}
+        />
         <Avatar slot="profile">
           <img src="/images/avatars/man_avatar_3.png" alt="Profile" />
         </Avatar>

--- a/packages/website/docs/_samples/fiori/ShellBar/Basic/main.js
+++ b/packages/website/docs/_samples/fiori/ShellBar/Basic/main.js
@@ -11,3 +11,8 @@ import "@ui5/webcomponents-icons/dist/menu2.js";
 import "@ui5/webcomponents-icons/dist/sys-help.js";
 import "@ui5/webcomponents-icons/dist/customer.js";
 import "@ui5/webcomponents-icons/dist/da.js";
+import "@ui5/webcomponents-icons/dist/da-2.js";
+
+document.getElementById("joule")?.addEventListener("click", (e) => {
+    e.target.icon = e.target.pressed ? "da-2" : "da";
+});

--- a/packages/website/docs/_samples/fiori/ShellBar/Basic/sample.html
+++ b/packages/website/docs/_samples/fiori/ShellBar/Basic/sample.html
@@ -20,7 +20,7 @@
             <ui5-shellbar-search slot="searchField" show-clear-icon placeholder="Search Apps, Products"></ui5-shellbar-search>
 
             <ui5-shellbar-item icon="sys-help" text="Help"></ui5-shellbar-item>
-            <ui5-toggle-button id="joule" icon="sap-icon://da" tooltip="Joule" slot="assistant"></ui5-toggle-button>
+            <ui5-toggle-button id="joule" icon="sap-icon://da" design="Transparent" tooltip="Joule" slot="assistant"></ui5-toggle-button>
             <ui5-avatar slot="profile">
                 <img src="../assets/images/avatars/man_avatar_3.png"/>
             </ui5-avatar>

--- a/packages/website/docs/_samples/fiori/ShellBar/Basic/sample.html
+++ b/packages/website/docs/_samples/fiori/ShellBar/Basic/sample.html
@@ -20,7 +20,7 @@
             <ui5-shellbar-search slot="searchField" show-clear-icon placeholder="Search Apps, Products"></ui5-shellbar-search>
 
             <ui5-shellbar-item icon="sys-help" text="Help"></ui5-shellbar-item>
-            <ui5-toggle-button icon="sap-icon://da" tooltip="Joule" slot="assistant"></ui5-toggle-button>
+            <ui5-toggle-button id="joule" icon="sap-icon://da" tooltip="Joule" slot="assistant"></ui5-toggle-button>
             <ui5-avatar slot="profile">
                 <img src="../assets/images/avatars/man_avatar_3.png"/>
             </ui5-avatar>

--- a/packages/website/docs/_samples/fiori/ShellBar/Basic/sample.tsx
+++ b/packages/website/docs/_samples/fiori/ShellBar/Basic/sample.tsx
@@ -1,3 +1,4 @@
+import { type UI5CustomEvent } from "@ui5/webcomponents-base";
 import { useState } from "react";
 import createReactComponent from "@ui5/webcomponents-base/dist/createReactComponent.js";
 import ShellBarClass from "@ui5/webcomponents-fiori/dist/ShellBar.js";
@@ -24,6 +25,10 @@ const ToggleButton = createReactComponent(ToggleButtonClass);
 function App() {
   const [jouleIcon, setJouleIcon] = useState("da");
 
+  const handleToggleClick = (e: UI5CustomEvent<ToggleButtonClass, "click">) => {
+    setJouleIcon(e.currentTarget.pressed ? "da-2" : "da");
+  };
+
   return (
     <>
       <ShellBar notificationsCount="72" showNotifications={true}>
@@ -41,9 +46,10 @@ function App() {
         <ShellBarItem icon="sys-help" text="Help" />
         <ToggleButton
           icon={jouleIcon}
+          design="Transparent"
           tooltip="Joule"
           slot="assistant"
-          onClick={(e) => setJouleIcon((e.target as EventTarget & { pressed: boolean }).pressed ? "da-2" : "da")}
+          onClick={handleToggleClick}
         />
         <Avatar slot="profile">
           <img src="/images/avatars/man_avatar_3.png" alt="Profile" />

--- a/packages/website/docs/_samples/fiori/ShellBar/Basic/sample.tsx
+++ b/packages/website/docs/_samples/fiori/ShellBar/Basic/sample.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import createReactComponent from "@ui5/webcomponents-base/dist/createReactComponent.js";
 import ShellBarClass from "@ui5/webcomponents-fiori/dist/ShellBar.js";
 import ShellBarBrandingClass from "@ui5/webcomponents-fiori/dist/ShellBarBranding.js";
@@ -10,6 +11,7 @@ import "@ui5/webcomponents-icons/dist/menu2.js";
 import "@ui5/webcomponents-icons/dist/sys-help.js";
 import "@ui5/webcomponents-icons/dist/customer.js";
 import "@ui5/webcomponents-icons/dist/da.js";
+import "@ui5/webcomponents-icons/dist/da-2.js";
 
 const ShellBar = createReactComponent(ShellBarClass);
 const ShellBarBranding = createReactComponent(ShellBarBrandingClass);
@@ -20,6 +22,8 @@ const Button = createReactComponent(ButtonClass);
 const ToggleButton = createReactComponent(ToggleButtonClass);
 
 function App() {
+  const [jouleIcon, setJouleIcon] = useState("da");
+
   return (
     <>
       <ShellBar notificationsCount="72" showNotifications={true}>
@@ -35,7 +39,12 @@ function App() {
         />
 
         <ShellBarItem icon="sys-help" text="Help" />
-        <ToggleButton icon="da" tooltip="Joule" slot="assistant" />
+        <ToggleButton
+          icon={jouleIcon}
+          tooltip="Joule"
+          slot="assistant"
+          onClick={(e) => setJouleIcon((e.target as EventTarget & { pressed: boolean }).pressed ? "da-2" : "da")}
+        />
         <Avatar slot="profile">
           <img src="/images/avatars/man_avatar_3.png" alt="Profile" />
         </Avatar>

--- a/packages/website/docs/_samples/fiori/ShellBar/EmbeddedBackNavigation/main.js
+++ b/packages/website/docs/_samples/fiori/ShellBar/EmbeddedBackNavigation/main.js
@@ -13,3 +13,8 @@ import "@ui5/webcomponents-icons/dist/sys-help.js";
 import "@ui5/webcomponents-icons/dist/bell.js";
 import "@ui5/webcomponents-icons/dist/customer.js";
 import "@ui5/webcomponents-icons/dist/da.js";
+import "@ui5/webcomponents-icons/dist/da-2.js";
+
+document.getElementById("joule")?.addEventListener("click", (e) => {
+    e.target.icon = e.target.pressed ? "da-2" : "da";
+});

--- a/packages/website/docs/_samples/fiori/ShellBar/EmbeddedBackNavigation/sample.html
+++ b/packages/website/docs/_samples/fiori/ShellBar/EmbeddedBackNavigation/sample.html
@@ -21,7 +21,7 @@
             <ui5-shellbar-search slot="searchField" show-clear-icon placeholder="Search Apps, Products"></ui5-shellbar-search>
 
             <ui5-shellbar-item icon="sys-help" text="Help"></ui5-shellbar-item>
-            <ui5-toggle-button icon="sap-icon://da" tooltip="Joule" slot="assistant"></ui5-toggle-button>
+            <ui5-toggle-button id="joule" icon="sap-icon://da" tooltip="Joule" slot="assistant"></ui5-toggle-button>
             <ui5-avatar slot="profile">
                 <img src="../assets/images/avatars/man_avatar_3.png"/>
             </ui5-avatar>

--- a/packages/website/docs/_samples/fiori/ShellBar/EmbeddedBackNavigation/sample.html
+++ b/packages/website/docs/_samples/fiori/ShellBar/EmbeddedBackNavigation/sample.html
@@ -21,7 +21,7 @@
             <ui5-shellbar-search slot="searchField" show-clear-icon placeholder="Search Apps, Products"></ui5-shellbar-search>
 
             <ui5-shellbar-item icon="sys-help" text="Help"></ui5-shellbar-item>
-            <ui5-toggle-button id="joule" icon="sap-icon://da" tooltip="Joule" slot="assistant"></ui5-toggle-button>
+            <ui5-toggle-button id="joule" icon="sap-icon://da" design="Transparent" tooltip="Joule" slot="assistant"></ui5-toggle-button>
             <ui5-avatar slot="profile">
                 <img src="../assets/images/avatars/man_avatar_3.png"/>
             </ui5-avatar>

--- a/packages/website/docs/_samples/fiori/ShellBar/EmbeddedBackNavigation/sample.tsx
+++ b/packages/website/docs/_samples/fiori/ShellBar/EmbeddedBackNavigation/sample.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import createReactComponent from "@ui5/webcomponents-base/dist/createReactComponent.js";
 import ShellBarClass from "@ui5/webcomponents-fiori/dist/ShellBar.js";
 import ShellBarBrandingClass from "@ui5/webcomponents-fiori/dist/ShellBarBranding.js";
@@ -12,6 +13,7 @@ import "@ui5/webcomponents-icons/dist/sys-help.js";
 import "@ui5/webcomponents-icons/dist/bell.js";
 import "@ui5/webcomponents-icons/dist/customer.js";
 import "@ui5/webcomponents-icons/dist/da.js";
+import "@ui5/webcomponents-icons/dist/da-2.js";
 
 const ShellBar = createReactComponent(ShellBarClass);
 const ShellBarBranding = createReactComponent(ShellBarBrandingClass);
@@ -22,6 +24,8 @@ const Button = createReactComponent(ButtonClass);
 const ToggleButton = createReactComponent(ToggleButtonClass);
 
 function App() {
+  const [jouleIcon, setJouleIcon] = useState("da");
+
   return (
     <>
       <ShellBar notificationsCount="72" showNotifications={true}>
@@ -38,7 +42,12 @@ function App() {
         />
 
         <ShellBarItem icon="sys-help" text="Help" />
-        <ToggleButton icon="da" tooltip="Joule" slot="assistant" />
+        <ToggleButton
+          icon={jouleIcon}
+          tooltip="Joule"
+          slot="assistant"
+          onClick={(e) => setJouleIcon((e.target as EventTarget & { pressed: boolean }).pressed ? "da-2" : "da")}
+        />
         <Avatar slot="profile">
           <img src="/images/avatars/man_avatar_3.png" alt="Profile" />
         </Avatar>

--- a/packages/website/docs/_samples/fiori/ShellBar/EmbeddedBackNavigation/sample.tsx
+++ b/packages/website/docs/_samples/fiori/ShellBar/EmbeddedBackNavigation/sample.tsx
@@ -1,3 +1,4 @@
+import { type UI5CustomEvent } from "@ui5/webcomponents-base";
 import { useState } from "react";
 import createReactComponent from "@ui5/webcomponents-base/dist/createReactComponent.js";
 import ShellBarClass from "@ui5/webcomponents-fiori/dist/ShellBar.js";
@@ -26,6 +27,10 @@ const ToggleButton = createReactComponent(ToggleButtonClass);
 function App() {
   const [jouleIcon, setJouleIcon] = useState("da");
 
+  const handleToggleClick = (e: UI5CustomEvent<ToggleButtonClass, "click">) => {
+    setJouleIcon(e.currentTarget.pressed ? "da-2" : "da");
+  };
+
   return (
     <>
       <ShellBar notificationsCount="72" showNotifications={true}>
@@ -44,9 +49,10 @@ function App() {
         <ShellBarItem icon="sys-help" text="Help" />
         <ToggleButton
           icon={jouleIcon}
+          design="Transparent"
           tooltip="Joule"
           slot="assistant"
-          onClick={(e) => setJouleIcon((e.target as EventTarget & { pressed: boolean }).pressed ? "da-2" : "da")}
+          onClick={handleToggleClick}
         />
         <Avatar slot="profile">
           <img src="/images/avatars/man_avatar_3.png" alt="Profile" />

--- a/packages/website/docs/_samples/fiori/ShellBar/MultipleNonProductiveInstances/main.js
+++ b/packages/website/docs/_samples/fiori/ShellBar/MultipleNonProductiveInstances/main.js
@@ -13,3 +13,10 @@ import "@ui5/webcomponents-icons/dist/menu2.js";
 import "@ui5/webcomponents-icons/dist/sys-help.js";
 import "@ui5/webcomponents-icons/dist/customer.js";
 import "@ui5/webcomponents-icons/dist/da.js";
+import "@ui5/webcomponents-icons/dist/da-2.js";
+
+["joule-emea", "joule-apj"].forEach(id => {
+    document.getElementById(id)?.addEventListener("click", (e) => {
+        e.target.icon = e.target.pressed ? "da-2" : "da";
+    });
+});

--- a/packages/website/docs/_samples/fiori/ShellBar/MultipleNonProductiveInstances/sample.html
+++ b/packages/website/docs/_samples/fiori/ShellBar/MultipleNonProductiveInstances/sample.html
@@ -25,7 +25,7 @@
             <ui5-shellbar-search slot="searchField" show-clear-icon placeholder="Search Apps, Products"></ui5-shellbar-search>
 
             <ui5-shellbar-item icon="sys-help" text="Help"></ui5-shellbar-item>
-            <ui5-toggle-button id="joule-emea" icon="sap-icon://da" tooltip="Joule" slot="assistant"></ui5-toggle-button>
+            <ui5-toggle-button id="joule-emea" icon="sap-icon://da" design="Transparent" tooltip="Joule" slot="assistant"></ui5-toggle-button>
             <ui5-avatar slot="profile">
                 <img src="../assets/images/avatars/man_avatar_3.png"/>
             </ui5-avatar>
@@ -44,7 +44,7 @@
             <ui5-shellbar-search slot="searchField" show-clear-icon placeholder="Search Apps, Products"></ui5-shellbar-search>
 
             <ui5-shellbar-item icon="sys-help" text="Help"></ui5-shellbar-item>
-            <ui5-toggle-button id="joule-apj" icon="sap-icon://da" tooltip="Joule" slot="assistant"></ui5-toggle-button>
+            <ui5-toggle-button id="joule-apj" icon="sap-icon://da" design="Transparent" tooltip="Joule" slot="assistant"></ui5-toggle-button>
             <ui5-avatar slot="profile">
                 <img src="../assets/images/avatars/man_avatar_3.png"/>
             </ui5-avatar>

--- a/packages/website/docs/_samples/fiori/ShellBar/MultipleNonProductiveInstances/sample.html
+++ b/packages/website/docs/_samples/fiori/ShellBar/MultipleNonProductiveInstances/sample.html
@@ -25,7 +25,7 @@
             <ui5-shellbar-search slot="searchField" show-clear-icon placeholder="Search Apps, Products"></ui5-shellbar-search>
 
             <ui5-shellbar-item icon="sys-help" text="Help"></ui5-shellbar-item>
-            <ui5-toggle-button icon="sap-icon://da" tooltip="Joule" slot="assistant"></ui5-toggle-button>
+            <ui5-toggle-button id="joule-emea" icon="sap-icon://da" tooltip="Joule" slot="assistant"></ui5-toggle-button>
             <ui5-avatar slot="profile">
                 <img src="../assets/images/avatars/man_avatar_3.png"/>
             </ui5-avatar>
@@ -44,7 +44,7 @@
             <ui5-shellbar-search slot="searchField" show-clear-icon placeholder="Search Apps, Products"></ui5-shellbar-search>
 
             <ui5-shellbar-item icon="sys-help" text="Help"></ui5-shellbar-item>
-            <ui5-toggle-button icon="sap-icon://da" tooltip="Joule" slot="assistant"></ui5-toggle-button>
+            <ui5-toggle-button id="joule-apj" icon="sap-icon://da" tooltip="Joule" slot="assistant"></ui5-toggle-button>
             <ui5-avatar slot="profile">
                 <img src="../assets/images/avatars/man_avatar_3.png"/>
             </ui5-avatar>

--- a/packages/website/docs/_samples/fiori/ShellBar/MultipleNonProductiveInstances/sample.tsx
+++ b/packages/website/docs/_samples/fiori/ShellBar/MultipleNonProductiveInstances/sample.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import createReactComponent from "@ui5/webcomponents-base/dist/createReactComponent.js";
 import ShellBarClass from "@ui5/webcomponents-fiori/dist/ShellBar.js";
 import ShellBarBrandingClass from "@ui5/webcomponents-fiori/dist/ShellBarBranding.js";
@@ -12,6 +13,7 @@ import "@ui5/webcomponents-icons/dist/menu2.js";
 import "@ui5/webcomponents-icons/dist/sys-help.js";
 import "@ui5/webcomponents-icons/dist/customer.js";
 import "@ui5/webcomponents-icons/dist/da.js";
+import "@ui5/webcomponents-icons/dist/da-2.js";
 
 const ShellBar = createReactComponent(ShellBarClass);
 const ShellBarBranding = createReactComponent(ShellBarBrandingClass);
@@ -24,6 +26,9 @@ const Text = createReactComponent(TextClass);
 const ToggleButton = createReactComponent(ToggleButtonClass);
 
 function App() {
+  const [jouleIconEmea, setJouleIconEmea] = useState("da");
+  const [jouleIconApj, setJouleIconApj] = useState("da");
+
   return (
     <>
       <ShellBar
@@ -50,7 +55,12 @@ function App() {
         />
 
         <ShellBarItem icon="sys-help" text="Help" />
-        <ToggleButton icon="da" tooltip="Joule" slot="assistant" />
+        <ToggleButton
+          icon={jouleIconEmea}
+          tooltip="Joule"
+          slot="assistant"
+          onClick={(e) => setJouleIconEmea((e.target as EventTarget & { pressed: boolean }).pressed ? "da-2" : "da")}
+        />
         <Avatar slot="profile">
           <img src="/images/avatars/man_avatar_3.png" alt="Profile" />
         </Avatar>
@@ -78,7 +88,12 @@ function App() {
         />
 
         <ShellBarItem icon="sys-help" text="Help" />
-        <ToggleButton icon="da" tooltip="Joule" slot="assistant" />
+        <ToggleButton
+          icon={jouleIconApj}
+          tooltip="Joule"
+          slot="assistant"
+          onClick={(e) => setJouleIconApj((e.target as EventTarget & { pressed: boolean }).pressed ? "da-2" : "da")}
+        />
         <Avatar slot="profile">
           <img src="/images/avatars/man_avatar_3.png" alt="Profile" />
         </Avatar>

--- a/packages/website/docs/_samples/fiori/ShellBar/MultipleNonProductiveInstances/sample.tsx
+++ b/packages/website/docs/_samples/fiori/ShellBar/MultipleNonProductiveInstances/sample.tsx
@@ -1,3 +1,4 @@
+import { type UI5CustomEvent } from "@ui5/webcomponents-base";
 import { useState } from "react";
 import createReactComponent from "@ui5/webcomponents-base/dist/createReactComponent.js";
 import ShellBarClass from "@ui5/webcomponents-fiori/dist/ShellBar.js";
@@ -29,6 +30,17 @@ function App() {
   const [jouleIconEmea, setJouleIconEmea] = useState("da");
   const [jouleIconApj, setJouleIconApj] = useState("da");
 
+  const handleEmeaToggleClick = (
+    e: UI5CustomEvent<ToggleButtonClass, "click">,
+  ) => {
+    setJouleIconEmea(e.currentTarget.pressed ? "da-2" : "da");
+  };
+  const handleApjToggleClick = (
+    e: UI5CustomEvent<ToggleButtonClass, "click">,
+  ) => {
+    setJouleIconApj(e.currentTarget.pressed ? "da-2" : "da");
+  };
+
   return (
     <>
       <ShellBar
@@ -57,9 +69,10 @@ function App() {
         <ShellBarItem icon="sys-help" text="Help" />
         <ToggleButton
           icon={jouleIconEmea}
+          design="Transparent"
           tooltip="Joule"
           slot="assistant"
-          onClick={(e) => setJouleIconEmea((e.target as EventTarget & { pressed: boolean }).pressed ? "da-2" : "da")}
+          onClick={handleEmeaToggleClick}
         />
         <Avatar slot="profile">
           <img src="/images/avatars/man_avatar_3.png" alt="Profile" />
@@ -90,9 +103,10 @@ function App() {
         <ShellBarItem icon="sys-help" text="Help" />
         <ToggleButton
           icon={jouleIconApj}
+          design="Transparent"
           tooltip="Joule"
           slot="assistant"
-          onClick={(e) => setJouleIconApj((e.target as EventTarget & { pressed: boolean }).pressed ? "da-2" : "da")}
+          onClick={handleApjToggleClick}
         />
         <Avatar slot="profile">
           <img src="/images/avatars/man_avatar_3.png" alt="Profile" />

--- a/packages/website/docs/_samples/fiori/ShellBar/MultipleProductiveInstances/main.js
+++ b/packages/website/docs/_samples/fiori/ShellBar/MultipleProductiveInstances/main.js
@@ -12,3 +12,10 @@ import "@ui5/webcomponents-icons/dist/menu2.js";
 import "@ui5/webcomponents-icons/dist/sys-help.js";
 import "@ui5/webcomponents-icons/dist/customer.js";
 import "@ui5/webcomponents-icons/dist/da.js";
+import "@ui5/webcomponents-icons/dist/da-2.js";
+
+["joule-emea", "joule-apj"].forEach(id => {
+    document.getElementById(id)?.addEventListener("click", (e) => {
+        e.target.icon = e.target.pressed ? "da-2" : "da";
+    });
+});

--- a/packages/website/docs/_samples/fiori/ShellBar/MultipleProductiveInstances/sample.html
+++ b/packages/website/docs/_samples/fiori/ShellBar/MultipleProductiveInstances/sample.html
@@ -24,7 +24,7 @@
 
 
             <ui5-shellbar-item icon="sys-help" text="Help"></ui5-shellbar-item>
-            <ui5-toggle-button id="joule-emea" icon="sap-icon://da" tooltip="Joule" slot="assistant"></ui5-toggle-button>
+            <ui5-toggle-button id="joule-emea" icon="sap-icon://da" design="Transparent" tooltip="Joule" slot="assistant"></ui5-toggle-button>
             <ui5-avatar slot="profile">
                 <img src="../assets/images/avatars/man_avatar_3.png"/>
             </ui5-avatar>
@@ -42,7 +42,7 @@
             <ui5-shellbar-search slot="searchField" show-clear-icon placeholder="Search Apps, Products"></ui5-shellbar-search>
 
             <ui5-shellbar-item icon="sys-help" text="Help"></ui5-shellbar-item>
-            <ui5-toggle-button id="joule-apj" icon="sap-icon://da" tooltip="Joule" slot="assistant"></ui5-toggle-button>
+            <ui5-toggle-button id="joule-apj" icon="sap-icon://da" design="Transparent" tooltip="Joule" slot="assistant"></ui5-toggle-button>
             <ui5-avatar slot="profile">
                 <img src="../assets/images/avatars/man_avatar_3.png"/>
             </ui5-avatar>

--- a/packages/website/docs/_samples/fiori/ShellBar/MultipleProductiveInstances/sample.html
+++ b/packages/website/docs/_samples/fiori/ShellBar/MultipleProductiveInstances/sample.html
@@ -24,7 +24,7 @@
 
 
             <ui5-shellbar-item icon="sys-help" text="Help"></ui5-shellbar-item>
-            <ui5-toggle-button icon="sap-icon://da" tooltip="Joule" slot="assistant"></ui5-toggle-button>
+            <ui5-toggle-button id="joule-emea" icon="sap-icon://da" tooltip="Joule" slot="assistant"></ui5-toggle-button>
             <ui5-avatar slot="profile">
                 <img src="../assets/images/avatars/man_avatar_3.png"/>
             </ui5-avatar>
@@ -42,7 +42,7 @@
             <ui5-shellbar-search slot="searchField" show-clear-icon placeholder="Search Apps, Products"></ui5-shellbar-search>
 
             <ui5-shellbar-item icon="sys-help" text="Help"></ui5-shellbar-item>
-            <ui5-toggle-button icon="sap-icon://da" tooltip="Joule" slot="assistant"></ui5-toggle-button>
+            <ui5-toggle-button id="joule-apj" icon="sap-icon://da" tooltip="Joule" slot="assistant"></ui5-toggle-button>
             <ui5-avatar slot="profile">
                 <img src="../assets/images/avatars/man_avatar_3.png"/>
             </ui5-avatar>

--- a/packages/website/docs/_samples/fiori/ShellBar/MultipleProductiveInstances/sample.tsx
+++ b/packages/website/docs/_samples/fiori/ShellBar/MultipleProductiveInstances/sample.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import createReactComponent from "@ui5/webcomponents-base/dist/createReactComponent.js";
 import ShellBarClass from "@ui5/webcomponents-fiori/dist/ShellBar.js";
 import ShellBarBrandingClass from "@ui5/webcomponents-fiori/dist/ShellBarBranding.js";
@@ -11,6 +12,7 @@ import "@ui5/webcomponents-icons/dist/menu2.js";
 import "@ui5/webcomponents-icons/dist/sys-help.js";
 import "@ui5/webcomponents-icons/dist/customer.js";
 import "@ui5/webcomponents-icons/dist/da.js";
+import "@ui5/webcomponents-icons/dist/da-2.js";
 
 const ShellBar = createReactComponent(ShellBarClass);
 const ShellBarBranding = createReactComponent(ShellBarBrandingClass);
@@ -22,6 +24,9 @@ const Tag = createReactComponent(TagClass);
 const ToggleButton = createReactComponent(ToggleButtonClass);
 
 function App() {
+  const [jouleIconEmea, setJouleIconEmea] = useState("da");
+  const [jouleIconApj, setJouleIconApj] = useState("da");
+
   return (
     <>
       <ShellBar style={{ marginBottom: "1rem" }} notificationsCount="72" showNotifications={true}>
@@ -42,7 +47,12 @@ function App() {
         />
 
         <ShellBarItem icon="sys-help" text="Help" />
-        <ToggleButton icon="da" tooltip="Joule" slot="assistant" />
+        <ToggleButton
+          icon={jouleIconEmea}
+          tooltip="Joule"
+          slot="assistant"
+          onClick={(e) => setJouleIconEmea((e.target as EventTarget & { pressed: boolean }).pressed ? "da-2" : "da")}
+        />
         <Avatar slot="profile">
           <img src="/images/avatars/man_avatar_3.png" alt="Profile" />
         </Avatar>
@@ -66,7 +76,12 @@ function App() {
         />
 
         <ShellBarItem icon="sys-help" text="Help" />
-        <ToggleButton icon="da" tooltip="Joule" slot="assistant" />
+        <ToggleButton
+          icon={jouleIconApj}
+          tooltip="Joule"
+          slot="assistant"
+          onClick={(e) => setJouleIconApj((e.target as EventTarget & { pressed: boolean }).pressed ? "da-2" : "da")}
+        />
         <Avatar slot="profile">
           <img src="/images/avatars/man_avatar_3.png" alt="Profile" />
         </Avatar>

--- a/packages/website/docs/_samples/fiori/ShellBar/MultipleProductiveInstances/sample.tsx
+++ b/packages/website/docs/_samples/fiori/ShellBar/MultipleProductiveInstances/sample.tsx
@@ -1,3 +1,4 @@
+import { type UI5CustomEvent } from "@ui5/webcomponents-base";
 import { useState } from "react";
 import createReactComponent from "@ui5/webcomponents-base/dist/createReactComponent.js";
 import ShellBarClass from "@ui5/webcomponents-fiori/dist/ShellBar.js";
@@ -27,6 +28,17 @@ function App() {
   const [jouleIconEmea, setJouleIconEmea] = useState("da");
   const [jouleIconApj, setJouleIconApj] = useState("da");
 
+  const handleEmeaToggleClick = (
+    e: UI5CustomEvent<ToggleButtonClass, "click">,
+  ) => {
+    setJouleIconEmea(e.currentTarget.pressed ? "da-2" : "da");
+  };
+  const handleApjToggleClick = (
+    e: UI5CustomEvent<ToggleButtonClass, "click">,
+  ) => {
+    setJouleIconApj(e.currentTarget.pressed ? "da-2" : "da");
+  };
+
   return (
     <>
       <ShellBar style={{ marginBottom: "1rem" }} notificationsCount="72" showNotifications={true}>
@@ -49,9 +61,10 @@ function App() {
         <ShellBarItem icon="sys-help" text="Help" />
         <ToggleButton
           icon={jouleIconEmea}
+          design="Transparent"
           tooltip="Joule"
           slot="assistant"
-          onClick={(e) => setJouleIconEmea((e.target as EventTarget & { pressed: boolean }).pressed ? "da-2" : "da")}
+          onClick={handleEmeaToggleClick}
         />
         <Avatar slot="profile">
           <img src="/images/avatars/man_avatar_3.png" alt="Profile" />
@@ -78,9 +91,10 @@ function App() {
         <ShellBarItem icon="sys-help" text="Help" />
         <ToggleButton
           icon={jouleIconApj}
+          design="Transparent"
           tooltip="Joule"
           slot="assistant"
-          onClick={(e) => setJouleIconApj((e.target as EventTarget & { pressed: boolean }).pressed ? "da-2" : "da")}
+          onClick={handleApjToggleClick}
         />
         <Avatar slot="profile">
           <img src="/images/avatars/man_avatar_3.png" alt="Profile" />

--- a/packages/website/docs/_samples/fiori/ShellBar/TrialExample/main.js
+++ b/packages/website/docs/_samples/fiori/ShellBar/TrialExample/main.js
@@ -12,3 +12,8 @@ import "@ui5/webcomponents-icons/dist/menu2.js";
 import "@ui5/webcomponents-icons/dist/sys-help.js";
 import "@ui5/webcomponents-icons/dist/customer.js";
 import "@ui5/webcomponents-icons/dist/da.js";
+import "@ui5/webcomponents-icons/dist/da-2.js";
+
+document.getElementById("joule")?.addEventListener("click", (e) => {
+    e.target.icon = e.target.pressed ? "da-2" : "da";
+});

--- a/packages/website/docs/_samples/fiori/ShellBar/TrialExample/sample.html
+++ b/packages/website/docs/_samples/fiori/ShellBar/TrialExample/sample.html
@@ -23,7 +23,7 @@
             <ui5-shellbar-search slot="searchField" show-clear-icon placeholder="Search Apps, Products"></ui5-shellbar-search>
 
             <ui5-shellbar-item icon="sys-help" text="Help"></ui5-shellbar-item>
-            <ui5-toggle-button icon="sap-icon://da" tooltip="Joule" slot="assistant"></ui5-toggle-button>
+            <ui5-toggle-button id="joule" icon="sap-icon://da" tooltip="Joule" slot="assistant"></ui5-toggle-button>
             <ui5-avatar slot="profile">
                 <img src="../assets/images/avatars/man_avatar_3.png"/>
             </ui5-avatar>

--- a/packages/website/docs/_samples/fiori/ShellBar/TrialExample/sample.html
+++ b/packages/website/docs/_samples/fiori/ShellBar/TrialExample/sample.html
@@ -23,7 +23,7 @@
             <ui5-shellbar-search slot="searchField" show-clear-icon placeholder="Search Apps, Products"></ui5-shellbar-search>
 
             <ui5-shellbar-item icon="sys-help" text="Help"></ui5-shellbar-item>
-            <ui5-toggle-button id="joule" icon="sap-icon://da" tooltip="Joule" slot="assistant"></ui5-toggle-button>
+            <ui5-toggle-button id="joule" icon="sap-icon://da" design="Transparent" tooltip="Joule" slot="assistant"></ui5-toggle-button>
             <ui5-avatar slot="profile">
                 <img src="../assets/images/avatars/man_avatar_3.png"/>
             </ui5-avatar>

--- a/packages/website/docs/_samples/fiori/ShellBar/TrialExample/sample.tsx
+++ b/packages/website/docs/_samples/fiori/ShellBar/TrialExample/sample.tsx
@@ -1,3 +1,4 @@
+import { type UI5CustomEvent } from "@ui5/webcomponents-base";
 import { useState } from "react";
 import createReactComponent from "@ui5/webcomponents-base/dist/createReactComponent.js";
 import ShellBarClass from "@ui5/webcomponents-fiori/dist/ShellBar.js";
@@ -28,6 +29,10 @@ const ToggleButton = createReactComponent(ToggleButtonClass);
 function App() {
   const [jouleIcon, setJouleIcon] = useState("da");
 
+  const handleToggleClick = (e: UI5CustomEvent<ToggleButtonClass, "click">) => {
+    setJouleIcon(e.currentTarget.pressed ? "da-2" : "da");
+  };
+
   return (
     <>
       <ShellBar notificationsCount="72" showNotifications={true}>
@@ -50,9 +55,10 @@ function App() {
         <ShellBarItem icon="sys-help" text="Help" />
         <ToggleButton
           icon={jouleIcon}
+          design="Transparent"
           tooltip="Joule"
           slot="assistant"
-          onClick={(e) => setJouleIcon((e.target as EventTarget & { pressed: boolean }).pressed ? "da-2" : "da")}
+          onClick={handleToggleClick}
         />
         <Avatar slot="profile">
           <img src="/images/avatars/man_avatar_3.png" alt="Profile" />

--- a/packages/website/docs/_samples/fiori/ShellBar/TrialExample/sample.tsx
+++ b/packages/website/docs/_samples/fiori/ShellBar/TrialExample/sample.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import createReactComponent from "@ui5/webcomponents-base/dist/createReactComponent.js";
 import ShellBarClass from "@ui5/webcomponents-fiori/dist/ShellBar.js";
 import ShellBarBrandingClass from "@ui5/webcomponents-fiori/dist/ShellBarBranding.js";
@@ -12,6 +13,7 @@ import "@ui5/webcomponents-icons/dist/menu2.js";
 import "@ui5/webcomponents-icons/dist/sys-help.js";
 import "@ui5/webcomponents-icons/dist/customer.js";
 import "@ui5/webcomponents-icons/dist/da.js";
+import "@ui5/webcomponents-icons/dist/da-2.js";
 
 const ShellBar = createReactComponent(ShellBarClass);
 const ShellBarBranding = createReactComponent(ShellBarBrandingClass);
@@ -24,6 +26,8 @@ const Text = createReactComponent(TextClass);
 const ToggleButton = createReactComponent(ToggleButtonClass);
 
 function App() {
+  const [jouleIcon, setJouleIcon] = useState("da");
+
   return (
     <>
       <ShellBar notificationsCount="72" showNotifications={true}>
@@ -44,7 +48,12 @@ function App() {
         />
 
         <ShellBarItem icon="sys-help" text="Help" />
-        <ToggleButton icon="da" tooltip="Joule" slot="assistant" />
+        <ToggleButton
+          icon={jouleIcon}
+          tooltip="Joule"
+          slot="assistant"
+          onClick={(e) => setJouleIcon((e.target as EventTarget & { pressed: boolean }).pressed ? "da-2" : "da")}
+        />
         <Avatar slot="profile">
           <img src="/images/avatars/man_avatar_3.png" alt="Profile" />
         </Avatar>

--- a/packages/website/docs/_samples/fiori/SideNavigation/OverlayMode/main.js
+++ b/packages/website/docs/_samples/fiori/SideNavigation/OverlayMode/main.js
@@ -29,6 +29,11 @@ import "@ui5/webcomponents-icons/dist/write-new.js";
 import "@ui5/webcomponents-icons/dist/widgets.js";
 import "@ui5/webcomponents-icons/dist/compare.js";
 import "@ui5/webcomponents-icons/dist/da.js";
+import "@ui5/webcomponents-icons/dist/da-2.js";
+
+document.getElementById("joule")?.addEventListener("click", (e) => {
+    e.target.icon = e.target.pressed ? "da-2" : "da";
+});
 import "@ui5/webcomponents-icons/dist/sys-help.js";
 
 menuBtn.addEventListener("click", function () {

--- a/packages/website/docs/_samples/fiori/SideNavigation/OverlayMode/sample.html
+++ b/packages/website/docs/_samples/fiori/SideNavigation/OverlayMode/sample.html
@@ -21,7 +21,7 @@
             <ui5-shellbar-search slot="searchField" show-clear-icon placeholder="Search Apps, Products"></ui5-shellbar-search>
 
             <ui5-shellbar-item icon="sys-help" text="Help"></ui5-shellbar-item>
-            <ui5-toggle-button icon="sap-icon://da" tooltip="Joule" slot="assistant"></ui5-toggle-button>
+            <ui5-toggle-button id="joule" icon="sap-icon://da" tooltip="Joule" slot="assistant"></ui5-toggle-button>
             <ui5-avatar slot="profile">
                 <img src="../assets/images/avatars/man_avatar_3.png"/>
             </ui5-avatar>

--- a/packages/website/docs/_samples/fiori/SideNavigation/OverlayMode/sample.html
+++ b/packages/website/docs/_samples/fiori/SideNavigation/OverlayMode/sample.html
@@ -21,7 +21,7 @@
             <ui5-shellbar-search slot="searchField" show-clear-icon placeholder="Search Apps, Products"></ui5-shellbar-search>
 
             <ui5-shellbar-item icon="sys-help" text="Help"></ui5-shellbar-item>
-            <ui5-toggle-button id="joule" icon="sap-icon://da" tooltip="Joule" slot="assistant"></ui5-toggle-button>
+            <ui5-toggle-button id="joule" icon="sap-icon://da" design="Transparent" tooltip="Joule" slot="assistant"></ui5-toggle-button>
             <ui5-avatar slot="profile">
                 <img src="../assets/images/avatars/man_avatar_3.png"/>
             </ui5-avatar>

--- a/packages/website/docs/_samples/fiori/SideNavigation/OverlayMode/sample.tsx
+++ b/packages/website/docs/_samples/fiori/SideNavigation/OverlayMode/sample.tsx
@@ -30,6 +30,7 @@ import "@ui5/webcomponents-icons/dist/write-new.js";
 import "@ui5/webcomponents-icons/dist/widgets.js";
 import "@ui5/webcomponents-icons/dist/compare.js";
 import "@ui5/webcomponents-icons/dist/da.js";
+import "@ui5/webcomponents-icons/dist/da-2.js";
 import "@ui5/webcomponents-icons/dist/sys-help.js";
 
 const Page = createReactComponent(PageClass);
@@ -53,6 +54,7 @@ const ToggleButton = createReactComponent(ToggleButtonClass);
 function App() {
   const [navOpen, setNavOpen] = useState(false);
   const [dialogOpen, setDialogOpen] = useState(false);
+  const [jouleIcon, setJouleIcon] = useState("da");
 
   const handleSideNavigationSelectionChange = (
     e: UI5CustomEvent<SideNavigationClass, "selection-change">,
@@ -113,7 +115,12 @@ function App() {
           />
 
           <ShellBarItem icon="sys-help" text="Help" />
-          <ToggleButton icon="da" tooltip="Joule" slot="assistant" />
+          <ToggleButton
+            icon={jouleIcon}
+            tooltip="Joule"
+            slot="assistant"
+            onClick={(e) => setJouleIcon((e.target as EventTarget & { pressed: boolean }).pressed ? "da-2" : "da")}
+          />
           <Avatar slot="profile">
             <img src="/images/avatars/man_avatar_3.png" alt="Profile" />
           </Avatar>

--- a/packages/website/docs/_samples/fiori/SideNavigation/OverlayMode/sample.tsx
+++ b/packages/website/docs/_samples/fiori/SideNavigation/OverlayMode/sample.tsx
@@ -56,6 +56,10 @@ function App() {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [jouleIcon, setJouleIcon] = useState("da");
 
+  const handleToggleClick = (e: UI5CustomEvent<ToggleButtonClass, "click">) => {
+    setJouleIcon(e.currentTarget.pressed ? "da-2" : "da");
+  };
+
   const handleSideNavigationSelectionChange = (
     e: UI5CustomEvent<SideNavigationClass, "selection-change">,
   ) => {
@@ -117,9 +121,10 @@ function App() {
           <ShellBarItem icon="sys-help" text="Help" />
           <ToggleButton
             icon={jouleIcon}
+            design="Transparent"
             tooltip="Joule"
             slot="assistant"
-            onClick={(e) => setJouleIcon((e.target as EventTarget & { pressed: boolean }).pressed ? "da-2" : "da")}
+            onClick={handleToggleClick}
           />
           <Avatar slot="profile">
             <img src="/images/avatars/man_avatar_3.png" alt="Profile" />

--- a/packages/website/docs/_samples/patterns/UXCIntegration/Basic/sample.html
+++ b/packages/website/docs/_samples/patterns/UXCIntegration/Basic/sample.html
@@ -38,7 +38,7 @@
 
             <ui5-shellbar-spacer slot="content"></ui5-shellbar-spacer>
 
-            <ui5-toggle-button icon="sap-icon://da" slot="assistant"></ui5-toggle-button>
+            <ui5-toggle-button icon="sap-icon://da" design="Transparent" slot="assistant"></ui5-toggle-button>
 
 			<ui5-shellbar-search slot="searchField" id="search-scope" scope-value="all" show-clear-icon placeholder="Search Apps, Products">
 				<ui5-search-scope text="All" value="all" slot="scopes"></ui5-search-scope>

--- a/packages/website/docs/_samples/patterns/UXCIntegration/Basic/sample.tsx
+++ b/packages/website/docs/_samples/patterns/UXCIntegration/Basic/sample.tsx
@@ -529,6 +529,7 @@ function App() {
 
           <ToggleButton
             icon={daIcon}
+            design="Transparent"
             slot="assistant"
             onClick={handleToggleButtonClick}
           />


### PR DESCRIPTION
The Joule toggle button in the assistant slot was missing the correct icon swap behavior. When toggled on, the button should display the filled Joule icon (da-2); when toggled off, it should show the outlined icon (da).

Updated all affected website samples (HTML + React variants):
- Import da-2 icon alongside da
- Add click handler that swaps icon between da and da-2 on toggle
- Add unique IDs to toggle buttons in multi-instance samples

Fixes #14021 
