### PR TITLE
fix(ui5-input): update previousValue on programmatic value change while focused

### DIFF
--- a/packages/main/cypress/specs/Input.cy.tsx
+++ b/packages/main/cypress/specs/Input.cy.tsx
@@ -520,6 +520,23 @@ describe("Input general interaction", () => {
 		cy.get("@onSelectionChange").should("have.been.calledOnce");
 	});
 
+	it("Should fire 'change' event when value is set programmatically while focused and user types the same value", () => {
+		cy.mount(<Input id="prog-change-input" value="f" onChange={cy.stub().as("onChange")} />);
+
+		cy.get("[ui5-input]").realClick();
+		cy.get("[ui5-input]").should("be.focused");
+
+		// simulate programmatic value reset while focused
+		cy.document().then(doc => {
+			(doc.querySelector<Input>("#prog-change-input") as Input).value = "";
+		});
+
+		cy.realType("f");
+		cy.realPress("Tab");
+
+		cy.get("@onChange").should("have.been.calledOnce");
+	});
+
 	it("Should control suggestions dynamically based on threshold", () => {
 		const THRESHOLD = 3;
 		const countries = [

--- a/packages/main/src/Input.ts
+++ b/packages/main/src/Input.ts
@@ -753,6 +753,10 @@ class Input extends UI5Element implements SuggestionComponent, IFormInputElement
 	}
 
 	onBeforeRendering() {
+		if (this.focused && !this.isTyping && this.value !== this.previousValue) {
+			this.previousValue = this.value;
+		}
+
 		if (this.showSuggestions) {
 			this.enableSuggestions();
 

--- a/packages/main/src/Input.ts
+++ b/packages/main/src/Input.ts
@@ -644,6 +644,7 @@ class Input extends UI5Element implements SuggestionComponent, IFormInputElement
 	_selectedText?: string;
 	_clearIconClicked?: boolean;
 	_focusedAfterClear: boolean;
+	_preventPreviousValueUpdate = false; // set before internal value mutations so onBeforeRendering skips the external-change sync
 	_changeToBeFired?: boolean; // used to wait change event firing after suggestion item selection
 	_matchedSuggestionItem?: IInputSuggestionItemSelectable; // stores the original matched suggestion for preserving case
 	_performTextSelection?: boolean;
@@ -753,9 +754,10 @@ class Input extends UI5Element implements SuggestionComponent, IFormInputElement
 	}
 
 	onBeforeRendering() {
-		if (this.focused && !this.isTyping && this.value !== this.previousValue) {
+		if (this.focused && !this.isTyping && !this._preventPreviousValueUpdate && this.value !== this.previousValue) {
 			this.previousValue = this.value;
 		}
+		this._preventPreviousValueUpdate = false;
 
 		if (this.showSuggestions) {
 			this.enableSuggestions();
@@ -1101,6 +1103,7 @@ class Input extends UI5Element implements SuggestionComponent, IFormInputElement
 		const hasSuggestions = this.showSuggestions && !!this.Suggestions;
 		const isOpen = hasSuggestions && this.open;
 		const innerInput = this.getInputDOMRefSync()!;
+		this._preventPreviousValueUpdate = true;
 		const isAutoCompleted = innerInput.selectionEnd! - innerInput.selectionStart! > 0;
 
 		this.isTyping = false;
@@ -1231,6 +1234,7 @@ class Input extends UI5Element implements SuggestionComponent, IFormInputElement
 
 	_clear() {
 		const valueBeforeClear = this.value;
+		this._preventPreviousValueUpdate = true;
 		this.value = "";
 		const prevented = !this.fireDecoratorEvent(INPUT_EVENTS.INPUT, { inputType: "" });
 


### PR DESCRIPTION
## Summary

- When `value` is changed programmatically while the input is focused, `previousValue` was not updated
- This caused the `change` event to be silently dropped when the user later typed the same value as the original `previousValue`
- Fix: in `onBeforeRendering`, sync `previousValue` to `this.value` when focused and not typing — mirroring native `<input>` behavior where setting `.value` via script resets the change-detection baseline

## Root cause

`previousValue` is set once in `_onfocusin` and never updated when `this.value` is mutated externally while focused. Native `<input>` updates its internal "last committed value" reference whenever `value` is set via script (per the HTML spec), so programmatic resets are properly accounted for in change detection.

## Test

Added a Cypress regression test: focus input with value `"f"` → programmatically reset to `""` → type `"f"` → blur → `change` must fire.

Fixes #14034