### PR TITLE
refactor(ui5-table): resolve rows/headerRow slots through chained slot projеction (nested slotting)

### DIFF
--- a/packages/main/src/Table.ts
+++ b/packages/main/src/Table.ts
@@ -454,12 +454,32 @@ class Table extends UI5Element {
 		this._events.forEach(eventType => this.removeEventListener(eventType, this._onEventBound));
 	}
 
+	/**
+	 * The effective rows of the table. Resolves any projected `<slot>` element in the
+	 * `rows` slot to its flattened assigned rows (chained slotting), and returns real
+	 * rows unchanged otherwise. Internal logic and features must read rows through this.
+	 * @private
+	 */
+	get _rows(): TableRow[] {
+		return this.getSlottedNodes<TableRow>("rows");
+	}
+
+	/**
+	 * Returns the header row(s), flattening any chained `<slot>` projection so that
+	 * consumers always receive the real `ui5-table-header-row` even when the table is
+	 * nested inside another component (e.g. `ui5-input-table-suggest`).
+	 * @private
+	 */
+	get _headerRow(): TableHeaderRow[] {
+		return this.getSlottedNodes<TableHeaderRow>("headerRow");
+	}
+
 	onBeforeRendering(): void {
 		let alternateIndex = 0;
 		const hasFlexibleColumns = this._hasFlexibleColumns;
-		const rowActionCount = this.rowActionCount > 0 && this.rows.length > 0 ? this.rowActionCount : 0;
-		this._renderNavigated = this.rows.some(row => row.navigated);
-		[...this.headerRow, ...this.rows].forEach(row => {
+		const rowActionCount = this.rowActionCount > 0 && this._rows.length > 0 ? this.rowActionCount : 0;
+		this._renderNavigated = this._rows.some(row => row.navigated);
+		[...this._headerRow, ...this._rows].forEach(row => {
 			if (!row.isGroupRow()) {
 				row._rowActionCount = rowActionCount;
 				row._renderDummyCell = !hasFlexibleColumns;
@@ -566,14 +586,14 @@ class Table extends UI5Element {
 	}
 
 	_scrollElementIntoView(element: HTMLElement) {
-		const verticalStickyElements = this.headerRow.filter(row => row.sticky);
+		const verticalStickyElements = this._headerRow.filter(row => row.sticky);
 		if (verticalStickyElements.length) {
 			const verticalScrollContainer = findVerticalScrollContainer(this._tableElement, true);
 			const deltaY = computeAxisScrollDelta(element, verticalScrollContainer, verticalStickyElements, "y");
 			verticalScrollContainer.scrollBy({ top: deltaY });
 		}
 
-		const horizontalStickyElements = this.overflowMode === "Scroll" ? this.headerRow[0]._stickyCells : [];
+		const horizontalStickyElements = this.overflowMode === "Scroll" ? this._headerRow[0]._stickyCells : [];
 		if (horizontalStickyElements.length) {
 			const horizontalScrollContainer = this._tableElement;
 			const deltaX = computeAxisScrollDelta(element, horizontalScrollContainer, horizontalStickyElements, "x");
@@ -586,7 +606,7 @@ class Table extends UI5Element {
 	}
 
 	_getPopinOrderedColumns(reverse: boolean) {
-		let headers = [...this.headerRow[0].cells];
+		let headers = [...this._headerRow[0].cells];
 		headers = headers.reverse(); // reverse the "visual" order
 		headers = headers.sort((a, b) => a.importance - b.importance); // sort by importance (asc)
 		headers.pop(); // remove the most important column, as it will not be popped in
@@ -605,16 +625,16 @@ class Table extends UI5Element {
 	 * @private
 	 */
 	_refreshPopinState() {
-		this.headerRow[0]?.cells.forEach(header => {
+		this._headerRow[0]?.cells.forEach(header => {
 			this._setHeaderPopinState(header, header._popin, header._popinWidth);
 		});
 	}
 
 	_setHeaderPopinState(headerCell: TableHeaderCell, inPopin: boolean, popinWidth: number) {
-		const headerIndex = this.headerRow[0].cells.indexOf(headerCell);
+		const headerIndex = this._headerRow[0].cells.indexOf(headerCell);
 		headerCell._popin = inPopin && this.overflowMode === TableOverflowMode.Popin;
 		headerCell._popinWidth = popinWidth;
-		this.rows.forEach(row => {
+		this._rows.forEach(row => {
 			const cell = row.cells[headerIndex];
 			if (cell) {
 				cell._popinHidden = headerCell.popinHidden;
@@ -639,7 +659,7 @@ class Table extends UI5Element {
 	get styles() {
 		const virtualizer = this._getVirtualizer();
 		const headerStyleMap: Record<string, string> = {};
-		this.headerRow[0]?.cells.forEach(headerCell => {
+		this._headerRow[0]?.cells.forEach(headerCell => {
 			headerStyleMap[`--halign-${headerCell._id}`] = headerCell.horizontalAlign || "initial";
 		});
 		return {
@@ -656,12 +676,12 @@ class Table extends UI5Element {
 	}
 
 	get _gridTemplateColumns() {
-		if (!this.headerRow[0]) {
+		if (!this._headerRow[0]) {
 			return;
 		}
 
 		const widths = [];
-		const visibleHeaderCells = this.headerRow[0]._visibleCells;
+		const visibleHeaderCells = this._headerRow[0]._visibleCells;
 
 		// Selection Cell Width
 		if (this._isRowSelectorRequired) {
@@ -687,7 +707,7 @@ class Table extends UI5Element {
 		}
 
 		// Row Action Cell Width
-		if (this.rowActionCount > 0 && this.rows.length > 0) {
+		if (this.rowActionCount > 0 && this._rows.length > 0) {
 			widths.push(`calc(var(--_ui5_button_base_min_width) * ${this.rowActionCount} + var(--_ui5_table_row_actions_gap) * ${this.rowActionCount - 1} + var(--_ui5_table_cell_horizontal_padding) * 2)`);
 		}
 
@@ -704,15 +724,15 @@ class Table extends UI5Element {
 	}
 
 	get _hasPopin() {
-		return this.overflowMode === TableOverflowMode.Popin && this.headerRow?.[0]?._hasPopin;
+		return this.overflowMode === TableOverflowMode.Popin && this._headerRow?.[0]?._hasPopin;
 	}
 
 	get _hasFlexibleColumns(): boolean {
-		return this.headerRow?.[0]?._visibleCells.some(cell => !isValidColumnWidth(cell.width));
+		return this._headerRow?.[0]?._visibleCells.some(cell => !isValidColumnWidth(cell.width));
 	}
 
 	get _isRowSelectorRequired() {
-		return this.rows.length > 0 && this._getSelection()?.isRowSelectorRequired();
+		return this._rows.length > 0 && this._getSelection()?.isRowSelectorRequired();
 	}
 
 	get _scrollContainer() {
@@ -732,22 +752,22 @@ class Table extends UI5Element {
 	}
 
 	get _ariaRowCount() {
-		return this._getVirtualizer()?.rowCount || this.rows.length + 1;
+		return this._getVirtualizer()?.rowCount || this._rows.length + 1;
 	}
 
 	get _ariaColCount() {
-		if (!this.headerRow[0]) {
+		if (!this._headerRow[0]) {
 			return 0;
 		}
 
-		let ariaColCount = this.headerRow[0]._visibleCells.length;
+		let ariaColCount = this._headerRow[0]._visibleCells.length;
 		if (this._isRowSelectorRequired) {
 			ariaColCount++;
 		}
-		if (this.rowActionCount > 0 && this.rows.length > 0) {
+		if (this.rowActionCount > 0 && this._rows.length > 0) {
 			ariaColCount++;
 		}
-		if (this.headerRow[0]._popinCells.length > 0) {
+		if (this._headerRow[0]._popinCells.length > 0) {
 			ariaColCount++;
 		}
 
@@ -756,7 +776,7 @@ class Table extends UI5Element {
 
 	get _ariaMultiSelectable() {
 		const selection = this._getSelection();
-		return (selection?.isSelectable() && this.rows.length) ? selection.isMultiSelectable() : undefined;
+		return (selection?.isSelectable() && this._rows.length) ? selection.isMultiSelectable() : undefined;
 	}
 
 	get isTable() {

--- a/packages/main/src/TableCell.ts
+++ b/packages/main/src/TableCell.ts
@@ -5,7 +5,6 @@ import TableCellTemplate from "./TableCellTemplate.js";
 import TableCellStyles from "./generated/themes/TableCell.css.js";
 import TableCellBase from "./TableCellBase.js";
 import type TableRow from "./TableRow.js";
-import type Table from "./Table.js";
 import { LABEL_COLON } from "./generated/i18n/i18n-defaults.js";
 
 /**
@@ -70,10 +69,10 @@ class TableCell extends TableCellBase {
 
 	get _headerCell() {
 		const row = this.parentElement as TableRow | null;
-		const table = row?.parentElement as Table | null;
+		const table = row?._table;
 		const index = row?.cells?.indexOf(this) ?? -1;
 
-		return (index !== -1) ? table?.headerRow?.[0]?.cells?.[index] : null;
+		return (index !== -1) ? table?._headerRow?.[0]?.cells?.[index] : null;
 	}
 
 	get _popinHeaderNodes() {

--- a/packages/main/src/TableCustomAnnouncement.ts
+++ b/packages/main/src/TableCustomAnnouncement.ts
@@ -142,7 +142,7 @@ class TableCustomAnnouncement extends TableExtension {
 	}
 
 	private _findGroupRow(row: TableRow): TableGroupRow | undefined {
-		const rows = this._table.rows;
+		const rows = this._table._rows;
 		const rowIndex = rows.indexOf(row);
 		for (let i = rowIndex; i >= 0; i--) {
 			if (rows[i].isGroupRow()) {

--- a/packages/main/src/TableDragAndDrop.ts
+++ b/packages/main/src/TableDragAndDrop.ts
@@ -40,7 +40,7 @@ export default class TableDragAndDrop extends TableExtension {
 		}
 
 		const closestPosition = findClosestPosition(
-			this._table.rows,
+			this._table._rows,
 			e.clientY,
 			Orientation.Vertical,
 		);

--- a/packages/main/src/TableGroupRow.ts
+++ b/packages/main/src/TableGroupRow.ts
@@ -112,7 +112,7 @@ class TableGroupRow extends TableRow {
 	}
 
 	get _ariaColSpan(): number {
-		const colSpan = this._table?.headerRow[0]?._visibleCells.length ?? 1;
+		const colSpan = this._table?._headerRow[0]?._visibleCells.length ?? 1;
 		return (this._renderDummyCell) ? colSpan - 1 : colSpan;
 	}
 }

--- a/packages/main/src/TableGrowing.ts
+++ b/packages/main/src/TableGrowing.ts
@@ -150,7 +150,7 @@ class TableGrowing extends UI5Element implements ITableGrowing {
 				focusRow ||= this.getFocusDomRef() as HTMLElement;
 			}
 
-			focusRow ||= this._table?.rows[0] as HTMLElement;
+			focusRow ||= this._table?._rows[0] as HTMLElement;
 
 			focusRow?.focus();
 		}
@@ -194,7 +194,7 @@ class TableGrowing extends UI5Element implements ITableGrowing {
 	loadMore(): void {
 		// remembers the last row. only do this when the table has a growing component rendered.
 		if (this._table && this.hasGrowingComponent()) {
-			this._currentLastRow = this._table.rows[this._table.rows.length - 1];
+			this._currentLastRow = this._table._rows[this._table._rows.length - 1];
 			this._shouldFocusRow = true;
 		}
 

--- a/packages/main/src/TableNavigation.ts
+++ b/packages/main/src/TableNavigation.ts
@@ -45,15 +45,15 @@ class TableNavigation extends TableExtension {
 
 	_getNavigationItemsOfGrid() {
 		const items = [];
-		if (this._table.headerRow[0] && !isElementHidden(this._table.headerRow[0])) {
-			items.push(this._getNavigationItemsOfRow(this._table.headerRow[0]));
+		if (this._table._headerRow[0] && !isElementHidden(this._table._headerRow[0])) {
+			items.push(this._getNavigationItemsOfRow(this._table._headerRow[0]));
 			this._gridWalker.setFirstRowPos(1);
 		} else {
 			this._gridWalker.setFirstRowPos(0);
 		}
 
-		if (this._table.rows.length) {
-			this._table.rows.forEach(row => items.push(this._getNavigationItemsOfRow(row)));
+		if (this._table._rows.length) {
+			this._table._rows.forEach(row => items.push(this._getNavigationItemsOfRow(row)));
 		} else if (this._table._noDataRow) {
 			items.push(this._getNavigationItemsOfRow(this._table._noDataRow));
 		}
@@ -161,7 +161,7 @@ class TableNavigation extends TableExtension {
 			return false;
 		}
 
-		const lastRow = this._table.rows.at(-1);
+		const lastRow = this._table._rows.at(-1);
 		const growingButton = this._table._getGrowing()?.getFocusDomRef();
 		const shouldFocusGrowingButton = direction === 1 && eventOrigin === lastRow;
 		const shouldFocusLastRow = direction === -1 && eventOrigin === growingButton;

--- a/packages/main/src/TableRow.ts
+++ b/packages/main/src/TableRow.ts
@@ -193,7 +193,7 @@ class TableRow extends TableRowBase<TableCell> {
 			return this.position;
 		}
 		if (this._table) {
-			return this._table.rows.indexOf(this);
+			return this._table._rows.indexOf(this);
 		}
 		return -1;
 	}

--- a/packages/main/src/TableRowBase.ts
+++ b/packages/main/src/TableRowBase.ts
@@ -28,6 +28,10 @@ import {
 abstract class TableRowBase<TCell extends TableCellBase = TableCellBase> extends UI5Element {
 	cells!: Array<TCell>;
 
+	// Cached owning table. Only a successful resolution is stored; cleared on
+	// connect/disconnect so a re-slotted or moved row re-resolves its table.
+	_tableRef?: Table;
+
 	@property({ type: Number, noAttribute: true })
 	_invalidate = 0;
 
@@ -64,8 +68,13 @@ abstract class TableRowBase<TCell extends TableCellBase = TableCellBase> extends
 	}
 
 	onEnterDOM() {
+		this._tableRef = undefined;
 		!this.role && this.setAttribute("role", "row");
 		this.toggleAttribute("ui5-table-row-base", true);
+	}
+
+	onExitDOM() {
+		this._tableRef = undefined;
 	}
 
 	onBeforeRendering() {
@@ -120,8 +129,31 @@ abstract class TableRowBase<TCell extends TableCellBase = TableCellBase> extends
 	}
 
 	get _table(): Table | undefined {
+		if (this._tableRef) {
+			return this._tableRef;
+		}
+
 		const element = this.parentElement;
-		return isInstanceOfTable(element) ? element : undefined;
+		if (isInstanceOfTable(element)) {
+			this._tableRef = element;
+			return element;
+		}
+
+		// When the row is projected through chained slots (e.g. ui5-input-table-suggest),
+		// its parentElement is the outer component, not the table. Follow the slot
+		// assignment chain across shadow boundaries to reach the owning table.
+		let assignedSlot = this.assignedSlot;
+		while (assignedSlot) {
+			const root = assignedSlot.getRootNode();
+			const host = root instanceof ShadowRoot ? root.host : undefined;
+			if (isInstanceOfTable(host)) {
+				this._tableRef = host;
+				return host;
+			}
+			assignedSlot = assignedSlot.assignedSlot;
+		}
+
+		return undefined;
 	}
 
 	get _tableId() {
@@ -161,7 +193,7 @@ abstract class TableRowBase<TCell extends TableCellBase = TableCellBase> extends
 	}
 
 	get _hasPopin() {
-		return (this._table?.rows.length ?? 0) > 0 && this.cells.some(c => c._popin && !c._popinHidden);
+		return (this._table?._rows.length ?? 0) > 0 && this.cells.some(c => c._popin && !c._popinHidden);
 	}
 
 	get _stickyCells() {

--- a/packages/main/src/TableSelection.ts
+++ b/packages/main/src/TableSelection.ts
@@ -111,9 +111,9 @@ class TableSelection extends UI5Element implements ITableFeature {
 	}
 
 	onTableBeforeRendering() {
-		if (this.isMultiSelectable() && this._table && this._table.headerRow[0] && this._rowsLength !== this._table.rows.length) {
-			this._rowsLength = this._table.rows.length;
-			this._table.headerRow[0]._invalidate++;
+		if (this.isMultiSelectable() && this._table && this._table._headerRow[0] && this._rowsLength !== this._table._rows.length) {
+			this._rowsLength = this._table._rows.length;
+			this._table._headerRow[0]._invalidate++;
 		}
 
 		this._table?.removeEventListener("click", this.onClickCaptureBound);
@@ -166,19 +166,19 @@ class TableSelection extends UI5Element implements ITableFeature {
 		}
 
 		const selectedArray = this.selectedAsArray;
-		return this._table.rows.some(row => {
+		return this._table._rows.some(row => {
 			const rowKey = this.getRowKey(row);
 			return selectedArray.includes(rowKey);
 		});
 	}
 
 	areAllRowsSelected(): boolean {
-		if (!this._table || !this._table.rows.length || this.mode !== TableSelectionMode.Multiple) {
+		if (!this._table || !this._table._rows.length || this.mode !== TableSelectionMode.Multiple) {
 			return false;
 		}
 
 		const selectedArray = this.selectedAsArray;
-		return this._table.rows.filter(row => row._isSelectable).every(row => {
+		return this._table._rows.filter(row => row._isSelectable).every(row => {
 			const rowKey = this.getRowKey(row);
 			return selectedArray.includes(rowKey);
 		});
@@ -229,7 +229,7 @@ class TableSelection extends UI5Element implements ITableFeature {
 
 	_selectHeaderRow(selected: boolean) {
 		const selectedSet = this.selectedAsSet;
-		this._table!.rows.filter(row => row._isSelectable).forEach(row => {
+		this._table!._rows.filter(row => row._isSelectable).forEach(row => {
 			const rowKey = this.getRowKey(row);
 			selectedSet[selected ? "add" : "delete"](rowKey);
 		});
@@ -248,8 +248,8 @@ class TableSelection extends UI5Element implements ITableFeature {
 		}
 
 		this._table._invalidate++;
-		this._table.headerRow[0]._invalidate++;
-		this._table.rows.forEach(row => row._invalidate++);
+		this._table._headerRow[0]._invalidate++;
+		this._table._rows.forEach(row => row._invalidate++);
 	}
 
 	_onkeydown(e: KeyboardEvent) {
@@ -312,8 +312,8 @@ class TableSelection extends UI5Element implements ITableFeature {
 
 		if (e.shiftKey && this._rangeSelection?.isMouse) {
 			const startRow = this._rangeSelection.rows[0];
-			const startIndex = this._table.rows.indexOf(startRow);
-			const endIndex = this._table.rows.indexOf(row);
+			const startIndex = this._table._rows.indexOf(startRow);
+			const endIndex = this._table._rows.indexOf(row);
 
 			const selectionState = this.isSelected(startRow);
 
@@ -369,10 +369,10 @@ class TableSelection extends UI5Element implements ITableFeature {
 		if (shouldReverseSelection) {
 			this._reverseRangeSelection();
 		} else {
-			const rowIndex = this._table!.rows.indexOf(targetRow);
+			const rowIndex = this._table!._rows.indexOf(targetRow);
 			const [startIndex, endIndex] = [rowIndex, rowIndex - change].sort((a, b) => a - b);
 
-			selectionChanged = this._table?.rows.slice(startIndex, endIndex + 1).reduce((changed, row) => {
+			selectionChanged = this._table?._rows.slice(startIndex, endIndex + 1).reduce((changed, row) => {
 				const isRowNotInSelection = !this._rangeSelection?.rows.includes(row);
 				const isRowSelectionDifferent = this.isSelected(row) !== this._rangeSelection!.selected;
 

--- a/packages/main/src/TableSelectionBase.ts
+++ b/packages/main/src/TableSelectionBase.ts
@@ -81,9 +81,9 @@ abstract class TableSelectionBase extends UI5Element implements ITableFeature {
 	}
 
 	onTableBeforeRendering() {
-		if (this._table && this._table.headerRow[0] && this._rowsLength !== this._table.rows.length) {
-			this._rowsLength = this._table.rows.length;
-			this._table.headerRow[0]._invalidate++;
+		if (this._table && this._table._headerRow[0] && this._rowsLength !== this._table._rows.length) {
+			this._rowsLength = this._table._rows.length;
+			this._table._headerRow[0]._invalidate++;
 		}
 	}
 
@@ -110,7 +110,7 @@ abstract class TableSelectionBase extends UI5Element implements ITableFeature {
 	 * Returns the ARIA description of the Table as an alternative to aria-multiselectable.
 	 */
 	getAriaDescriptionForTable(): string | undefined {
-		if (!this._table || !this._table.rows.length) {
+		if (!this._table || !this._table._rows.length) {
 			return undefined;
 		}
 
@@ -142,7 +142,7 @@ abstract class TableSelectionBase extends UI5Element implements ITableFeature {
 	 */
 	getRowByKey(rowKey: string): TableRow | undefined {
 		if (this._table && rowKey) {
-			return this._table.rows.find(row => this.getRowKey(row) === rowKey);
+			return this._table._rows.find(row => this.getRowKey(row) === rowKey);
 		}
 	}
 
@@ -168,8 +168,8 @@ abstract class TableSelectionBase extends UI5Element implements ITableFeature {
 	protected _invalidateTableAndRows() {
 		if (this._table) {
 			this._table._invalidate++;
-			this._table.rows.forEach(row => row._invalidate++);
-			this._table.headerRow.forEach(row => row._invalidate++);
+			this._table._rows.forEach(row => row._invalidate++);
+			this._table._headerRow.forEach(row => row._invalidate++);
 		}
 	}
 }

--- a/packages/main/src/TableSelectionMulti.ts
+++ b/packages/main/src/TableSelectionMulti.ts
@@ -108,7 +108,7 @@ class TableSelectionMulti extends TableSelectionBase {
 			return;
 		}
 
-		const tableRows = row.isHeaderRow() ? this._table!.rows : [row as TableRow];
+		const tableRows = row.isHeaderRow() ? this._table!._rows : [row as TableRow];
 		const selectedSet = this.getSelectedAsSet();
 		const selectionChanged = tableRows.reduce((selectedSetChanged, tableRow) => {
 			const rowKey = this.getRowKey(tableRow);
@@ -133,19 +133,19 @@ class TableSelectionMulti extends TableSelectionBase {
 	 * @public
 	 */
 	getSelectedRows(): TableRow[] {
-		return this._table ? this._table.rows.filter(row => this.isSelected(row)) : [];
+		return this._table ? this._table._rows.filter(row => this.isSelected(row)) : [];
 	}
 
 	/**
 	 * Determines whether all rows are selected.
 	 */
 	areAllRowsSelected(): boolean {
-		if (!this._table || !this._table.rows.length) {
+		if (!this._table || !this._table._rows.length) {
 			return false;
 		}
 
 		const selectedSet = this.getSelectedAsSet();
-		return this._table.rows.filter(row => row._isSelectable).every(row => {
+		return this._table._rows.filter(row => row._isSelectable).every(row => {
 			const rowKey = this.getRowKey(row);
 			return selectedSet.has(rowKey);
 		});
@@ -176,7 +176,7 @@ class TableSelectionMulti extends TableSelectionBase {
 	 * Returns the ARIA description of the selection component displayed in the column header.
 	 */
 	getAriaDescriptionForColumnHeader(): string | undefined {
-		if (!this._table || !this._table.rows.length || this.behavior === "RowOnly") {
+		if (!this._table || !this._table._rows.length || this.behavior === "RowOnly") {
 			return undefined;
 		}
 
@@ -253,8 +253,8 @@ class TableSelectionMulti extends TableSelectionBase {
 
 		if (e.shiftKey && this._rangeSelection?.isMouse) {
 			const startRow = this._rangeSelection.rows[0];
-			const startIndex = this._table.rows.indexOf(startRow);
-			const endIndex = this._table.rows.indexOf(row);
+			const startIndex = this._table._rows.indexOf(startRow);
+			const endIndex = this._table._rows.indexOf(row);
 
 			// Set checkbox to the selection state of the start row (if it is selected)
 			const selectionState = this.isSelected(startRow);
@@ -311,11 +311,11 @@ class TableSelectionMulti extends TableSelectionBase {
 		if (shouldReverseSelection) {
 			this._reverseRangeSelection();
 		} else {
-			const rowIndex = this._table!.rows.indexOf(targetRow);
+			const rowIndex = this._table!._rows.indexOf(targetRow);
 			const [startIndex, endIndex] = [rowIndex, rowIndex - change].sort((a, b) => a - b);
 			const selectedSet = this.getSelectedAsSet();
 
-			selectionChanged = this._table?.rows.slice(startIndex, endIndex + 1).reduce((changed, row) => {
+			selectionChanged = this._table?._rows.slice(startIndex, endIndex + 1).reduce((changed, row) => {
 				const isRowNotInSelection = !this._rangeSelection?.rows.includes(row);
 				const isRowSelectionDifferent = this.isSelected(row) !== this._rangeSelection!.selected;
 

--- a/packages/main/src/TableSelectionSingle.ts
+++ b/packages/main/src/TableSelectionSingle.ts
@@ -62,7 +62,7 @@ class TableSelectionSingle extends TableSelectionBase {
 	 * @public
 	 */
 	getSelectedRow(): TableRow | undefined {
-		return this._table?.rows.find(row => this.isSelected(row));
+		return this._table?._rows.find(row => this.isSelected(row));
 	}
 }
 

--- a/packages/main/src/TableTemplate.tsx
+++ b/packages/main/src/TableTemplate.tsx
@@ -25,7 +25,7 @@ export default function TableTemplate(this: Table) {
 					</div>
 				</div>
 
-				{ this.rows.length === 0 &&
+				{ this._rows.length === 0 &&
 					<TableRow id="no-data-row">
 						<TableCell id="no-data-cell" data-excluded-from-navigation horizontal-align="Center">
 							{ this.noData.length > 0 ?
@@ -55,7 +55,7 @@ export default function TableTemplate(this: Table) {
 
 			<div id="after" role="none" tabindex={0} ui5-table-dummy-focus-area></div>
 
-			{ this.rows.length > 0 && this._getGrowing()?.hasGrowingComponent() &&
+			{ this._rows.length > 0 && this._getGrowing()?.hasGrowingComponent() &&
 				<slot name={this._getGrowing()?._individualSlot}></slot>
 			}
 		</>

--- a/packages/main/src/TableVirtualizer.ts
+++ b/packages/main/src/TableVirtualizer.ts
@@ -142,7 +142,7 @@ class TableVirtualizer extends UI5Element implements ITableFeature {
 		}
 
 		if (this._tabBlockingState & TabBlocking.Released) {
-			const tabBlockingRow = this._table.rows.at(this._tabBlockingState & TabBlocking.Next ? -1 : 0) as HTMLElement;
+			const tabBlockingRow = this._table._rows.at(this._tabBlockingState & TabBlocking.Next ? -1 : 0) as HTMLElement;
 			const tabForwardingElement = getTabbableElements(tabBlockingRow).at(this._tabBlockingState & TabBlocking.Next ? 0 : -1);
 			this._tabBlockingState = TabBlocking.None;
 			(tabForwardingElement || tabBlockingRow).focus();
@@ -181,7 +181,7 @@ class TableVirtualizer extends UI5Element implements ITableFeature {
 	}
 
 	_onScroll(): void {
-		const headerRow = this._table!.headerRow[0];
+		const headerRow = this._table!._headerRow[0];
 		const headerHeight = headerRow.offsetHeight;
 		let scrollTop = this._scrollContainer.scrollTop;
 		let scrollableHeight = this._scrollContainer.clientHeight;
@@ -219,7 +219,7 @@ class TableVirtualizer extends UI5Element implements ITableFeature {
 			return;
 		}
 
-		const firstRow = this._table.rows[0];
+		const firstRow = this._table._rows[0];
 		if (firstRow && firstRow.position !== undefined && firstRow.position > 0) {
 			const transform = firstRow.position * this.rowHeight;
 			return `translateY(${transform}px)`;
@@ -239,7 +239,7 @@ class TableVirtualizer extends UI5Element implements ITableFeature {
 		}
 
 		let scrollTopChange = 0;
-		const rows = this._table.rows;
+		const rows = this._table._rows;
 		const firstRow = rows[0];
 		const lastRow = rows[rows.length - 1];
 		const hasDataBeforeFirstRow = firstRow.position !== 0;


### PR DESCRIPTION
I'm building a new component, ui5-input-table-suggest — an input whose suggestion
list is a real ui5-table. The app supplies the rows, and I project them into an
internal table through nested slots:


https://github.com/UI5/webcomponents/pullpull/13678                                            
                                                                                   
That projection broke one assumption in the table: internal code found rows via  
the rows/headerRow slots and via each row's parentElement. 

When rows are projected from an outer component, parentElement is my component `(ui5-input-table-suggest`, not the table), so navigation, selection, popin, virtualization, drag & drop and ARIA counts stopped finding the rows.

**Changes:**

Add internal _rows/_headerRow getters that flatten chained <slot> projection via getSlottedNodes, and resolve TableRowBase._table across shadow boundaries.

Route all internal table logic through the new getters. Enables a `ui5-table` whose rows are projected from an outer component (ui5-input-table-suggest). No public API change.

Dev Notes:


```
  1. Table.ts — added internal getters _rows/_headerRow that flatten the nested
  slot projection (via getSlottedNodes), and routed all internal logic through
  them. The public rows and headerRow slots are unchanged.
  2. TableRowBase.ts — _table now resolves the owning table by following the slot
  chain across shadow boundaries (cached, cleared on connect/disconnect), instead
  of relying only on parentElement.
  3. The remaining table files just switch internal reads from rows/headerRow to
  _rows/_headerRow.

  Everything I changed is internal (_-prefixed) — no public API change. For a
  normal standalone table (no nested slot) the getters return exactly the same
  rows, so behavior is unchanged.
```


Related to #13678
