### PR TITLE
fix(ui5-list): restore keyboard and body selection for InactiveSelectable items

### DIFF
--- a/packages/main/cypress/specs/List.cy.tsx
+++ b/packages/main/cypress/specs/List.cy.tsx
@@ -3856,7 +3856,7 @@ describe("List - ListItem accessible role inheritance", () => {
 });
 
 describe("List - InactiveSelectable type", () => {
-	it("type='InactiveSelectable' + selectionMode='Multiple' — clicking item body does NOT toggle selection", () => {
+	it("type='InactiveSelectable' + selectionMode='Multiple' — clicking item body toggles selection", () => {
 		cy.mount(
 			<List selectionMode="Multiple">
 				<ListItemStandard id="item1" type="InactiveSelectable">Option A</ListItemStandard>
@@ -3867,25 +3867,25 @@ describe("List - InactiveSelectable type", () => {
 		// Initially not selected
 		cy.get("#item1").should("not.have.attr", "selected");
 
-		// Click item body — should NOT change selection
+		// Click item body — toggles selection
+		cy.get("#item1").click();
+		cy.get("#item1").should("have.attr", "selected");
+
+		// Click item body again — deselects
 		cy.get("#item1").click();
 		cy.get("#item1").should("not.have.attr", "selected");
 
-		// Clicking checkbox directly toggles selection
+		// Clicking checkbox directly also toggles selection
 		cy.get("#item1").shadow().find("ui5-checkbox").click();
 		cy.get("#item1").should("have.attr", "selected");
-
-		// Click checkbox again — should become deselected
-		cy.get("#item1").shadow().find("ui5-checkbox").click();
-		cy.get("#item1").should("not.have.attr", "selected");
 
 		// Second item is independent
 		cy.get("#item2").shadow().find("ui5-checkbox").click();
 		cy.get("#item2").should("have.attr", "selected");
-		cy.get("#item1").should("not.have.attr", "selected");
+		cy.get("#item1").should("have.attr", "selected");
 	});
 
-	it("type='InactiveSelectable' + selectionMode='Multiple' — pressing Space on item body does NOT toggle selection", () => {
+	it("type='InactiveSelectable' + selectionMode='Multiple' — pressing Space on item body toggles selection", () => {
 		cy.mount(
 			<List selectionMode="Multiple">
 				<ListItemStandard id="item1" type="InactiveSelectable">Option A</ListItemStandard>
@@ -3894,8 +3894,12 @@ describe("List - InactiveSelectable type", () => {
 
 		cy.get("#item1").should("not.have.attr", "selected");
 
-		// Focus item and press Space — should NOT change selection
+		// Focus item and press Space — toggles selection
 		cy.get("#item1").shadow().find("li").focus();
+		cy.realPress("Space");
+		cy.get("#item1").should("have.attr", "selected");
+
+		// Space again — deselects
 		cy.realPress("Space");
 		cy.get("#item1").should("not.have.attr", "selected");
 	});
@@ -3984,7 +3988,7 @@ describe("List - InactiveSelectable type", () => {
 		cy.get("@selectionChangeStub").should("not.have.been.called");
 	});
 
-	it("type='InactiveSelectable' + selectionMode='Single' — clicking item body does NOT select it", () => {
+	it("type='InactiveSelectable' + selectionMode='Single' — clicking item body selects it", () => {
 		cy.mount(
 			<List selectionMode="Single">
 				<ListItemStandard id="item1" type="InactiveSelectable">Option A</ListItemStandard>
@@ -3997,14 +4001,21 @@ describe("List - InactiveSelectable type", () => {
 			$list[0].addEventListener("ui5-selection-change", cy.stub().as("selectionChangeStub"));
 		});
 
-		// Single mode renders no radio button — clicking item body does nothing
+		// Single mode renders no radio, but the press path still selects the item
 		cy.get("#item1").click();
-		cy.get("#item1").should("not.have.attr", "selected");
+		cy.get("#item1").should("have.attr", "selected");
+		cy.get("@selectionChangeStub").should("have.been.calledOnce");
+
+		// item-click is never fired for this type
 		cy.get("@itemClickStub").should("not.have.been.called");
-		cy.get("@selectionChangeStub").should("not.have.been.called");
+
+		// Single selection: selecting the second deselects the first
+		cy.get("#item2").click();
+		cy.get("#item2").should("have.attr", "selected");
+		cy.get("#item1").should("not.have.attr", "selected");
 	});
 
-	it("type='InactiveSelectable' + selectionMode='Single' — pressing Space on item body does NOT select it", () => {
+	it("type='InactiveSelectable' + selectionMode='Single' — pressing Space on item body selects it", () => {
 		cy.mount(
 			<List selectionMode="Single">
 				<ListItemStandard id="item1" type="InactiveSelectable">Option A</ListItemStandard>
@@ -4016,7 +4027,7 @@ describe("List - InactiveSelectable type", () => {
 		cy.get("#item1").shadow().find("li").focus();
 		cy.realPress("Space");
 
-		cy.get("#item1").should("not.have.attr", "selected");
+		cy.get("#item1").should("have.attr", "selected");
 	});
 
 	it("type='InactiveSelectable' + selectionMode='None' — clicking item does nothing", () => {
@@ -4057,7 +4068,7 @@ describe("List - InactiveSelectable type", () => {
 		cy.get("@selectionChangeStub").should("not.have.been.called");
 	});
 
-	it("type='InactiveSelectable' + selectionMode='Multiple' — selection-change event is fired when clicking checkbox", () => {
+	it("type='InactiveSelectable' + selectionMode='Multiple' — selection-change event is fired when clicking item body", () => {
 		cy.mount(
 			<List selectionMode="Multiple">
 				<ListItemStandard id="item1" type="InactiveSelectable">Option A</ListItemStandard>
@@ -4068,16 +4079,17 @@ describe("List - InactiveSelectable type", () => {
 			$list[0].addEventListener("ui5-selection-change", cy.stub().as("selectionChangeStub"));
 		});
 
-		// Click item body — should NOT fire selection-change
+		// Click item body — fires selection-change and selects
 		cy.get("#item1").click();
-		cy.get("@selectionChangeStub").should("not.have.been.called");
-
-		// Click checkbox — should fire selection-change
-		cy.get("#item1").shadow().find("ui5-checkbox").click();
+		cy.get("#item1").should("have.attr", "selected");
 		cy.get("@selectionChangeStub").should("have.been.calledOnce");
+
+		// Click checkbox — fires selection-change again
+		cy.get("#item1").shadow().find("ui5-checkbox").click();
+		cy.get("@selectionChangeStub").should("have.been.calledTwice");
 	});
 
-	it("type='InactiveSelectable' + selectionMode='SingleStart' — clicking item body does NOT select it", () => {
+	it("type='InactiveSelectable' + selectionMode='SingleStart' — clicking item body selects it", () => {
 		cy.mount(
 			<List selectionMode="SingleStart">
 				<ListItemStandard id="item1" type="InactiveSelectable">Option A</ListItemStandard>
@@ -4086,17 +4098,15 @@ describe("List - InactiveSelectable type", () => {
 		);
 
 		cy.get("#item1").click();
-		cy.get("#item1").should("not.have.attr", "selected");
-
-		cy.get("#item1").shadow().find("[id$='-singleSelectionElement']").click();
 		cy.get("#item1").should("have.attr", "selected");
 
+		// Selecting the second item deselects the first (single selection)
 		cy.get("#item2").shadow().find("[id$='-singleSelectionElement']").click();
 		cy.get("#item2").should("have.attr", "selected");
 		cy.get("#item1").should("not.have.attr", "selected");
 	});
 
-	it("type='InactiveSelectable' + selectionMode='SingleEnd' — clicking item body does NOT select it", () => {
+	it("type='InactiveSelectable' + selectionMode='SingleEnd' — clicking item body selects it", () => {
 		cy.mount(
 			<List selectionMode="SingleEnd">
 				<ListItemStandard id="item1" type="InactiveSelectable">Option A</ListItemStandard>
@@ -4105,17 +4115,15 @@ describe("List - InactiveSelectable type", () => {
 		);
 
 		cy.get("#item1").click();
-		cy.get("#item1").should("not.have.attr", "selected");
-
-		cy.get("#item1").shadow().find("[id$='-singleSelectionElement']").click();
 		cy.get("#item1").should("have.attr", "selected");
 
+		// Selecting the second item deselects the first (single selection)
 		cy.get("#item2").shadow().find("[id$='-singleSelectionElement']").click();
 		cy.get("#item2").should("have.attr", "selected");
 		cy.get("#item1").should("not.have.attr", "selected");
 	});
 
-	it("type='InactiveSelectable' + selectionMode='Multiple' — pressing Enter on item body does NOT toggle selection", () => {
+	it("type='InactiveSelectable' + selectionMode='Multiple' — pressing Enter on item body toggles selection", () => {
 		cy.mount(
 			<List selectionMode="Multiple">
 				<ListItemStandard id="item1" type="InactiveSelectable">Option A</ListItemStandard>
@@ -4126,10 +4134,10 @@ describe("List - InactiveSelectable type", () => {
 
 		cy.get("#item1").shadow().find("li").focus();
 		cy.realPress("Enter");
-		cy.get("#item1").should("not.have.attr", "selected");
+		cy.get("#item1").should("have.attr", "selected");
 	});
 
-	it("type='InactiveSelectable' + selectionMode='Single' — pressing Enter on item body does NOT select it", () => {
+	it("type='InactiveSelectable' + selectionMode='Single' — pressing Enter on item body selects it", () => {
 		cy.mount(
 			<List selectionMode="Single">
 				<ListItemStandard id="item1" type="InactiveSelectable">Option A</ListItemStandard>
@@ -4141,7 +4149,7 @@ describe("List - InactiveSelectable type", () => {
 		cy.get("#item1").shadow().find("li").focus();
 		cy.realPress("Enter");
 
-		cy.get("#item1").should("not.have.attr", "selected");
+		cy.get("#item1").should("have.attr", "selected");
 	});
 
 	it("type='InactiveSelectable' — item-click event is NOT fired on Enter key", () => {
@@ -4195,22 +4203,27 @@ describe("List - InactiveSelectable type", () => {
 		cy.get("@selectionChangeStub").should("have.been.calledOnce");
 	});
 
-	it("type='InactiveSelectable' + selectionMode='SingleAuto' — clicking item does nothing", () => {
+	it("type='InactiveSelectable' + selectionMode='SingleAuto' — focus does not select, but clicking does", () => {
 		cy.mount(
 			<List selectionMode="SingleAuto">
 				<ListItemStandard id="item1" type="InactiveSelectable">Option A</ListItemStandard>
+				<ListItemStandard id="item2">Option B</ListItemStandard>
 			</List>
 		);
 
 		cy.get("[ui5-list]").then(($list) => {
 			$list[0].addEventListener("ui5-item-click", cy.stub().as("itemClickStub"));
-			$list[0].addEventListener("ui5-selection-change", cy.stub().as("selectionChangeStub"));
 		});
 
-		cy.get("#item1").click();
-
+		// Moving focus onto the item must NOT auto-select it (SingleAuto opt-out)
+		cy.get("#item1").shadow().find("li").focus();
 		cy.get("#item1").should("not.have.attr", "selected");
+
+		// An explicit click, however, selects it
+		cy.get("#item1").click();
+		cy.get("#item1").should("have.attr", "selected");
+
+		// item-click is still never fired for this type
 		cy.get("@itemClickStub").should("not.have.been.called");
-		cy.get("@selectionChangeStub").should("not.have.been.called");
 	});
 });

--- a/packages/main/src/List.ts
+++ b/packages/main/src/List.ts
@@ -1408,7 +1408,10 @@ class List extends UI5Element {
 	onItemPress(e: CustomEvent<ListItemBasePressEventDetail>) {
 		const pressedItem = e.detail.item;
 
-		if (!this.fireDecoratorEvent("item-click", { item: pressedItem })) {
+		// if InactiveSelectable - don't fire the public "item-click" event
+		// we fall through to the selection code below
+		const isInactiveSelectable = (pressedItem as ListItem).isInactiveSelectable;
+		if (!isInactiveSelectable && !this.fireDecoratorEvent("item-click", { item: pressedItem })) {
 			return;
 		}
 

--- a/packages/main/src/ListItem.ts
+++ b/packages/main/src/ListItem.ts
@@ -112,10 +112,10 @@ abstract class ListItem extends ListItemBase {
 	 * **Note:** When set to `Active` or `Navigation`, the item will provide visual response upon press and hover,
 	 * while with type `Inactive`, `InactiveSelectable` and `Detail` - will not.
 	 *
-	 * **Note:** `InactiveSelectable` behaves like `Inactive` but allows selection to be toggled
-	 * via the checkbox (Multi mode) or radio button (Single modes) when the list has a selection mode.
-	 * Clicking the item body or pressing Space/Enter does not trigger selection — only interacting
-	 * with the selection component directly does. The `item-click` event is not fired for this type.
+	 * **Note:** `InactiveSelectable` behaves like `Inactive` (no active press/hover feedback and the
+	 * `item-click` event is not fired), but the item can still be selected. Clicking the item body,
+	 * pressing Space/Enter, or interacting with the selection component (checkbox in Multi mode, radio
+	 * button in Single modes) toggles the selection when the list has a selection mode.
 	 * @default "Active"
 	 * @public
 	*/
@@ -403,7 +403,7 @@ abstract class ListItem extends ListItemBase {
 	}
 
 	fireItemPress(e: Event) {
-		if (this.isInactive || this.isInactiveSelectable) {
+		if (this.isInactive) {
 			return;
 		}
 		super.fireItemPress(e);

--- a/packages/main/src/types/ListItemType.ts
+++ b/packages/main/src/types/ListItemType.ts
@@ -11,7 +11,8 @@ enum ListItemType {
 
 	/**
 	 * Indicates the list item does not have any active feedback when item is pressed,
-	 * but selection (checkbox/radio) is still possible when a selection mode is active.
+	 * but the item can still be selected when a selection mode is active
+	 * (via the item body, Space/Enter, or the checkbox/radio).
 	 * The `item-click` event is not fired for items of this type.
 	 * @public
 	 * @since 2.25.1

--- a/packages/main/test/pages/ListInactiveSelectable.html
+++ b/packages/main/test/pages/ListInactiveSelectable.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>List - InactiveSelectable</title>
+	<script src="%VITE_BUNDLE_PATH%" type="module"></script>
+	<style>
+		body { font-family: sans-serif; padding: 2rem; background: var(--sapBackgroundColor, #f5f6f7); }
+		h2 { margin-top: 2rem; }
+		.hint { color: #555; font-size: 0.85rem; margin: 0.25rem 0 0.5rem; }
+		.log { margin-top: 1rem; padding: 0.5rem; background: #fff; border: 1px solid #ccc; min-height: 4rem; font-family: monospace; font-size: 0.85rem; white-space: pre-wrap; }
+	</style>
+</head>
+<body>
+
+<h1>InactiveSelectable — manual test</h1>
+<p class="hint">
+	Expected: <b>no active press/hover feedback</b> and the <b>item-click event never fires</b> for InactiveSelectable items.
+	But the item <b>can still be selected</b> — via the item body (click / Space / Enter) or the checkbox/radio.
+	Screen reader should not announce the raw "InactiveSelectable" text.
+</p>
+
+<h2>Multiple selection (checkboxes)</h2>
+<p class="hint">Click the row body, press Space, or press Enter → selection toggles (selection-change fires). Clicking the checkbox also toggles. item-click never fires.</p>
+<ui5-list id="list-multi" selection-mode="Multiple">
+	<ui5-li type="InactiveSelectable">InactiveSelectable item 1</ui5-li>
+	<ui5-li type="InactiveSelectable">InactiveSelectable item 2</ui5-li>
+	<ui5-li type="Active">Active item</ui5-li>
+	<ui5-li type="Inactive">Inactive item (never selectable)</ui5-li>
+</ui5-list>
+
+<h2>SingleStart selection (radio at start)</h2>
+<p class="hint">Click the row body / Space / Enter → selects. Clicking the radio also selects. item-click never fires.</p>
+<ui5-list id="list-single-start" selection-mode="SingleStart">
+	<ui5-li type="InactiveSelectable">InactiveSelectable item 1</ui5-li>
+	<ui5-li type="InactiveSelectable">InactiveSelectable item 2</ui5-li>
+	<ui5-li type="Active">Active item</ui5-li>
+</ui5-list>
+
+<h2>SingleEnd selection (radio at end)</h2>
+<p class="hint">Click the row body / Space / Enter → selects. Clicking the radio also selects. item-click never fires.</p>
+<ui5-list id="list-single-end" selection-mode="SingleEnd">
+	<ui5-li type="InactiveSelectable">InactiveSelectable item 1</ui5-li>
+	<ui5-li type="InactiveSelectable">InactiveSelectable item 2</ui5-li>
+	<ui5-li type="Active">Active item</ui5-li>
+</ui5-list>
+
+<h2>Single selection (NO selection component rendered)</h2>
+<p class="hint">
+	⚠️ Single mode renders <b>no</b> checkbox/radio, but selection is still driven by the press path:
+	clicking the row body (or Space / Enter) <b>now selects</b> the item — watch the highlighted row / aria-selected,
+	even though there is no visible control. This is the edge case to review.
+</p>
+<ui5-list id="list-single" selection-mode="Single">
+	<ui5-li type="InactiveSelectable">InactiveSelectable item 1</ui5-li>
+	<ui5-li type="InactiveSelectable">InactiveSelectable item 2</ui5-li>
+	<ui5-li type="Active">Active item</ui5-li>
+</ui5-list>
+
+<h2>SingleAuto selection (select-on-focus)</h2>
+<p class="hint">
+	Arrow-key focus onto an InactiveSelectable item does <b>not</b> auto-select it (it opts out of focus-select),
+	but an explicit click / Space / Enter <b>does</b> select it. The Active item still selects on focus.
+</p>
+<ui5-list id="list-single-auto" selection-mode="SingleAuto">
+	<ui5-li type="InactiveSelectable">InactiveSelectable item 1</ui5-li>
+	<ui5-li type="Active">Active item</ui5-li>
+	<ui5-li type="InactiveSelectable">InactiveSelectable item 2</ui5-li>
+</ui5-list>
+
+<h2>Events</h2>
+<div class="log" id="log">— events will appear here —</div>
+
+<script type="module">
+	const log = document.getElementById("log");
+	const append = (msg) => { log.textContent = msg + "\n" + log.textContent; };
+
+	["list-multi", "list-single-start", "list-single-end", "list-single", "list-single-auto"].forEach(id => {
+		const list = document.getElementById(id);
+		list.addEventListener("ui5-item-click", e => append(`[${id}] item-click fired on: "${e.detail.item.textContent.trim()}"`));
+		list.addEventListener("ui5-selection-change", e => append(`[${id}] selection-change: ${e.detail.selectedItems.map(i => i.textContent.trim()).join(", ") || "(none)"}`));
+	});
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
Downport of #14037 to **2.25.1**.

## Problem

`InactiveSelectable` items could not be selected via **Space, Enter, or item-body click** — `fireItemPress` early-returned for the type, and the checkbox/radio are `tabindex="-1"` (keyboard-unreachable). Only a direct mouse click on the checkbox/radio worked.

## Fix

- `ListItem.ts` — `fireItemPress` no longer early-returns for `InactiveSelectable`.
- `List.ts` — `onItemPress` suppresses only the public `item-click` event for `InactiveSelectable`, while still selecting.
- JSDoc corrected (`@since 2.25.1` preserved).

## Tests

`List.cy.tsx` updated to the corrected contract — **147/147 passing**. Manual page added at `test/pages/ListInactiveSelectable.html`.

Clean cherry-pick of `b02452d3abe` onto `release-2.25.1` (no conflicts; `@since 2.25.1` unchanged).