### PR TITLE
fix(ui5-token): mobile focus support

### DIFF
--- a/packages/main/src/Token.ts
+++ b/packages/main/src/Token.ts
@@ -13,6 +13,7 @@ import {
 } from "@ui5/webcomponents-base/dist/Keys.js";
 import type I18nBundle from "@ui5/webcomponents-base/dist/i18nBundle.js";
 import i18n from "@ui5/webcomponents-base/dist/decorators/i18n.js";
+import { isDesktop } from "@ui5/webcomponents-base/dist/Device.js";
 import { TOKEN_ARIA_DELETE, TOKEN_ARIA_DELETABLE, TOKEN_ARIA_LABEL } from "./generated/i18n/i18n-defaults.js";
 
 import type { IIcon } from "./Icon.js";
@@ -158,6 +159,12 @@ class Token extends UI5Element implements IToken {
 		if (!this.toBeDeleted) {
 			this.selected = !this.selected;
 			this.fireDecoratorEvent("select");
+		}
+	}
+
+	onEnterDOM() {
+		if (isDesktop()) {
+			this.setAttribute("desktop", "");
 		}
 	}
 

--- a/packages/main/src/themes/Token.css
+++ b/packages/main/src/themes/Token.css
@@ -63,7 +63,8 @@
 	padding: var(--_ui5_token_readonly_padding);
 }
 
-:host([selected]) .ui5-token--wrapper:focus {
+:host([desktop][selected]) .ui5-token--wrapper:focus,
+:host([selected]) .ui5-token--wrapper:focus-visible {
 	outline: var(--_ui5_token_selected_focus_outline);
 }
 
@@ -94,12 +95,14 @@
 	font-family: var(--_ui5_token_selected_text_font_family);
 }
 
-.ui5-token--wrapper:focus {
+:host([desktop]) .ui5-token--wrapper:focus,
+.ui5-token--wrapper:focus-visible {
 	outline-offset: var(--_ui5_token_outline_offset);
 	outline: var(--_ui5_token_focus_outline);
 }
 
-.ui5-token--wrapper:focus::after {
+:host([desktop]) .ui5-token--wrapper:focus::after,
+.ui5-token--wrapper:focus-visible::after {
 	content: var(--ui5_token_focus_pseudo_element_content);
 	position: absolute;
 	pointer-events: none;


### PR DESCRIPTION
[BGSOFUIRILA-4588](https://jira.tools.sap/browse/BGSOFUIRILA-4588)

- `Token` focus outline always visible on desktop when focused
- on mobile focus outline is visible when external keyboard is used

Implementation is done with `focus-visible` and [desktop] host attr
